### PR TITLE
Align log levels with operator-sdk default impl

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -21,10 +21,11 @@ package consts
 */
 
 const (
-	LogLevelError   = 1
-	LogLevelWarning = 2
-	LogLevelInfo    = 3
-	LogLevelDebug   = 4
+	// Note: if a different logger is used than zap (operator-sdk default), these values would probably need to change.
+	LogLevelError = iota - 2
+	LogLevelWarning
+	LogLevelInfo
+	LogLevelDebug
 )
 
 const (


### PR DESCRIPTION
This commit aligns the defiend log levels with
the default logging implementation used (zap).

Leveled log messages will now be printed with
their proper string and adhere to the log level
provided to the process via --zap-level flag.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>