### PR TITLE
Deploy network operator controller on master

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,6 +26,12 @@ spec:
       labels:
         name: network-operator
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
       serviceAccountName: network-operator
       containers:
         - name: network-operator

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -30,6 +30,10 @@ spec:
       labels:
         {{- include "network-operator.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.operator.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -49,6 +49,8 @@ operator:
       operator: "Equal"
       value: ""
       effect: "NoSchedule"
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
   repository: mellanox
   image: network-operator
   nameOverride: ""

--- a/example/deploy/operator.yaml
+++ b/example/deploy/operator.yaml
@@ -26,6 +26,12 @@ spec:
       labels:
         name: network-operator
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
       serviceAccountName: network-operator
       containers:
         - name: network-operator


### PR DESCRIPTION
This Commit modifies operator deployment yamls
to deploy operator on master node.

- Add nodeSelector to deploy on master node and matching
  toleration.
- Support specifying nodeSelector in addition to toleration
  in helm deployment which by default will deploy the operator
  on master node.