### PR TITLE
Change default Multus CNI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ spec:
     multus:
       image: multus
       repository: nfvpe
-      version: v3.6
+      version: v3.4.1
       # if config is missing or empty then multus config will be automatically generated from the CNI configuration file of the master plugin (the first file in lexicographical order in cni-conf-dir)
       config: ''
     ipamPlugin:

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -183,7 +183,7 @@ Specifies components to deploy in order to facilitate a secondary network in Kub
 | `multus.deploy` | bool | `true` | Deploy Multus Secondary Network  |
 | `multus.image` | string | `multus` | Multus image name  |
 | `multus.repository` | string | `nfvpe` | Multus image repository  |
-| `multus.version` | string | `v3.6` | Multus image version  |
+| `multus.version` | string | `v3.4.1` | Multus image version  |
 | `multus.config` | string | `` | Multus CNI config, if empty then config will be automatically generated from the CNI configuration file of the master plugin (the first file in lexicographical order in cni-conf-dir)  |
 
 ##### IPAM CNI Plugin Secondary Network

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -110,7 +110,7 @@ secondaryNetwork:
     deploy: true
     image: multus
     repository: nfvpe
-    version: v3.6
+    version: v3.4.1
     config: ""
   ipamPlugin:
     deploy: true

--- a/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/deploy/crds/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -46,7 +46,7 @@ spec:
     multus:
       image: multus
       repository: nfvpe
-      version: v3.6
+      version: v3.4.1
       config: ''
     ipamPlugin:
       image: whereabouts


### PR DESCRIPTION
Due to Issue: https://github.com/intel/multus-cni/issues/592
When multus is removed from the cluster it is left in an inoperable
as CNI calls fail due to removed RBAC.

While it makes sense to occur for secondary network when specified
in a pod spec as net-attach-def name, it should not fail on primary
network.

Downgrade multus CNI to v3.4.1 where such an issue does not occur.