### PR TITLE
Remove hostNetwork from Node feature Discovery helm deployment chart

### DIFF
--- a/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         {{- toYaml .Values.worker.annotations | nindent 8 }}
     spec:
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
hostNetwork is not needed for NFD since v0.6.0

fixes #39 