### PR TITLE
Add host-device secondary network example deployment

### DIFF
--- a/example/delete-rdma-net-hostdev-ipam.sh
+++ b/example/delete-rdma-net-hostdev-ipam.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Deleting Secondary Network with Whereabouts IPAM"
+echo "################################################"
+kubectl delete -f networking/rdma-net-hostdev-cr-whereabouts-ipam.yml
+kubectl delete -f networking/whareabouts-daemonset-install.yaml
+kubectl delete -f networking/whereabouts.cni.cncf.io_ippools.yaml
+kubectl delete -f networking/multus-daemonset.yml

--- a/example/delete-rdma-net-hostdev.sh
+++ b/example/delete-rdma-net-hostdev.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Deleting Secondary Network"
+echo "##########################"
+kubectl delete -f networking/rdma-net-hostdev-cr.yml
+kubectl delete -f networking/multus-daemonset.yml

--- a/example/deploy-rdma-net-hostdev-ipam.sh
+++ b/example/deploy-rdma-net-hostdev-ipam.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Deploying Secondary Network with Whereabouts IPAM: \"rdma-net-hostdev-ipam\" with RDMA resource : \"rdma/hca_shared_devices_a\""
+echo "#######################################################################################################################"
+kubectl apply -f networking/multus-daemonset.yml
+kubectl apply -f networking/whereabouts.cni.cncf.io_ippools.yaml
+kubectl apply -f networking/whareabouts-daemonset-install.yaml
+kubectl apply -f networking/rdma-net-hostdev-cr-whereabouts-ipam.yml
+

--- a/example/deploy-rdma-net-hostdev.sh
+++ b/example/deploy-rdma-net-hostdev.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Deploying Secondary Network: \"rdma-net-hostdev\" with RDMA resource : \"rdma/hca_shared_devices_a\""
+echo "#######################################################################################################################"
+kubectl apply -f networking/multus-daemonset.yml
+kubectl apply -f networking/whereabouts.cni.cncf.io_ippools.yaml
+kubectl apply -f networking/whareabouts-daemonset-install.yaml
+kubectl apply -f networking/rdma-net-hostdev-cr.yml
+

--- a/example/networking/rdma-net-hostdev-cr-whereabouts-ipam.yml
+++ b/example/networking/rdma-net-hostdev-cr-whereabouts-ipam.yml
@@ -1,0 +1,31 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: rdma/hca_shared_devices_a
+  name: rdma-net-hostdev-ipam
+  namespace: default
+spec:
+  # Configuration below assumes 'ens2f0' as device for host-device CNI,
+  # replace with (RDMA capable) netdevice of your choice.
+  config: |-
+    {
+        "cniVersion": "0.3.1",
+        "name": "rdma-net-hostdev-ipam",
+        "plugins": [
+            {
+                "ipam": {
+                    "datastore": "kubernetes",
+                    "kubernetes": {
+                        "kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
+                    },
+                    "log_file": "/tmp/whereabouts.log",
+                    "log_level": "debug",
+                    "range": "192.168.111.0/24",
+                    "type": "whereabouts"
+                },
+                "type": "host-device",
+                "device": "ens2f0"
+            }
+        ]
+    }

--- a/example/networking/rdma-net-hostdev-cr.yml
+++ b/example/networking/rdma-net-hostdev-cr.yml
@@ -1,0 +1,21 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: rdma/hca_shared_devices_a
+  name: rdma-net-hostdev
+  namespace: default
+spec:
+  # Configuration below assumes 'ens2f0' as master device for host-device CNI,
+  # replace with (RDMA capable) netdevice of your choice.
+  config: |-
+    {
+        "cniVersion": "0.3.1",
+        "name": "rdma-net-hostdev",
+        "plugins": [
+            {
+                "type": "host-device",
+                "master": "ens2f0"
+            }
+        ]
+    }


### PR DESCRIPTION
This commit adds Example on how to deploy a secondary
RDMA network using host-device CNI.

This is intended to be used to directly assign the physical
NIC interface to the pod when DPDK application need to run
but SR-IOV is not utilized.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>