### PR TITLE
Update state OFED with new container image name format

### DIFF
--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -15,13 +15,13 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
-  name: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-ds
+    app: ofed-driver-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+  name: ofed-driver-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-ds
   namespace: {{ .RuntimeSpec.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+      app: ofed-driver-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
   template:
     metadata:
       # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
@@ -30,7 +30,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        app: ofed-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+        app: ofed-driver-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
     spec:
       tolerations:
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
@@ -45,7 +45,7 @@ spec:
           effect: NoSchedule
       hostNetwork: true
       containers:
-        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+              - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.CPUArch }}
           imagePullPolicy: IfNotPresent
           name: ofed-driver-container
           securityContext:


### PR DESCRIPTION
Latest official MOFED driver containers have changed
image fromat to:
mofed-<Branch Name>:<Version>-<OS Name><OS Version>-<CPU Arch>

e.g mofed-5.1-2:5.1-2.5.1.1-ubuntu18.04-x86_64

modify template and state ofed code to fit the new format.
- ofed-driver daemonset template
  - Modify container image name
  - Remove CPU arch from daemonset name and templates as it
    is not required and kubernetes forbits _ in object names.
- state ofed driver: translate golang amd64 CPU Arch to x86_64

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>