### PR TITLE
Remove multus generate config file when undeploy multus

### DIFF
--- a/manifests/stage-multus-cni/0050-multus-ds.yml
+++ b/manifests/stage-multus-cni/0050-multus-ds.yml
@@ -35,7 +35,15 @@ spec:
           command: ["/entrypoint.sh"]
           args:
             - "--cni-version=0.4.0"
+            # /tmp/multus-conf/00-multus.conf is where multus-cfg ConfigMap is mounted then entrypoint.sh copy it to
+            # /host/etc/cni/net.d/00-multus.conf
             - "--multus-conf-file={{- if .CrSpec.Config -}}/tmp/multus-conf/00-multus.conf{{- else -}}auto{{- end -}}"
+          # Remove multus config file to prevent failing of creating/deleting pods since multus will fail due to
+          # permission issue, https://github.com/intel/multus-cni/issues/592
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -f /host/etc/cni/net.d/00-multus.conf"]
           resources:
             requests:
               cpu: "100m"


### PR DESCRIPTION
When deploying Multus secondary network, it generates config file
00-multus.conf which will be CNI config file, when Multus has
removed the config file and bin file will stay which leading to
use Multus even if the secondary network was deleted.

When Muluts is deleted also the permission will be deleted, thus
lead to failure in creating/removing any pod that uses CNI
including removing the network operator itself.

This commit fixes the issue deleting the config file generated by
multus

Fixes #74 