### PR TITLE
Mount /dev/inside rdma shared device plugin

### DIFF
--- a/manifests/stage-rdma-device-plugin/0020-k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/stage-rdma-device-plugin/0020-k8s-rdma-shared-dev-plugin-ds.yaml
@@ -53,6 +53,8 @@ spec:
             mountPath: /var/lib/kubelet/
           - name: config
             mountPath: /k8s-rdma-shared-dev-plugin
+          - name: devs
+            mountPath: /dev/
       volumes:
         - name: device-plugin
           hostPath:
@@ -63,5 +65,8 @@ spec:
             items:
             - key: config.json
               path: config.json
+        - name: devs
+          hostPath:
+            path: /dev/
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"


### PR DESCRIPTION
Currently rdma resources "/dev/infiniband" are mounted by using hostNetwork, where rdma resources will not be tracked when kernel modules/drivers are installed after deploying rdma shared device plugin.

This patch mounts "/dev/infiniband" inside the container with volumes which keeps tracking the changes to "/dev/infiniband"

Fixes #31 