### PR TITLE
Modify RequeueTimeSeconds to be uint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"sync"
-	"time"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -41,7 +40,7 @@ type StateConfig struct {
 type ControllerConfig struct {
 	//nolint:stylecheck
 	// Request requeue time(seconds) in case the system still needs to be reconciled
-	RequeueTimeSeconds time.Duration `env:"CONTROLLER_REQUEST_REQUEUE_SECONDS" envDefault:5`
+	RequeueTimeSeconds uint `env:"CONTROLLER_REQUEST_REQUEUE_SECONDS" envDefault:"5"`
 }
 
 func FromEnv() *OperatorConfig {

--- a/pkg/controller/nicclusterpolicy/nicclusterpolicy_controller.go
+++ b/pkg/controller/nicclusterpolicy/nicclusterpolicy_controller.go
@@ -155,7 +155,7 @@ func (r *ReconcileNicClusterPolicy) Reconcile(request reconcile.Request) (reconc
 	}
 	if managerStatus.Status != state.SyncStateReady {
 		return reconcile.Result{
-			RequeueAfter: config.FromEnv().Controller.RequeueTimeSeconds * time.Second,
+			RequeueAfter: time.Duration(config.FromEnv().Controller.RequeueTimeSeconds) * time.Second,
 		}, nil
 	}
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Specifying uint is in my opinion clearer than time.Duration
which requires the user to suffix the input with a time marker e.g '5s'

In addition we do not want to allow other time granularity like minutes
at this point.