### PR TITLE
State NV peer mem driver

### DIFF
--- a/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -33,3 +33,8 @@ spec:
         "devices": ["enp5s0f0"]
       }]
       }
+  nvPeerDriver:
+    image: REPLACE_IMAGE
+    repository: REPLACE_REPOSITORY
+    version: REPLACE_VERSION
+    gpuDriverSourcePath: /run/nvidia/driver

--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -1,0 +1,64 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+  name: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}-ds
+  namespace: {{ .RuntimeSpec.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+  template:
+    metadata:
+      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+      # reserves resources for critical add-on pods so that they can be rescheduled after
+      # a failure.  This annotation works in tandem with the toleration below.
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+    spec:
+      tolerations:
+        - operator: Exists
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+          imagePullPolicy: IfNotPresent
+          name: nv-peer-mem-driver-container
+          securityContext:
+            privileged: true
+            seLinuxOptions:
+              level: "s0"
+          volumeMounts:
+            - name: run-mlnx-ofed
+              mountPath: /run/mellanox/drivers
+              mountPropagation: HostToContainer
+            - name: run-nvidia
+              mountPath: /run/nvidia/drivers
+              mountPropagation: HostToContainer
+      volumes:
+        - name: run-mlnx-ofed
+          hostPath:
+            path: /run/mellanox/drivers
+        - name: run-nvidia
+          hostPath:
+            path: {{ .CrSpec.GPUDriverSourcePath }}
+      nodeSelector:
+        feature.node.kubernetes.io/pci-15b3.present: "true"
+        feature.node.kubernetes.io/pci-10de.present: "true"

--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -37,6 +37,7 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      hostNetwork: true
       containers:
         - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
           imagePullPolicy: IfNotPresent

--- a/pkg/nodeinfo/attributes.go
+++ b/pkg/nodeinfo/attributes.go
@@ -36,6 +36,7 @@ const (
 	NodeLabelHostname      = "kubernetes.io/hostname"
 	NodeLabelCPUArch       = "kubernetes.io/arch"
 	NodeLabelMlnxNIC       = "feature.node.kubernetes.io/pci-15b3.present"
+	NodeLabelNvGPU         = "feature.node.kubernetes.io/pci-10de.present"
 )
 
 type AttributeType int

--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -76,9 +76,14 @@ func newNicClusterPolicyStates(k8sAPIClient client.Client, scheme *runtime.Schem
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Device plugin State")
 	}
+	nvPeerMemState, err := NewStateNVPeer(
+		k8sAPIClient, scheme, filepath.Join(config.FromEnv().State.ManifestBaseDir, "stage-nv-peer-mem-driver"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create NV peer memory driver State")
+	}
 
 	return []Group{
 		NewStateGroup([]State{ofedState}),
-		NewStateGroup([]State{sharedDpState}),
+		NewStateGroup([]State{sharedDpState, nvPeerMemState}),
 	}, nil
 }


### PR DESCRIPTION
This commit adds a new state that deploys
NV Peer memory driver container on nodes that have
both mellanox and nvidia hardware.

- Add manifest file
- Nv peer memory state implementation
- Instantiate new state in factory
- Extend node attributes with nvidia gpu pci label