### PR TITLE
Add Probes to driver container daemonsets

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -53,6 +53,29 @@ spec:
             - name: run-nvidia
               mountPath: /run/nvidia/drivers
               mountPropagation: HostToContainer
+          startupProbe:
+            exec:
+              command:
+                [sh, -c, 'ls /.driver-ready']
+            initialDelaySeconds: 10
+            failureThreshold: 60
+            successThreshold: 1
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                [sh, -c, 'lsmod | grep nv_peer_mem']
+            periodSeconds: 30
+            initialDelaySeconds: 30
+            failureThreshold: 1
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                [sh, -c, 'lsmod | grep nv_peer_mem']
+            periodSeconds: 30
+            initialDelaySeconds: 10
+            failureThreshold: 1
       volumes:
         - name: run-mlnx-ofed
           hostPath:

--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -52,6 +52,29 @@ spec:
               mountPropagation: Bidirectional
             - name: etc-network
               mountPath: /etc/network
+          startupProbe:
+            exec:
+              command:
+                [sh, -c, 'ls /.driver-ready']
+            initialDelaySeconds: 10
+            failureThreshold: 60
+            successThreshold: 1
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                [sh, -c, 'lsmod | grep mlx5_core']
+            periodSeconds: 30
+            initialDelaySeconds: 30
+            failureThreshold: 1
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                [sh, -c, 'lsmod | grep mlx5_core']
+            periodSeconds: 30
+            initialDelaySeconds: 10
+            failureThreshold: 1
       volumes:
         - name: run-mlnx-ofed
           hostPath:


### PR DESCRIPTION
This would ensure proper operation of the operator
in regards to dependencies between components as
the network-operator waits for one stage group to be done
before moving the the other.

In addition, liveliness probes would trigger a restart
of the container in case the driver was suddenly unloaded
for some reason.