### PR TITLE
Minor log level fix

### DIFF
--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -97,7 +97,7 @@ func (smgr *stateManager) SyncState(customResource interface{}, infoCatalog Info
 			return managerResult, err
 		}
 		if !done {
-			log.V(consts.LogLevelError).Info("State Group Not ready")
+			log.V(consts.LogLevelInfo).Info("State Group Not ready")
 			return managerResult, nil
 		}
 		log.V(consts.LogLevelInfo).Info("Sync Completed successfully for State group", "index", i)


### PR DESCRIPTION
state manager should not emit error log
when state group is not ready. this is not an error
modify to INFO log

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>