### PR TITLE
Update deployment example with v0.1.0 tagged operator image

### DIFF
--- a/example/deploy/operator.yaml
+++ b/example/deploy/operator.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: network-operator
           # Replace this with the built image name
-          image: mellanox/network-operator
+          image: mellanox/network-operator:v0.1.0
           command:
           - network-operator
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This commit updates example deployment to deploy a v0.1.0
tagged operator image as a prestep to tagging the repository.