### PR TITLE
Add helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Status:
 ## System Requirements
 * RDMA capable hardware: Mellanox ConnectX-4 NIC or newer.
 * NVIDIA GPU and driver supporting GPUDirect e.g Quadro RTX 6000/8000 or Tesla T4 or Tesla V100 or Tesla V100.
+(GPU-Direct only)
 * Operating System: Ubuntu18.04 with kernel `4.15.0-109-generic`.
 
 >__NOTE__: As more driver containers are built the operator will be able to support additional platforms.

--- a/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -22,7 +22,7 @@ spec:
     listKind: NicClusterPolicyList
     plural: nicclusterpolicies
     singular: nicclusterpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:

--- a/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -15,7 +15,6 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: example-nicclusterpolicy
-  namespace: mlnx-network-operator-resources
 spec:
   ofedDriver:
     image: REPLACE_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/etc/manifests"
             - name: WATCH_NAMESPACE
-              value: "mlnx-network-operator-resources"
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -68,18 +68,82 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+rules:
+  - apiGroups:
       - ""
     resources:
       - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
+      - create
+      - delete
       - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - apps
     resources:
-      - replicasets
       - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
     verbs:
       - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
   - apiGroups:
       - mellanox.com
     resources:
@@ -92,76 +156,21 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: network-operator
-  namespace: mlnx-network-operator-resources
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - network-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
 - apiGroups:
   - mellanox.com
   resources:
@@ -174,18 +183,19 @@ rules:
   - patch
   - update
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: network-operator
-  creationTimestamp: null
-rules:
-  - apiGroups:
+- apiGroups:
     - ""
-    resources:
+  resources:
     - nodes
-    verbs:
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
     - get
     - list
     - watch

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -17,9 +17,9 @@ metadata:
   name: network-operator
   namespace: REPLACE_NAMESPACE
 subjects:
-- kind: ServiceAccount
-  name: network-operator
-  namespace: REPLACE_NAMESPACE
+  - kind: ServiceAccount
+    name: network-operator
+    namespace: REPLACE_NAMESPACE
 roleRef:
   kind: Role
   name: network-operator

--- a/deployment/network-operator/.helmignore
+++ b/deployment/network-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -1,18 +1,22 @@
 apiVersion: v2
+name: network-operator
+version: 0.2.0-beta
+kubeVersion: '>= 1.15.0'
 appVersion: v0.2.0
+description: Nvidia Mellanox network operator
+type: application
+keywords:
+  - gpu-direct
+  - rdma
+home: https://mellanox.github.io/network-operator
+sources:
+  - https://github.com/Mellanox/network-operator
 dependencies:
 - condition: nfd.enabled
   name: node-feature-discovery
   repository: ""
   version: 0.1.0
-description: Nvidia Mellanox network operator
-home: https://github.com/Mellanox/network-operator
-keywords:
-- gpu-direct
-- rdma
-kubeVersion: '>= 1.15.0'
-name: network-operator
-sources:
-- https://github.com/Mellanox/network-operator
-type: application
-version: 0.2.0
+
+
+
+

--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: v0.2.0
+dependencies:
+- condition: nfd.enabled
+  name: node-feature-discovery
+  repository: ""
+  version: 0.1.0
+description: Nvidia Mellanox network operator
+home: https://github.com/Mellanox/network-operator
+keywords:
+- gpu-direct
+- rdma
+kubeVersion: '>= 1.15.0'
+name: network-operator
+sources:
+- https://github.com/Mellanox/network-operator
+type: application
+version: 0.2.0

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -42,7 +42,7 @@ $ helm repo add mellanox https://mellanox.github.io/network-operator
 $ helm repo update
 
 # Install Operator
-$ helm install -n network-operator --create-namespace --wait mellanox/network-operator
+$ helm install -n network-operator --create-namespace --wait mellanox/network-operator network-operator
 
 # View deployed resources
 $ kubectl -n network-operator get pods
@@ -123,7 +123,7 @@ override to the parameter via CLI it would simply be cumbersome.
 Below are several deployment examples `values.yaml` provided to helm during installation
 of the network operator in the following manner:
 
