### PR TITLE
Support deploying SR-IOV network operator

### DIFF
--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -16,6 +16,10 @@ dependencies:
   name: node-feature-discovery
   repository: ""
   version: 0.1.0
+- condition: sriovNetworkOperator.enabled
+  name: sriov-network-operator
+  repository: ""
+  version: 0.1.0
 
 
 

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -17,6 +17,26 @@ RDMA and GPUDirect RDMA workloads in a kubernetes cluster including:
 * Kubernetes device plugins to provide hardware resources for fast network
 * Kubernetes secondary network for Network intensive workloads
 
+## Additional components
+
+### Node Feature Discovery
+Nvidia Network Operator relies on the existance of specific node labels to operate properly.
+e.g label a node as having Nvidia networking hardware available.
+This can be achieved by either manually labeling Kubernetes nodes or using
+[Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery) to perform the labeling.
+
+To allow zero touch deployment of the Operator we provide a helm chart to be used to
+optionally deploy Node Feature Discovery in the cluster. This is enabled via `nfd.enabled` chart parameter.
+
+### SR-IOV Network Operator
+Nvidia Network Operator can operate in unison with SR-IOV Network Operator
+to enable SR-IOV workloads in a Kubernetes cluster. We provide a helm chart to be used to optionally
+deploy [SR-IOV Network Operator](https://github.com/openshift/sriov-network-operator) in the cluster.
+This is enabled via `sriovNetworkOperator.enabled` chart parameter.
+
+For more information on how to configure SR-IOV in your Kubernetes cluster using SR-IOV Network Operator
+refer to the project's github.
+
 ## QuickStart
 
 ### System Requirements
@@ -70,6 +90,7 @@ We have introduced the following Chart parameters.
 | Name | Type | Default | description |
 | ---- | ---- | ------- | ----------- |
 | `nfd.enabled` | bool | `True` | deploy Node Feature Discovery |
+| `sriovNetworkOperator.enabled` | bool | `False` | deploy SR-IOV Network Operator |
 | `operator.repository` | string | `mellanox` | Network Operator image repository |
 | `operator.image` | string | `network-operator` | Network Operator image name |
 | `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used |

--- a/deployment/network-operator/charts/sriov-network-operator/.helmignore
+++ b/deployment/network-operator/charts/sriov-network-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: sriov-network-operator
+description: |
+  SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovibnetworks_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovibnetworks_crd.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sriovibnetworks.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovIBNetwork
+    listKind: SriovIBNetworkList
+    plural: sriovibnetworks
+    singular: sriovibnetwork
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovIBNetwork is the Schema for the sriovibnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovIBNetworkSpec defines the desired state of SriovIBNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
+                  supported: (infinibandGUID), e.g. ''{"infinibandGUID": true}'''
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovIBNetworkStatus defines the observed state of SriovIBNetwork
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovibnetworks_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovibnetworks_crd.yaml
@@ -1,3 +1,16 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
@@ -1,3 +1,16 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sriovnetworknodepolicies.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovNetworkNodePolicy
+    listKind: SriovNetworkNodePolicyList
+    plural: sriovnetworknodepolicies
+    singular: sriovnetworknodepolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodePolicy is the Schema for the sriovnetworknodepolicies
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
+            properties:
+              deviceType:
+                description: The driver type for configured VFs. Allowed value "netdevice",
+                  "vfio-pci". Defaults to netdevice.
+                enum:
+                - netdevice
+                - vfio-pci
+                type: string
+              isRdma:
+                description: RDMA mode. Defaults to false.
+                type: boolean
+              linkType:
+                description: NIC Link Type. Allowed value "eth", "ETH", "ib", and
+                  "IB".
+                enum:
+                - eth
+                - ETH
+                - ib
+                - IB
+                type: string
+              mtu:
+                description: MTU of VF
+                minimum: 1
+                type: integer
+              nicSelector:
+                description: NicSelector selects the NICs to be configured
+                properties:
+                  deviceID:
+                    description: The device hex code of SR-IoV device. Allowed value
+                      "158b", "1015", "1017".
+                    type: string
+                  pfNames:
+                    description: Name of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  rootDevices:
+                    description: PCI address of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  vendor:
+                    description: The vendor hex code of SR-IoV device. Allowed value
+                      "8086", "15b3".
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              numVfs:
+                description: Number of VFs for each PF
+                minimum: 0
+                type: integer
+              priority:
+                description: Priority of the policy, higher priority policies can
+                  override lower ones.
+                maximum: 99
+                minimum: 0
+                type: integer
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - nicSelector
+            - nodeSelector
+            - numVfs
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkNodePolicyStatus defines the observed state of
+              SriovNetworkNodePolicy
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
@@ -1,3 +1,16 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
@@ -1,0 +1,138 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sriovnetworknodestates.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovNetworkNodeState
+    listKind: SriovNetworkNodeStateList
+    plural: sriovnetworknodestates
+    singular: sriovnetworknodestate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodeStateSpec defines the desired state of SriovNetworkNodeState
+            properties:
+              dpConfigVersion:
+                type: string
+              interfaces:
+                items:
+                  properties:
+                    linkType:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    vfGroups:
+                      items:
+                        properties:
+                          deviceType:
+                            type: string
+                          policyName:
+                            type: string
+                          resourceName:
+                            type: string
+                          vfRange:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+            type: object
+          status:
+            description: SriovNetworkNodeStateStatus defines the observed state of
+              SriovNetworkNodeState
+            properties:
+              interfaces:
+                items:
+                  properties:
+                    Vfs:
+                      items:
+                        properties:
+                          Vlan:
+                            type: integer
+                          assigned:
+                            type: string
+                          deviceID:
+                            type: string
+                          driver:
+                            type: string
+                          mac:
+                            type: string
+                          mtu:
+                            type: integer
+                          name:
+                            type: string
+                          pciAddress:
+                            type: string
+                          vendor:
+                            type: string
+                          vfID:
+                            type: integer
+                        required:
+                        - pciAddress
+                        - vfID
+                        type: object
+                      type: array
+                    deviceID:
+                      type: string
+                    driver:
+                      type: string
+                    linkSpeed:
+                      type: string
+                    linkType:
+                      type: string
+                    mac:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    totalvfs:
+                      type: integer
+                    vendor:
+                      type: string
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+              lastSyncError:
+                type: string
+              syncStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks_crd.yaml
@@ -1,3 +1,16 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks_crd.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sriovnetworks.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovNetwork
+    listKind: SriovNetworkList
+    plural: sriovnetworks
+    singular: sriovnetwork
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetwork is the Schema for the sriovnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkSpec defines the desired state of SriovNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
+                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              maxTxRate:
+                description: Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting)
+                minimum: 0
+                type: integer
+              minTxRate:
+                description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting). min_tx_rate should be <= max_tx_rate.
+                minimum: 0
+                type: integer
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+              spoofChk:
+                description: VF spoof check, (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              trust:
+                description: VF trust mode (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              vlan:
+                description: VLAN ID to assign for the VF. Defaults to 0.
+                maximum: 4096
+                minimum: 0
+                type: integer
+              vlanQoS:
+                description: VLAN QoS ID to assign for the VF. Defaults to 0.
+                maximum: 7
+                minimum: 0
+                type: integer
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkStatus defines the observed state of SriovNetwork
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovoperatorconfigs_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovoperatorconfigs_crd.yaml
@@ -1,3 +1,16 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovoperatorconfigs_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovoperatorconfigs_crd.yaml
@@ -1,0 +1,72 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sriovoperatorconfigs.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovOperatorConfig
+    listKind: SriovOperatorConfigList
+    plural: sriovoperatorconfigs
+    singular: sriovoperatorconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovOperatorConfig is the Schema for the sriovoperatorconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovOperatorConfigSpec defines the desired state of SriovOperatorConfig
+            properties:
+              configDaemonNodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              enableInjector:
+                description: Flag to control whether the network resource injector
+                  webhook shall be deployed
+                type: boolean
+              enableOperatorWebhook:
+                description: Flag to control whether the operator admission controller
+                  webhook shall be deployed
+                type: boolean
+              logLevel:
+                description: Flag to control the log verbose level of the operator.
+                  Set to '0' to show only the basic logs. And set to '2' to show all
+                  the available logs.
+                maximum: 2
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig
+            properties:
+              injector:
+                description: Show the runtime status of the network resource injector
+                  webhook
+                type: string
+              operatorWebhook:
+                description: Show the runtime status of the operator admission controller
+                  webhook
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/NOTES.txt
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/NOTES.txt
@@ -1,0 +1,2 @@
+For additional instructions on how to use SR-IOV network operator,
+refer to: https://github.com/openshift/sriov-network-operator

--- a/deployment/network-operator/charts/sriov-network-operator/templates/_helpers.tpl
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sriov-network-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sriov-network-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sriov-network-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sriov-network-operator.labels" -}}
+helm.sh/chart: {{ include "sriov-network-operator.chart" . }}
+{{ include "sriov-network-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sriov-network-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sriov-network-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sriov-network-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sriov-network-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/_helpers.tpl
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/_helpers.tpl
@@ -1,4 +1,19 @@
 {{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "sriov-network-operator.name" -}}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sriov-network-operator.fullname" . }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: [namespaces, serviceaccounts]
+  verbs: ["*"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources: ["network-attachment-definitions"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: [clusterroles, clusterrolebindings]
+  verbs: ["*"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["*"]
+- apiGroups: ["sriovnetwork.openshift.io"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-network-config-daemon
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]

--- a/deployment/network-operator/charts/sriov-network-operator/templates/clusterrolebinding.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/clusterrolebinding.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/clusterrolebinding.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sriov-network-operator.fullname" . }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "sriov-network-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "sriov-network-operator.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sriov-network-config-daemon
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: sriov-network-config-daemon
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: sriov-network-config-daemon
+

--- a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,19 +52,19 @@ spec:
             - name: SRIOV_CNI_IMAGE
               value: {{ .Values.images.sriovCni }}
             - name: SRIOV_INFINIBAND_CNI_IMAGE
-              value: {{ .Values.images.ibSriovCni | quote }}
+              value: {{ .Values.images.ibSriovCni }}
             - name: SRIOV_DEVICE_PLUGIN_IMAGE
-              value: {{ .Values.images.sriovDevicePlugin | quote }}
+              value: {{ .Values.images.sriovDevicePlugin }}
             - name: NETWORK_RESOURCES_INJECTOR_IMAGE
               value: ""
             - name: OPERATOR_NAME
               value: sriov-network-operator
             - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-              value: {{ .Values.images.sriovConfigDaemon | quote }}
+              value: {{ .Values.images.sriovConfigDaemon }}
             - name: SRIOV_NETWORK_WEBHOOK_IMAGE
               value: ""
             - name: RESOURCE_PREFIX
-              value: openshift.io
+              value: nvidia.com
             - name: ENABLE_ADMISSION_CONTROLLER
               value: "false"
             - name: NAMESPACE

--- a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sriov-network-operator.fullname" . }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: sriov-network-operator
+  template:
+    metadata:
+      labels:
+        name: sriov-network-operator
+    spec:
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sriov-network-operator.fullname" . }}
+      containers:
+        - name: sriov-network-operator
+          image: {{ .Values.images.operator }}
+          command:
+          - sriov-network-operator
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SRIOV_CNI_IMAGE
+              value: {{ .Values.images.sriovCni }}
+            - name: SRIOV_INFINIBAND_CNI_IMAGE
+              value: {{ .Values.images.ibSriovCni | quote }}
+            - name: SRIOV_DEVICE_PLUGIN_IMAGE
+              value: {{ .Values.images.sriovDevicePlugin | quote }}
+            - name: NETWORK_RESOURCES_INJECTOR_IMAGE
+              value: ""
+            - name: OPERATOR_NAME
+              value: sriov-network-operator
+            - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
+              value: {{ .Values.images.sriovConfigDaemon | quote }}
+            - name: SRIOV_NETWORK_WEBHOOK_IMAGE
+              value: ""
+            - name: RESOURCE_PREFIX
+              value: openshift.io
+            - name: ENABLE_ADMISSION_CONTROLLER
+              value: "false"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RELEASE_VERSION
+              value: {{ .Release.AppVersion }}
+            - name: SRIOV_CNI_BIN_PATH
+              value: /opt/cni/bin
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
@@ -1,0 +1,89 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ include "sriov-network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - sriov-network-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - serviceaccounts
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - '*'
+- apiGroups:
+  - sriovnetwork.openshift.io
+  resources:
+  - '*'
+  - sriovnetworknodestates
+  verbs:
+  - '*'
+- apiGroups:
+    - security.openshift.io
+  resourceNames:
+    - privileged
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - use

--- a/deployment/network-operator/charts/sriov-network-operator/templates/role_binding.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/role_binding.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/role_binding.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/role_binding.yaml
@@ -1,0 +1,31 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "sriov-network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "sriov-network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "sriov-network-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: sriov-network-config-daemon
+  apiGroup: rbac.authorization.k8s.io

--- a/deployment/network-operator/charts/sriov-network-operator/templates/service_account.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/service_account.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/service_account.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/service_account.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sriov-network-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovnetworknodepolicy_cr.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovnetworknodepolicy_cr.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovnetworknodepolicy_cr.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovnetworknodepolicy_cr.yaml
@@ -1,0 +1,12 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: default
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+spec:
+  priority: 99
+  numVfs: 0
+  resourceName: ""
+  nicSelector: {}
+  nodeSelector: {}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovoperatorconfig_cr.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovoperatorconfig_cr.yaml
@@ -1,3 +1,18 @@
+{{/*
+  Copyright 2020 NVIDIA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovOperatorConfig
 metadata:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovoperatorconfig_cr.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetwork.openshift.io_v1_sriovoperatorconfig_cr.yaml
@@ -1,0 +1,11 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  labels:
+    {{- include "sriov-network-operator.labels" . | nindent 4 }}
+spec:
+  # Add fields here
+  enableInjector: false
+  enableOperatorWebhook: false
+  configDaemonNodeSelector: {}

--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Default values for sriov-network-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -28,8 +42,9 @@ resources: {}
 
 # Image URIs for sriov-network-operator components
 images:
-  operator: adriancdockerhub/sriov-network-operator:latest
-  sriovConfigDaemon: adriancdockerhub/sriov-network-config-daemon:latest
+  operator: quay.io/openshift/origin-sriov-network-operator:4.8
+  sriovConfigDaemon: quay.io/openshift/origin-sriov-network-config-daemon:4.8
   sriovCni: nfvpe/sriov-cni:v2.5
   ibSriovCni: mellanox/ib-sriov-cni:v1.0.0
-  sriovDevicePlugin: nfvpe/sriov-device-plugin:v3.2
+  # Upstream image nfvpe/sriov-device-plugin:v3.2 failing
+  sriovDevicePlugin: quay.io/openshift/origin-sriov-network-device-plugin:4.8

--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -1,0 +1,35 @@
+# Default values for sriov-network-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+operator:
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Equal"
+      value: ""
+      effect: "NoSchedule"
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  nameOverride: ""
+  fullnameOverride: ""
+  # tag, if defined will use the given image tag, else Chart.AppVersion will be used
+  # tag
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Image URIs for sriov-network-operator components
+images:
+  operator: adriancdockerhub/sriov-network-operator:latest
+  sriovConfigDaemon: adriancdockerhub/sriov-network-config-daemon:latest
+  sriovCni: nfvpe/sriov-cni:v2.5
+  ibSriovCni: mellanox/ib-sriov-cni:v1.0.0
+  sriovDevicePlugin: nfvpe/sriov-device-plugin:v3.2

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -19,6 +19,9 @@
 nfd:
   enabled: true
 
+sriovNetworkOperator:
+  enabled: false
+
 # Node Feature discovery chart related values
 node-feature-discovery:
   worker:


### PR DESCRIPTION
This commit adds Helm chart to sriov-network-operator.

- Add this chart as an optional dependency to the main
  network-operator chart
- Add the needed chart files/crds/templates
- update README