### PR TITLE
Cleanup nodeinfo.AttrTypeOSNameFull

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -15,13 +15,13 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
-  name: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}-ds
+    app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+  name: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-ds
   namespace: {{ .RuntimeSpec.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+      app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
   template:
     metadata:
       # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
@@ -30,7 +30,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+        app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
     spec:
       tolerations:
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
@@ -45,7 +45,7 @@ spec:
           effect: NoSchedule
       hostNetwork: true
       containers:
-        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
           imagePullPolicy: IfNotPresent
           name: nv-peer-mem-driver-container
           securityContext:

--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -15,13 +15,13 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
-  name: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}-ds
+    app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+  name: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-ds
   namespace: {{ .RuntimeSpec.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+      app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
   template:
     metadata:
       # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
@@ -30,7 +30,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+        app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
     spec:
       tolerations:
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
@@ -45,7 +45,7 @@ spec:
           effect: NoSchedule
       hostNetwork: true
       containers:
-        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSNameFull }}
+        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
           imagePullPolicy: IfNotPresent
           name: ofed-driver-container
           securityContext:

--- a/pkg/nodeinfo/attributes_test.go
+++ b/pkg/nodeinfo/attributes_test.go
@@ -45,8 +45,6 @@ var _ = Describe("NodeAttributes tests", func() {
 			Expect(attr.Attributes[AttrTypeHostname]).To(Equal(testNode.Labels[NodeLabelHostname]))
 			Expect(attr.Attributes[AttrTypeOSName]).To(Equal(testNode.Labels[NodeLabelOSName]))
 			Expect(attr.Attributes[AttrTypeOSVer]).To(Equal(testNode.Labels[NodeLabelOSVer]))
-			Expect(attr.Attributes[AttrTypeOSNameFull]).To(Equal(
-				testNode.Labels[NodeLabelOSName] + testNode.Labels[NodeLabelOSVer]))
 			Expect(attr.Attributes[AttrTypeCPUArch]).To(Equal(testNode.Labels[NodeLabelCPUArch]))
 		})
 	})
@@ -61,8 +59,6 @@ var _ = Describe("NodeAttributes tests", func() {
 			var exist bool
 			_, exist = attr.Attributes[AttrTypeHostname]
 			Expect(exist).To(BeTrue())
-			_, exist = attr.Attributes[AttrTypeOSNameFull]
-			Expect(exist).To(BeTrue())
 			_, exist = attr.Attributes[AttrTypeOSName]
 			Expect(exist).To(BeTrue())
 			_, exist = attr.Attributes[AttrTypeOSVer]
@@ -72,30 +68,29 @@ var _ = Describe("NodeAttributes tests", func() {
 		})
 	})
 
