### PR TITLE
Added missing STATE_MANIFEST_BASE_DIR in the operator pod.

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -35,6 +35,8 @@ spec:
           - network-operator
           imagePullPolicy: Always
           env:
+            - name: STATE_MANIFEST_BASE_DIR
+              value: "/etc/manifests"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -96,6 +96,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: network-operator
   creationTimestamp: null
 rules:
   - apiGroups:


### PR DESCRIPTION
Added the missing STATE_MANIFEST_BASE_DIR environment variable
in the deploy/operator.yaml file. Also added the name field for
the cluster role definition inside deploy/role.yaml file.