### PR TITLE
Align Tolerations for daemonsets

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -33,7 +33,13 @@ spec:
         app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
     spec:
       tolerations:
-        - operator: Exists
+        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+        # This, along with the annotation above marks this pod as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -33,7 +33,13 @@ spec:
         app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}-kver{{ .RuntimeSpec.KernelVerFull }}
     spec:
       tolerations:
-        - operator: Exists
+        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+        # This, along with the annotation above marks this pod as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-rdma-device-plugin/0020-k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/stage-rdma-device-plugin/0020-k8s-rdma-shared-dev-plugin-ds.yaml
@@ -36,6 +36,12 @@ spec:
       # This, along with the annotation above marks this pod as a critical add-on.
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       containers:
       - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
         name: rdma-shared-dp


### PR DESCRIPTION
This commit aligns tolerations for daemonsets
and removes the "tolerate all" entry which should
not have been there in the first place.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>