-	Context("Create NodeAttributes from node with no OS name", func() {
-		It("Should return NodeAttributes with no AttrTypeOS", func() {
-			testNode.Labels[NodeLabelOSName] = "ubuntu"
-			attr := newNodeAttributes(&testNode)
-
-			_, exist := attr.Attributes[AttrTypeOSNameFull]
-			Expect(exist).To(BeFalse())
-		})
-	})
-
-	Context("Create NodeAttributes from node with no OS version", func() {
-		It("Should return NodeAttributes with no AttrTypeOS", func() {
-			testNode.Labels[NodeLabelOSVer] = "20.04"
-			attr := newNodeAttributes(&testNode)
-
-			_, exist := attr.Attributes[AttrTypeOSNameFull]
-			Expect(exist).To(BeFalse())
-		})
-	})
-
 	Context("Create NodeAttributes with no labels", func() {
 		It("Should return NodeAttributes with no attributes", func() {
 			attr := newNodeAttributes(&testNode)
 			Expect(attr.Attributes).To(BeEmpty())
+		})
+	})
+
+	Context("Node Attributes from labels", func() {
+		It("Should return Node Attribute from labels", func() {
+			testNode.Labels[NodeLabelOSName] = "ubuntu"
+			attr := NodeAttributes{Attributes: make(map[AttributeType]string)}
+
+			nLabels := testNode.GetLabels()
+			err := attr.fromLabel(AttrTypeOSName, nLabels, NodeLabelOSName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attr.Attributes[AttrTypeOSName]).To(Equal("ubuntu"))
+		})
+		It("Should return no Node Attribute from labels", func() {
+			attr := NodeAttributes{Attributes: make(map[AttributeType]string)}
+
+			nLabels := testNode.GetLabels()
+			err := attr.fromLabel(AttrTypeOSName, nLabels, NodeLabelOSName)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/state/state_nv_peer.go
+++ b/pkg/state/state_nv_peer.go
@@ -44,9 +44,10 @@ type stateNVPeer struct {
 }
 
 type nvPeerRuntimeSpec struct {
-	CPUArch    string
-	OSNameFull string
-	Namespace  string
+	CPUArch   string
+	OSName    string
+	OSVer     string
+	Namespace string
 }
 
 type nvPeerManifestRenderData struct {
@@ -126,16 +127,17 @@ func (s *stateNVPeer) getManifestObjects(
 
 	// TODO: Render daemonset multiple times according to CPUXOS matrix (ATM assume all nodes are the same)
 	if err := s.checkAttributesExist(attrs[0],
-		nodeinfo.AttrTypeCPUArch, nodeinfo.AttrTypeOSNameFull); err != nil {
+		nodeinfo.AttrTypeCPUArch, nodeinfo.AttrTypeOSName, nodeinfo.AttrTypeOSVer); err != nil {
 		return nil, err
 	}
 
 	renderData := &nvPeerManifestRenderData{
 		CrSpec: cr.Spec.NVPeerDriver,
 		RuntimeSpec: &nvPeerRuntimeSpec{
-			Namespace:  consts.NetworkOperatorResourceNamespace,
-			CPUArch:    attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
-			OSNameFull: attrs[0].Attributes[nodeinfo.AttrTypeOSNameFull],
+			Namespace: consts.NetworkOperatorResourceNamespace,
+			CPUArch:   attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
+			OSName:    attrs[0].Attributes[nodeinfo.AttrTypeOSName],
+			OSVer:     attrs[0].Attributes[nodeinfo.AttrTypeOSVer],
 		},
 	}
 	// render objects

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -58,11 +58,10 @@ type stateOFED struct {
 }
 
 type ofedRuntimeSpec struct {
-	CPUArch    string
-	OSNameFull string
-	OSName     string
-	OSVer      string
-	Namespace  string
+	CPUArch   string
+	OSName    string
+	OSVer     string
+	Namespace string
 }
 
 type ofedManifestRenderData struct {
@@ -141,18 +140,17 @@ func (s *stateOFED) getManifestObjects(
 	// Note: it is assumed MOFED driver container is able to handle multiple kernel version e.g by triggering DKMS
 	// if driver was compiled against a missmatching kernel to begin with.
 	if err := s.checkAttributesExist(attrs[0],
-		nodeinfo.AttrTypeCPUArch, nodeinfo.AttrTypeOSNameFull); err != nil {
+		nodeinfo.AttrTypeCPUArch, nodeinfo.AttrTypeOSName, nodeinfo.AttrTypeOSVer); err != nil {
 		return nil, err
 	}
 
 	renderData := &ofedManifestRenderData{
 		CrSpec: cr.Spec.OFEDDriver,
 		RuntimeSpec: &ofedRuntimeSpec{
-			Namespace:  consts.NetworkOperatorResourceNamespace,
-			CPUArch:    attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
-			OSNameFull: attrs[0].Attributes[nodeinfo.AttrTypeOSNameFull],
-			OSName:     attrs[0].Attributes[nodeinfo.AttrTypeOSName],
-			OSVer:      attrs[0].Attributes[nodeinfo.AttrTypeOSVer],
+			Namespace: consts.NetworkOperatorResourceNamespace,
+			CPUArch:   attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
+			OSName:    attrs[0].Attributes[nodeinfo.AttrTypeOSName],
+			OSVer:     attrs[0].Attributes[nodeinfo.AttrTypeOSVer],
 		},
 	}
 	// render objects


### PR DESCRIPTION
OSNameFull can be derrived from OSName and OSVer
Remove OSNameFull from Node Attributes package.

Fixes #42 