### PR TITLE
Increase ofed-driver startupProbe timeout to 10 minutes

### DIFF
--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -65,7 +65,7 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: 60
             successThreshold: 1
-            periodSeconds: 5
+            periodSeconds: 10
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
When deploying the ofed-driver on a non-supported kernel, the
container will try to rebuild the KDMS to support the new kernel,
this process has varying times based on the server capabilities.
This patch increases the timeout of ofed-driver startupProbe to 10
minutes as a precaution for somewhat old servers to not restart
container build waiting for the modules to be rebuilt.

Signed-off-by: abdallahyas <abdallahyas@mellanox.com>