-`$ helm install -f ./values.yaml -n network-operator --create-namespace --wait mellanox/network-operator `
+`$ helm install -f ./values.yaml -n network-operator --create-namespace --wait mellanox/network-operator network-operator`
 
 #### Example 1
 Network Operator deployment with a specific version of OFED driver and a single RDMA resource mapped to `enp1`

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -7,6 +7,9 @@ the lifecycle of Nvidia Mellanox network operator.
 Nvidia Mellanox Network Operator leverages [Kubernetes CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 and [Operator SDK](https://github.com/operator-framework/operator-sdk) to manage Networking related Components in order to enable Fast networking, 
 RDMA and GPUDirect for workloads in a Kubernetes cluster.
+Network Operator works in conjunction with [GPU-Operator](https://github.com/NVIDIA/gpu-operator) to enable GPU-Direct RDMA
+on compatible systems.
+
 
 The Goal of Network Operator is to manage _all_ networking related components to enable execution of
 RDMA and GPUDirect RDMA workloads in a kubernetes cluster including:
@@ -16,19 +19,24 @@ RDMA and GPUDirect RDMA workloads in a kubernetes cluster including:
 
 ## QuickStart
 
+### System Requirements
+* RDMA capable hardware: Mellanox ConnectX-4 NIC or newer.
+* NVIDIA GPU and driver supporting GPUDirect e.g Quadro RTX 6000/8000 or Tesla T4 or Tesla V100 or Tesla V100.
+(GPU-Direct only)
+* Operating System: Ubuntu18.04 with kernel `4.15.0-109-generic`.
+
 ### Prerequisites
 
 - Kubernetes v1.15+
 - Helm v3
 - Ubuntu 18.04LTS
 
-
 ### Install Helm
 
 Helm provides an install script to copy helm binary to your system:
 ```
 $ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-$ chmod 700 get_helm.sh
+$ chmod 500 get_helm.sh
 $ ./get_helm.sh
 ```
 
@@ -64,7 +72,7 @@ We have introduced the following Chart parameters.
 | `nfd.enabled` | bool | `True` | deploy Node Feature Discovery |
 | `operator.repository` | string | `mellanox` | Network Operator image repository |
 | `operator.image` | string | `network-operator` | Network Operator image name |
-| `operator.tag` | string | `None` | Network Operator image tag |
+| `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used |
 | `deployCR` | bool | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters |
 
 ### Custom resource parameters

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -1,0 +1,163 @@
+# Nvidia Mellanox Network Operator Helm Chart
+
+Nvidia Mellanox Network Operator Helm Chart provides an easy way to install, configure and manage
+the lifecycle of Nvidia Mellanox network operator.
+
+## Nvidia Mellanox Network Operator
+Nvidia Mellanox Network Operator leverages [Kubernetes CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+and [Operator SDK](https://github.com/operator-framework/operator-sdk) to manage Networking related Components in order to enable Fast networking, 
+RDMA and GPUDirect for workloads in a Kubernetes cluster.
+
+The Goal of Network Operator is to manage _all_ networking related components to enable execution of
+RDMA and GPUDirect RDMA workloads in a kubernetes cluster including:
+* Mellanox Networking drivers to enable advanced features
+* Kubernetes device plugins to provide hardware resources for fast network
+* Kubernetes secondary network for Network intensive workloads
+
+## QuickStart
+
+### Prerequisites
+
+- Kubernetes v1.15+
+- Helm v3
+- Ubuntu 18.04LTS
+
+
+### Install Helm
+
+Helm provides an install script to copy helm binary to your system:
+```
+$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+$ chmod 700 get_helm.sh
+$ ./get_helm.sh
+```
+
+For additional information and methods for installing Helm, refer to the official [helm website](https://helm.sh/)
+
+### Deploy Network Operator
+
+```
+# Add Repo
+$ helm repo add mellanox https://mellanox.github.io/network-operator
+$ helm repo update
+
+# Install Operator
+$ helm install -n network-operator --create-namespace --wait mellanox/network-operator
+
+# View deployed resources
+$ kubectl -n network-operator get pods
+```
+
+>__Note:__ By default the operator is deployed without an instance of `NicClusterPolicy`
+custom resource. The user is required to create it later with configuration matching the cluster or use
+chart parameters to deploy it together with the operator.
+
+## Chart parameters
+
+In order to tailor the deployment of the network operator to your cluster needs
+We have introduced the following Chart parameters.
+
+### General parameters
+
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
+| `nfd.enabled` | bool | `True` | deploy Node Feature Discovery |
+| `operator.repository` | string | `mellanox` | Network Operator image repository |
+| `operator.image` | string | `network-operator` | Network Operator image name |
+| `operator.tag` | string | `None` | Network Operator image tag |
+| `deployCR` | bool | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters |
+
+### Custom resource parameters
+
+#### Mellanox OFED driver
+
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
+| `ofedDriver.deploy` | bool | `false` | deploy Mellanox OFED driver container |
+| `ofedDriver.repository` | string | `mellanox` | Mellanox OFED driver image repository |
+| `ofedDriver.image` | string | `ofed-driver` | Mellanox OFED driver image name  |
+| `ofedDriver.version` | string | `5.0-2.1.8.0` | Mellanox OFED driver version  |
+
+#### NVIDIA Peer memory driver
+
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
+| `nvPeerDriver.deploy` | bool | `false` | deploy NVIDIA Peer memory driver container |
+| `nvPeerDriver.repository` | string | `mellanox` | NVIDIA Peer memory driver image repository |
+| `nvPeerDriver.image` | string | `nv-peer-mem-driver` | NVIDIA Peer memory driver image name  |
+| `nvPeerDriver.version` | string | `1.0-9` | Mellanox OFED driver version  |
+| `nvPeerDriver.gpuDriverSourcePath` | string | `/run/nvidia/driver` | GPU driver soruces root filesystem path(usually used in tandem with [gpu-operator](https://github.com/NVIDIA/gpu-operator)) |
+
+#### RDMA Device Plugin
+
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
+| `devicePlugin.deploy` | bool | `true` | Deploy device plugin  |
+| `devicePlugin.repository` | string | `mellanox` | Device plugin image repository |
+| `devicePlugin.image` | string | `k8s-rdma-shared-dev-plugin` | Device plugin image name  |
+| `devicePlugin.version` | string | `v1.0.0` | Device plugin version  |
+| `devicePlugin.resources` | list | See below | Device plugin resources |
+
+##### RDMA Device Plugin Resource configurations
+
+Consists of a list of RDMA resources each with a name a a list of RDMA capable network devices
+to be associated with the resource.
+
+```
+resources:
+    - name: rdma_shared_device_a
+      devices: [enp5s0f0]
+    - name: rdma_shared_device_b
+      devices: [ib0, ib1]
+``` 
+
+>__Note__: The parameter listed are non-exahustive, for the full list of chart parameters refer to
+the file: `values.yaml`
+
+## Deployment Examples
+
+As there are several parameters that are required to be provided to create the custom resource during
+operator deployment, it is recommended that a configuration file be used. While its possible to provide
+override to the parameter via CLI it would simply be cumbersome.
+
+Below are several deployment examples `values.yaml` provided to helm during installation
+of the network operator in the following manner:
+
+`$ helm install -f ./values.yaml -n network-operator --create-namespace --wait mellanox/network-operator `
+
+#### Example 1
+Network Operator deployment with a specific version of OFED driver and a single RDMA resource mapped to `enp1`
+netdev.
+
+__values.yaml:__
+```:yaml
+deployCR: true
+ofedDriver:
+  deploy: true
+  version: 5.0-2.1.8.0
+devicePlugin:
+  deploy: true
+  reources:
+    - name: rdma_shared_device_a
+      devices: [enp1]
+```
+
+#### Example 2
+Network Operator deployment with the default version of OFED and NV Peer mem driver, RDMA device
+plugin with two RDMA resources, the first mapped to `enp1` and `enp2`, the second mapped to `ib0`.
+
+__values.yaml:__
+```:yaml
+deployCR: true
+ofedDriver:
+  deploy: true
+nvPeerDriver:
+  deploy: true
+devicePlugin:
+  deploy: true
+  reources:
+    - name: rdma_shared_device_a
+      devices: [enp1, enp2]
+    - name: rdma_shared_device_b
+      devices: [ib0]
+```

--- a/deployment/network-operator/charts/node-feature-discovery/.helmignore
+++ b/deployment/network-operator/charts/node-feature-discovery/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/network-operator/charts/node-feature-discovery/Chart.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: v0.6.0
+description: |
+  Detects hardware features available on each node in a Kubernetes cluster, and advertises
+  those features using node labels.
+name: node-feature-discovery
+type: application
+version: 0.1.0

--- a/deployment/network-operator/charts/node-feature-discovery/templates/_helpers.tpl
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/_helpers.tpl
@@ -1,0 +1,79 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-feature-discovery.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "node-feature-discovery.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-feature-discovery.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "node-feature-discovery.labels" -}}
+helm.sh/chart: {{ include "node-feature-discovery.chart" . }}
+{{ include "node-feature-discovery.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "node-feature-discovery.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "node-feature-discovery.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "node-feature-discovery.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "node-feature-discovery.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/clusterrole.yaml
@@ -1,0 +1,33 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
@@ -1,0 +1,32 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "node-feature-discovery.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "node-feature-discovery.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/master.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/master.yaml
@@ -1,0 +1,100 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ include "node-feature-discovery.fullname" . }}-master
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    role: master
+spec:
+  replicas: {{ .Values.master.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}
+      role: master
+  template:
+    metadata:
+      labels:
+        {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
+        role: master
+      annotations:
+        {{- toYaml .Values.master.annotations | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "node-feature-discovery.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.master.podSecurityContext | nindent 8 }}
+      containers:
+        - name: master
+          securityContext:
+            {{- toYaml .Values.master.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - containerPort: 8080
+            name: grpc
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          command:
+            - "nfd-master"
+          
+          resources:
+            {{- toYaml .Values.master.resources | nindent 12 }}
+## Enable TLS authentication
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-master-cert.
+## Additional hardening can be enabled by specifying --verify-node-name in
+## args, in which case every nfd-worker requires a individual node-specific
+## TLS certificate.
+#          args:
+#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+#          volumeMounts:
+#            - name: nfd-ca-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#              readOnly: true
+#            - name: nfd-master-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#              readOnly: true
+#      volumes:
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-master-cert
+#          secret:
+#            secretName: nfd-master-cert
+    {{- with .Values.master.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.master.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.master.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/service.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/service.yaml
@@ -1,0 +1,32 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-master
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    role: master
+spec:
+  type: {{ .Values.master.service.type }}
+  ports:
+    - port: {{ .Values.master.service.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "node-feature-discovery.selectorLabels" . | nindent 4 }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
@@ -1,0 +1,28 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-feature-discovery.serviceAccountName" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
@@ -1,0 +1,128 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name:  {{ include "node-feature-discovery.fullname" . }}-worker
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    role: worker
+spec:
+  selector:
+    matchLabels:
+      {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}
+      role: worker
+  template:
+    metadata:
+      labels:
+        {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
+        role: worker
+      annotations:
+        {{- toYaml .Values.worker.annotations | nindent 8 }}
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "node-feature-discovery.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
+      containers:
+      - name: worker
+        securityContext:
+          {{- toYaml .Values.worker.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - "nfd-worker"
+        resources:
+          {{- toYaml .Values.worker.resources | nindent 12 }}
+        args:
+        - "--sleep-interval=60s"
+        - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
+        {{- with .Values.worker.options }}
+        - --options={{- toJson . }}
+        {{- end }}
+## Enable TLS authentication (1/3)
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-worker-cert
+#          - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#          - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#          - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+        volumeMounts:
+        - name: host-boot
+          mountPath: "/host-boot"
+          readOnly: true
+        - name: host-os-release
+          mountPath: "/host-etc/os-release"
+          readOnly: true
+        - name: host-sys
+          mountPath: "/host-sys"
+        - name: source-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - name: features-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+## Enable TLS authentication (2/3)
+#        - name: nfd-ca-cert
+#          mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#          readOnly: true
+#        - name: nfd-worker-cert
+#          mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#          readOnly: true
+      volumes:
+        - name: host-boot
+          hostPath:
+            path: "/boot"
+        - name: host-os-release
+          hostPath:
+            path: "/etc/os-release"
+        - name: host-sys
+          hostPath:
+            path: "/sys"
+        - name: source-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - name: features-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/features.d/"
+## Enable TLS authentication (3/3)
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-worker-cert
+#          secret:
+#            secretName: nfd-worker-cert
+    {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/deployment/network-operator/charts/node-feature-discovery/values.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/values.yaml
@@ -1,0 +1,149 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for node-feature-discovery.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: quay.io/kubernetes_incubator/node-feature-discovery
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+  
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+nameOverride: ""
+fullnameOverride: ""
+
+master:
+  replicaCount: 1
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations:
+  - key: "node-role.kubernetes.io/master"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+
+  annotations: {}
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [""]
+
+worker:
+  options: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations:
+  - key: "node-role.kubernetes.io/master"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+
+  annotations: {}
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [""]
+
+## RBAC parameteres
+## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+##
+rbac:
+  create: true
+  ## Service Account for pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccountName: default
+  ## Annotations for the Service Account
+  ##
+  serviceAccountAnnotations: {}
+  ## RBAC API version
+  ##
+  apiVersion: v1
+  ## Podsecuritypolicy
+  ##
+  pspEnabled: false

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -1,0 +1,151 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nicclusterpolicies.mellanox.com
+spec:
+  group: mellanox.com
+  names:
+    kind: NicClusterPolicy
+    listKind: NicClusterPolicyList
+    plural: nicclusterpolicies
+    singular: nicclusterpolicy
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: NicClusterPolicy is the Schema for the nicclusterpolicies API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NicClusterPolicySpec defines the desired state of NicClusterPolicy
+          properties:
+            devicePlugin:
+              description: DevicePluginSpec describes configuration options for device
+                plugin
+              properties:
+                config:
+                  description: Device plugin configuration
+                  type: string
+                image:
+                  pattern: '[a-zA-Z0-9\-]+'
+                  type: string
+                repository:
+                  pattern: '[a-zA-Z0-9\.\-\/]+'
+                  type: string
+                version:
+                  pattern: '[a-zA-Z0-9\.-]+'
+                  type: string
+              required:
+              - config
+              - image
+              - repository
+              - version
+              type: object
+            nvPeerDriver:
+              description: NVPeerDriverSpec describes configuration options for NV
+                Peer Memory driver
+              properties:
+                gpuDriverSourcePath:
+                  description: GPU driver sources path - Optional
+                  type: string
+                image:
+                  pattern: '[a-zA-Z0-9\-]+'
+                  type: string
+                repository:
+                  pattern: '[a-zA-Z0-9\.\-\/]+'
+                  type: string
+                version:
+                  pattern: '[a-zA-Z0-9\.-]+'
+                  type: string
+              required:
+              - image
+              - repository
+              - version
+              type: object
+            ofedDriver:
+              description: OFEDDriverSpec describes configuration options for OFED
+                driver
+              properties:
+                image:
+                  pattern: '[a-zA-Z0-9\-]+'
+                  type: string
+                repository:
+                  pattern: '[a-zA-Z0-9\.\-\/]+'
+                  type: string
+                version:
+                  pattern: '[a-zA-Z0-9\.-]+'
+                  type: string
+              required:
+              - image
+              - repository
+              - version
+              type: object
+          type: object
+        status:
+          description: NicClusterPolicyStatus defines the observed state of NicClusterPolicy
+          properties:
+            appliedStates:
+              description: AppliedStates provide a finer view of the observed state
+              items:
+                description: AppliedState defines a finer-grained view of the observed
+                  state of NicClusterPolicy
+                properties:
+                  name:
+                    type: string
+                  state:
+                    description: Represents reconcile state of the system
+                    enum:
+                    - ready
+                    - notReady
+                    - ignore
+                    - error
+                    type: string
+                required:
+                - name
+                - state
+                type: object
+              type: array
+            reason:
+              description: Informative string in case the observed state is error
+              type: string
+            state:
+              description: Reflects the current state of the cluster policy
+              enum:
+              - notReady
+              - ready
+              - error
+              type: string
+          required:
+          - state
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deployment/network-operator/templates/NOTES.txt
+++ b/deployment/network-operator/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Get Network Operator deployed resources by running the following commands:
+
+$ kubectl -n {{ .Release.Namespace }} get pods
+$ kubectl -n mlnx-network-operator-resources get pods

--- a/deployment/network-operator/templates/_helpers.tpl
+++ b/deployment/network-operator/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "network-operator.name" -}}
+{{- default .Chart.Name .Values.operator.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "network-operator.fullname" -}}
+{{- if .Values.operator.fullnameOverride }}
+{{- .Values.operator.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.operator.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "network-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "network-operator.labels" -}}
+helm.sh/chart: {{ include "network-operator.chart" . }}
+{{ include "network-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "network-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "network-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -1,0 +1,57 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+{{- if .Values.deployCR }}
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: clusterpolicy
+spec:
+  {{- if .Values.ofedDriver.deploy }}
+  ofedDriver:
+    image: {{ .Values.ofedDriver.image }}
+    repository: {{ .Values.ofedDriver.repository }}
+    version: {{ .Values.ofedDriver.version }}
+  {{- end }}
+  {{- if .Values.nvPeerDriver.deploy }}
+  nvPeerDriver:
+    image: {{ .Values.nvPeerDriver.image }}
+    repository: {{ .Values.nvPeerDriver.repository }}
+    version: {{ .Values.nvPeerDriver.version }}
+    gpuDriverSourcePath: {{ .Values.nvPeerDriver.gpuDriverSourcePath }}
+  {{- end }}
+  {{- if .Values.devicePlugin.deploy }}
+  devicePlugin:
+    # {{ required "A valid value for .Values.devicePlugin.resources is required" .Values.devicePlugin.resources }}
+    image: {{ .Values.devicePlugin.image }}
+    repository: {{ .Values.devicePlugin.repository }}
+    version: {{ .Values.devicePlugin.version }}
+    # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
+    # Replace 'devices' with your (RDMA capable) netdevice name.
+    config: |
+      {
+        "configList": [
+          {{- $length := len .Values.devicePlugin.resources }}
+          {{- range $index, $element := .Values.devicePlugin.resources }}
+          {
+            "resourceName": {{ $element.name | quote }},
+            "rdmaHcaMax": 1000,
+            "devices": {{ $element.devices | toJson }}
+          } {{- if ne $length (add1 $index) }},{{ end }}
+          {{- end }}
+        ]
+      }
+  {{- end }}
+{{ end }}

--- a/deployment/network-operator/templates/operator-resources-ns.yaml
+++ b/deployment/network-operator/templates/operator-resources-ns.yaml
@@ -1,0 +1,19 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mlnx-network-operator-resources

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -1,0 +1,55 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "network-operator.fullname" . }}
+  labels:
+    {{- include "network-operator.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "network-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "network-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "network-operator.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          # Replace this with the built image name
+          image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ .Values.operator.tag | default .Chart.AppVersion }}"
+          command:
+          - network-operator
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: STATE_MANIFEST_BASE_DIR
+              value: "/etc/manifests"
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "network-operator"

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -1,0 +1,203 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ include "network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ include "network-operator.fullname" . }}
+  namespace: mlnx-network-operator-resources
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: {{ include "network-operator.fullname" . }}
+rules:
+  - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch

--- a/deployment/network-operator/templates/role_binding.yaml
+++ b/deployment/network-operator/templates/role_binding.yaml
@@ -1,0 +1,55 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "network-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "network-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "network-operator.fullname" . }}
+  namespace: mlnx-network-operator-resources
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "network-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "network-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "network-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "network-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "network-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/deployment/network-operator/templates/service_account.yaml
+++ b/deployment/network-operator/templates/service_account.yaml
@@ -1,0 +1,20 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -1,0 +1,85 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for network-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nfd:
+  enabled: true
+
+# Node Feature discovery chart related values
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+      - key: "nvidia.com/gpu"
+        operator: "Equal"
+        value: "present"
+        effect: "NoSchedule"
+    options:
+      sources:
+        pci:
+          deviceClassWhitelist:
+            - "02"
+            - "0200"
+            - "0207"
+          deviceLabelFields:
+            - vendor
+
+# General Operator related values
+# The operator element allows to deploy network operator from an alternate location
+operator:
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Equal"
+      value: ""
+      effect: "NoSchedule"
+  repository: mellanox
+  image: network-operator
+  nameOverride: ""
+  fullnameOverride: ""
+  # tag, if defined will use the given image tag, else Chart.AppVersion will be used
+  # tag
+
+# NicClusterPolicy CR values:
+deployCR: false
+ofedDriver:
+  deploy: false
+  image: ofed-driver
+  repository: mellanox
+  version: 5.0-2.1.8.0
+
+nvPeerDriver:
+  deploy: false
+  image: nv-peer-mem-driver
+  repository: mellanox
+  version: 1.0-9
+  gpuDriverSourcePath: /run/nvidia/driver
+
+devicePlugin:
+  deploy: true
+  image: k8s-rdma-shared-dev-plugin
+  repository: mellanox
+  version: v1.0.0
+  # The following defines the RDMA resources in the cluster
+  # it must be provided by the user when deploying the chart
+  # each entry in the resources element will create a resource with the provided <name> and list of devices
+  # example:
+  resources:
+    - name: rdma_shared_device_a
+      devices: [enp5s0f0]

--- a/example/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/example/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -22,7 +22,7 @@ spec:
     listKind: NicClusterPolicyList
     plural: nicclusterpolicies
     singular: nicclusterpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:

--- a/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -15,7 +15,6 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: example-nicclusterpolicy
-  namespace: mlnx-network-operator-resources
 spec:
   ofedDriver:
     image: ofed-driver

--- a/example/deploy/operator.yaml
+++ b/example/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/etc/manifests"
             - name: WATCH_NAMESPACE
-              value: "mlnx-network-operator-resources"
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/example/deploy/role.yaml
+++ b/example/deploy/role.yaml
@@ -68,18 +68,82 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - mellanox.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: network-operator
+  namespace: mlnx-network-operator-resources
+rules:
+  - apiGroups:
       - ""
     resources:
       - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
+      - create
+      - delete
       - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - apps
     resources:
-      - replicasets
       - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
     verbs:
       - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - network-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
   - apiGroups:
       - mellanox.com
     resources:
@@ -92,76 +156,21 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: network-operator
-  namespace: mlnx-network-operator-resources
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - network-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
 - apiGroups:
   - mellanox.com
   resources:
@@ -174,18 +183,19 @@ rules:
   - patch
   - update
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: network-operator
-  creationTimestamp: null
-rules:
-  - apiGroups:
+- apiGroups:
     - ""
-    resources:
+  resources:
     - nodes
-    verbs:
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
     - get
     - list
     - watch

--- a/example/deploy/role_binding.yaml
+++ b/example/deploy/role_binding.yaml
@@ -17,9 +17,9 @@ metadata:
   name: network-operator
   namespace: mlnx-network-operator
 subjects:
-- kind: ServiceAccount
-  name: network-operator
-  namespace: mlnx-network-operator
+  - kind: ServiceAccount
+    name: network-operator
+    namespace: mlnx-network-operator
 roleRef:
   kind: Role
   name: network-operator

--- a/pkg/apis/mellanox/v1alpha1/nicclusterpolicy_types.go
+++ b/pkg/apis/mellanox/v1alpha1/nicclusterpolicy_types.go
@@ -108,7 +108,7 @@ type NicClusterPolicyStatus struct {
 
 // NicClusterPolicy is the Schema for the nicclusterpolicies API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=nicclusterpolicies,scope=Namespaced
+// +kubebuilder:resource:path=nicclusterpolicies,scope=Cluster
 type NicClusterPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Helm Deployment support

This commits adds support to deploy the network operator via helm.

- Create helm chart for network operator
- Update templates with needed resources
- Add NFD chart as dependency to facilitate Node feature discovery
  deployment if required
- Add README for instructions on how to deploy the operator via helm