### PR TITLE
nicclusterpolicy as Cluster resource

### DIFF
--- a/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -22,7 +22,7 @@ spec:
     listKind: NicClusterPolicyList
     plural: nicclusterpolicies
     singular: nicclusterpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:

--- a/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -15,7 +15,6 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: example-nicclusterpolicy
-  namespace: mlnx-network-operator-resources
 spec:
   ofedDriver:
     image: REPLACE_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/etc/manifests"
             - name: WATCH_NAMESPACE
-              value: "mlnx-network-operator-resources"
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -68,18 +68,82 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+rules:
+  - apiGroups:
       - ""
     resources:
       - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
+      - create
+      - delete
       - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - apps
     resources:
-      - replicasets
       - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
     verbs:
       - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
   - apiGroups:
       - mellanox.com
     resources:
@@ -92,76 +156,21 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: network-operator
-  namespace: mlnx-network-operator-resources
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - network-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
 - apiGroups:
   - mellanox.com
   resources:
@@ -174,18 +183,19 @@ rules:
   - patch
   - update
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: network-operator
-  creationTimestamp: null
-rules:
-  - apiGroups:
+- apiGroups:
     - ""
-    resources:
+  resources:
     - nodes
-    verbs:
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
     - get
     - list
     - watch

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -17,9 +17,9 @@ metadata:
   name: network-operator
   namespace: REPLACE_NAMESPACE
 subjects:
-- kind: ServiceAccount
-  name: network-operator
-  namespace: REPLACE_NAMESPACE
+  - kind: ServiceAccount
+    name: network-operator
+    namespace: REPLACE_NAMESPACE
 roleRef:
   kind: Role
   name: network-operator

--- a/example/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/example/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -22,7 +22,7 @@ spec:
     listKind: NicClusterPolicyList
     plural: nicclusterpolicies
     singular: nicclusterpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:

--- a/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -15,7 +15,6 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: example-nicclusterpolicy
-  namespace: mlnx-network-operator-resources
 spec:
   ofedDriver:
     image: ofed-driver

--- a/example/deploy/operator.yaml
+++ b/example/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/etc/manifests"
             - name: WATCH_NAMESPACE
-              value: "mlnx-network-operator-resources"
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/example/deploy/role.yaml
+++ b/example/deploy/role.yaml
@@ -68,18 +68,82 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+rules:
+  - apiGroups:
       - ""
     resources:
       - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
+      - create
+      - delete
       - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - apps
     resources:
-      - replicasets
       - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
     verbs:
       - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
   - apiGroups:
       - mellanox.com
     resources:
@@ -92,76 +156,21 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: network-operator
-  namespace: mlnx-network-operator-resources
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - network-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
 - apiGroups:
   - mellanox.com
   resources:
@@ -174,18 +183,19 @@ rules:
   - patch
   - update
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: network-operator
-  creationTimestamp: null
-rules:
-  - apiGroups:
+- apiGroups:
     - ""
-    resources:
+  resources:
     - nodes
-    verbs:
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
     - get
     - list
     - watch

--- a/example/deploy/role_binding.yaml
+++ b/example/deploy/role_binding.yaml
@@ -17,9 +17,9 @@ metadata:
   name: network-operator
   namespace: mlnx-network-operator
 subjects:
-- kind: ServiceAccount
-  name: network-operator
-  namespace: mlnx-network-operator
+  - kind: ServiceAccount
+    name: network-operator
+    namespace: mlnx-network-operator
 roleRef:
   kind: Role
   name: network-operator

--- a/pkg/apis/mellanox/v1alpha1/nicclusterpolicy_types.go
+++ b/pkg/apis/mellanox/v1alpha1/nicclusterpolicy_types.go
@@ -108,7 +108,7 @@ type NicClusterPolicyStatus struct {
 
 // NicClusterPolicy is the Schema for the nicclusterpolicies API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=nicclusterpolicies,scope=Namespaced
+// +kubebuilder:resource:path=nicclusterpolicies,scope=Cluster
 type NicClusterPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Change nicclusterpolicy CRD to be cluster scoped

This commit modifies nicclusterpolicy CRD to be cluster
scope instead of namespace scope as the CRD defines
cluster wide parameters that are not confined to a certain
namespace.

- Update CRD to be Cluster scoped
- Update deploy templates
- Update example deployment templates