### PR TITLE
Separate network operator resources

### DIFF
--- a/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -15,7 +15,7 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: example-nicclusterpolicy
-  namespace: REPLACE_NAMESPACE
+  namespace: mlnx-network-operator-resources
 spec:
   ofedDriver:
     image: REPLACE_IMAGE

--- a/deploy/operator-resources-ns.yaml
+++ b/deploy/operator-resources-ns.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mlnx-network-operator-resources

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,9 +38,7 @@ spec:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/etc/manifests"
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: "mlnx-network-operator-resources"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -18,6 +18,88 @@ metadata:
   name: network-operator
   namespace: REPLACE_NAMESPACE
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+rules:
 - apiGroups:
   - ""
   resources:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -19,6 +19,21 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: network-operator
+  namespace: REPLACE_NAMESPACE
+roleRef:
+  kind: Role
+  name: network-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+subjects:
+  - kind: ServiceAccount
+    name: network-operator
+    namespace: REPLACE_NAMESPACE
 roleRef:
   kind: Role
   name: network-operator
@@ -28,7 +43,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: network-operator
-  namespace: REPLACE_NAMESPACE
 subjects:
 - kind: ServiceAccount
   name: network-operator

--- a/example/deploy-operator.sh
+++ b/example/deploy-operator.sh
@@ -16,6 +16,7 @@
 echo "Deploying Network Operator:"
 echo "###########################"
 kubectl apply -f deploy/operator-ns.yaml
+kubectl apply -f deploy/operator-resources-ns.yaml
 kubectl apply -f deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
 kubectl apply -f deploy/role.yaml
 kubectl apply -f deploy/service_account.yaml

--- a/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -15,7 +15,7 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: example-nicclusterpolicy
-  namespace: mlnx-network-operator
+  namespace: mlnx-network-operator-resources
 spec:
   ofedDriver:
     image: ofed-driver

--- a/example/deploy/operator-resources-ns.yaml
+++ b/example/deploy/operator-resources-ns.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2020 NVIDIA
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-echo "Deleting Network Operator:"
-echo "##########################"
-kubectl delete -f deploy/operator.yaml
-kubectl delete -f deploy/role_binding.yaml
-kubectl delete -f deploy/service_account.yaml
-kubectl delete -f deploy/role.yaml
-kubectl delete -f deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
-kubectl delete -f deploy/operator-resources-ns.yaml
-kubectl delete -f deploy/operator-ns.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mlnx-network-operator-resources

--- a/example/deploy/operator.yaml
+++ b/example/deploy/operator.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: network-operator
           # Replace this with the built image name
-          image: mellanox/network-operator:v0.1.0
+          image: mellanox/network-operator
           command:
           - network-operator
           imagePullPolicy: IfNotPresent
@@ -38,9 +38,7 @@ spec:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/etc/manifests"
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: "mlnx-network-operator-resources"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/example/deploy/role.yaml
+++ b/example/deploy/role.yaml
@@ -18,6 +18,88 @@ metadata:
   name: network-operator
   namespace: mlnx-network-operator
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+rules:
 - apiGroups:
   - ""
   resources:

--- a/example/deploy/role_binding.yaml
+++ b/example/deploy/role_binding.yaml
@@ -19,6 +19,21 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: network-operator
+  namespace: mlnx-network-operator
+roleRef:
+  kind: Role
+  name: network-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+subjects:
+  - kind: ServiceAccount
+    name: network-operator
+    namespace: mlnx-network-operator
 roleRef:
   kind: Role
   name: network-operator
@@ -28,7 +43,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: network-operator
-  namespace: mlnx-network-operator
 subjects:
 - kind: ServiceAccount
   name: network-operator

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -26,3 +26,7 @@ const (
 	LogLevelInfo    = 3
 	LogLevelDebug   = 4
 )
+
+const (
+	NetworkOperatorResourceNamespace = "mlnx-network-operator-resources"
+)

--- a/pkg/state/state_nv_peer.go
+++ b/pkg/state/state_nv_peer.go
@@ -133,7 +133,7 @@ func (s *stateNVPeer) getManifestObjects(
 	renderData := &nvPeerManifestRenderData{
 		CrSpec: cr.Spec.NVPeerDriver,
 		RuntimeSpec: &nvPeerRuntimeSpec{
-			Namespace:  cr.Namespace,
+			Namespace:  consts.NetworkOperatorResourceNamespace,
 			CPUArch:    attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
 			OSNameFull: attrs[0].Attributes[nodeinfo.AttrTypeOS],
 		},

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -145,7 +145,7 @@ func (s *stateOFED) getManifestObjects(
 	renderData := &ofedManifestRenderData{
 		CrSpec: cr.Spec.OFEDDriver,
 		RuntimeSpec: &ofedRuntimeSpec{
-			Namespace:     cr.Namespace,
+			Namespace:     consts.NetworkOperatorResourceNamespace,
 			CPUArch:       attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
 			OSNameFull:    attrs[0].Attributes[nodeinfo.AttrTypeOS],
 			KernelVerFull: attrs[0].Attributes[nodeinfo.AttrTypeKernel],

--- a/pkg/state/state_shared_dp.go
+++ b/pkg/state/state_shared_dp.go
@@ -115,7 +115,7 @@ func (s *stateSharedDp) getManifestObjects(
 	renderData := &sharedDpManifestRenderData{
 		CrSpec: cr.Spec.DevicePlugin,
 		RuntimeSpec: &sharedDpRuntimeSpec{
-			Namespace: cr.Namespace,
+			Namespace: consts.NetworkOperatorResourceNamespace,
 		},
 	}
 	// render objects


### PR DESCRIPTION
Separate deployed network operator namespaced resources  from the namespace the operator is deployed in.

This PR modifies network operator to deploy namespaced resources to a predefined namespace, `mlnx-network-operator-resources`.

This will allow consolidation of resources regardless of the namespace the operator is deployed in.