### PR TITLE
Add an optional SriovNetwork section: additional metaplugins

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks_crd.yaml
@@ -63,6 +63,10 @@ spec:
                   rate limiting)
                 minimum: 0
                 type: integer
+              metaPlugins:
+                description: MetaPluginsConfig configuration to be used in order to
+                  chain metaplugins to the sriov interface returned by the operator.
+                type: string
               minTxRate:
                 description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
                   rate limiting). min_tx_rate should be <= max_tx_rate.


### PR DESCRIPTION
In order to generate a network attachment definition that chains the SR-IOV
CNI configuration with additional metaplugins (such as VRF, or firewall), we
expose a new MetaPluginsConfig where to put the json list of the extra configurations,
in the form of

{
	// meta plugin A config
},
{
	// meta plugin B config
}

metaPlugins param was introduces in sriov-network-operator in this
commit:
https://github.com/openshift/sriov-network-operator/commit/6a279015ed448cb61fa99f74f72dc837ae95df5e

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>