### PR TITLE
Remove default node selector from template

### DIFF
--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -34,6 +34,10 @@ spec:
       nodeSelector:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.affinity}}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.operator.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -49,8 +49,16 @@ operator:
       operator: "Equal"
       value: ""
       effect: "NoSchedule"
-  nodeSelector:
-    node-role.kubernetes.io/master: ""
+  nodeSelector: {}
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [""]
   repository: mellanox
   image: network-operator
   nameOverride: ""


### PR DESCRIPTION
This commit removes the default node selector
to schedule the operator on the master node.

instead a preffered node affinity is introduced
allowing the human operator(or otherwise) to deploy
it on other nodes in the cluster if desired.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>