### PR TITLE
Support HTTP proxy setting to be passed down to containers

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
           # Replace this with the built image name
           image: REPLACE_IMAGE
           command:
-          - network-operator
+            - network-operator
           imagePullPolicy: Always
           env:
             - name: STATE_MANIFEST_BASE_DIR
@@ -51,3 +51,9 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "network-operator"
+            - name: HTTP_PROXY
+              value: ""
+            - name: HTTPS_PROXY
+              value: ""
+            - name: NO_PROXY
+              value: ""

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -75,6 +75,16 @@ We have introduced the following Chart parameters.
 | `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used |
 | `deployCR` | bool | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters |
 
+### Proxy parameters
+These proxy parameter will translate to HTTP_PROXY, HTTPS_PROXY, NO_PROXY environment variables to be used by the network operator and relevant resources it deploys.
+Production cluster environment can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available.
+
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
+| `proxy.httpProxy` | string | `None` | proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be http |
+| `proxy.httpsProxy` | string | `None` | proxy URL to use for creating HTTPS connections outside the cluster |
+| `proxy.noProxy` | string | `None` | A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying |
+
 ### NicClusterPolicy Custom resource parameters
 
 #### Mellanox OFED driver

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -61,3 +61,15 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "network-operator"
+            {{- if .Values.proxy.httpProxy | empty | not }}
+            - name: HTTP_PROXY
+              value: {{ .Values.proxy.httpProxy }}
+            {{- end }}
+            {{- if .Values.proxy.httpsProxy | empty | not }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.proxy.httpsProxy }}
+            {{- end }}
+            {{- if .Values.proxy.noProxy | empty | not }}
+            - name: NO_PROXY
+              value: {{ .Values.proxy.noProxy }}
+            {{- end }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -66,6 +66,11 @@ operator:
   # tag, if defined will use the given image tag, else Chart.AppVersion will be used
   # tag
 
+proxy:
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: ""
+
 # NicClusterPolicy CR values:
 deployCR: false
 ofedDriver:

--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -52,6 +52,13 @@ spec:
             privileged: true
             seLinuxOptions:
               level: "s0"
+          env:
+            - name: HTTP_PROXY
+              value: {{ .RuntimeSpec.HTTPProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .RuntimeSpec.HTTPSProxy }}
+            - name: NO_PROXY
+              value: {{ .RuntimeSpec.NoProxy }}
           volumeMounts:
             - name: run-mlnx-ofed
               mountPath: /run/mellanox/drivers

--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -52,6 +52,13 @@ spec:
             privileged: true
             seLinuxOptions:
               level: "s0"
+          env:
+            - name: HTTP_PROXY
+              value: {{ .RuntimeSpec.HTTPProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .RuntimeSpec.HTTPSProxy }}
+            - name: NO_PROXY
+              value: {{ .RuntimeSpec.NoProxy }}
           volumeMounts:
             - name: run-mlnx-ofed
               mountPath: /run/mellanox/drivers

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -32,3 +32,9 @@ const (
 	NetworkOperatorResourceNamespace = "mlnx-network-operator-resources"
 	NicClusterPolicyResourceName     = "nic-cluster-policy"
 )
+
+const (
+	HTTPProxy  = "HttpProxy"
+	HTTPSProxy = "HttpsProxy"
+	NoProxy    = "NoProxy"
+)

--- a/pkg/state/state_nv_peer.go
+++ b/pkg/state/state_nv_peer.go
@@ -45,9 +45,12 @@ type stateNVPeer struct {
 
 type nvPeerRuntimeSpec struct {
 	runtimeSpec
-	CPUArch string
-	OSName  string
-	OSVer   string
+	CPUArch    string
+	OSName     string
+	OSVer      string
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
 }
 
 type nvPeerManifestRenderData struct {
@@ -138,6 +141,9 @@ func (s *stateNVPeer) getManifestObjects(
 			CPUArch:     attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
 			OSName:      attrs[0].Attributes[nodeinfo.AttrTypeOSName],
 			OSVer:       attrs[0].Attributes[nodeinfo.AttrTypeOSVer],
+			HTTPProxy:   utils.GetEnv(consts.HTTPProxy),
+			HTTPSProxy:  utils.GetEnv(consts.HTTPSProxy),
+			NoProxy:     utils.GetEnv(consts.NoProxy),
 		},
 	}
 	// render objects

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -59,9 +59,12 @@ type stateOFED struct {
 
 type ofedRuntimeSpec struct {
 	runtimeSpec
-	CPUArch string
-	OSName  string
-	OSVer   string
+	CPUArch    string
+	OSName     string
+	OSVer      string
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
 }
 
 type ofedManifestRenderData struct {
@@ -151,6 +154,9 @@ func (s *stateOFED) getManifestObjects(
 			CPUArch:     attrs[0].Attributes[nodeinfo.AttrTypeCPUArch],
 			OSName:      attrs[0].Attributes[nodeinfo.AttrTypeOSName],
 			OSVer:       attrs[0].Attributes[nodeinfo.AttrTypeOSVer],
+			HTTPProxy:   utils.GetEnv(consts.HTTPProxy),
+			HTTPSProxy:  utils.GetEnv(consts.HTTPSProxy),
+			NoProxy:     utils.GetEnv(consts.NoProxy),
 		},
 	}
 	// render objects

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -58,3 +58,8 @@ func GetFilesWithSuffix(baseDir string, suffixes ...string) ([]string, error) {
 func IsCRD(obj *unstructured.Unstructured) bool {
 	return obj.GetKind() == "CustomResourceDefinition"
 }
+
+// Getenv retrieves the value of the environment variable
+func GetEnv(name string) string {
+	return os.Getenv(name)
+}


### PR DESCRIPTION
Proxy settings will be provided to helm when the operator is installed. these should propagate to the operands created by the operator.

Fixes #23 