### PR TITLE
Network Operator watches for NicClusterPolicy with predefined name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The Operator Acts on the following CRDs:
 ### NICClusterPolicy CRD
 CRD that defines a Cluster state for Mellanox Network devices.
 
+>__NOTE__: The operator will act on a NicClusterPolicy instance with a predefined name "nic-cluster-policy", instances with different names will be ignored.
+
 #### NICClusterPolicy spec:
 NICClusterPolicy CRD Spec includes the following sub-states/stages:
 - `ofedDriver`: [OFED driver container](https://github.com/Mellanox/ofed-docker) to be deployed on Mellanox supporting nodes.
@@ -79,7 +81,7 @@ but without NV Peer Memory driver.
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: example-nicclusterpolicy
+  name: nic-cluster-policy
   namespace: mlnx-network-operator
 spec:
   ofedDriver:

--- a/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -136,6 +136,7 @@ spec:
             state:
               description: Reflects the current state of the cluster policy
               enum:
+              - ignore
               - notReady
               - ready
               - error

--- a/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -14,7 +14,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: example-nicclusterpolicy
+  name: nic-cluster-policy
 spec:
   ofedDriver:
     image: REPLACE_IMAGE

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -136,6 +136,7 @@ spec:
             state:
               description: Reflects the current state of the cluster policy
               enum:
+              - ignore
               - notReady
               - ready
               - error

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -17,7 +17,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: clusterpolicy
+  name: nic-cluster-policy
 spec:
   {{- if .Values.ofedDriver.deploy }}
   ofedDriver:

--- a/example/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
+++ b/example/deploy/crds/mellanox.com_nicclusterpolicies_crd.yaml
@@ -136,6 +136,7 @@ spec:
             state:
               description: Reflects the current state of the cluster policy
               enum:
+              - ignore
               - notReady
               - ready
               - error

--- a/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -14,7 +14,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: example-nicclusterpolicy
+  name: nic-cluster-policy
 spec:
   ofedDriver:
     image: ofed-driver

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/caarlos0/env/v6 v6.2.2
+	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/operator-framework/operator-sdk v0.17.1

--- a/pkg/apis/mellanox/v1alpha1/nicclusterpolicy_types.go
+++ b/pkg/apis/mellanox/v1alpha1/nicclusterpolicy_types.go
@@ -96,7 +96,7 @@ type NicClusterPolicyStatus struct {
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// Reflects the current state of the cluster policy
-	// +kubebuilder:validation:Enum={"notReady", "ready", "error"}
+	// +kubebuilder:validation:Enum={"ignore", "notReady", "ready", "error"}
 	State State `json:"state"`
 	// Informative string in case the observed state is error
 	Reason string `json:"reason,omitempty"`

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -30,4 +30,5 @@ const (
 
 const (
 	NetworkOperatorResourceNamespace = "mlnx-network-operator-resources"
+	NicClusterPolicyResourceName     = "nic-cluster-policy"
 )


### PR DESCRIPTION
Network Operator watches only for NicPolicy with name "nic-cluster-policy" to prevent polices overlapping

Signed-off-by: Mamduh Alassi <mamduhala@mellanox.com>

Fixes #17 