### PR TITLE
Make whereabouts daemonset use hostNetwork

### DIFF
--- a/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -32,6 +32,7 @@ spec:
         app: whereabouts
         name: whereabouts
     spec:
+      hostNetwork: true
       serviceAccountName: whereabouts
       nodeSelector:
         beta.kubernetes.io/arch: amd64


### PR DESCRIPTION
hereabouts is IPAM plugin which should not depend on another cni to be deployed or deleted