### PR TITLE
Add 'eSwitchMode' flag support

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
@@ -52,6 +52,12 @@ spec:
                 - netdevice
                 - vfio-pci
                 type: string
+              eSwitchMode:
+                description: NIC Device Mode. Allowed value "legacy","switchdev".
+                enum:
+                - legacy
+                - switchdev
+                type: string
               isRdma:
                 description: RDMA mode. Defaults to false.
                 type: boolean


### PR DESCRIPTION
NIC Device Mode cpould be set to  "legacy" or "switchdev" during
sriov-network-operator configuration.

Fixes: Issue #89 