### PR TITLE
Add helm chart tests

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -100,6 +100,23 @@ $ helm install --devel --set nfd.enabled=false -n network-operator --create-name
 custom resources. The user is required to create it later with configuration matching the cluster or use
 chart parameters to deploy it together with the operator.
 
+## Helm Tests
+
+Network Operator has Helm tests to verify deployment. To run tests it is required to set the following chart parameters on helm install/upgrade: `deployCR`, `devicePlugin`, `secondaryNetwork` as the test depends on `NicClusterPolicy` instance being deployed by Helm.
+Supported Tests:
+- Device Plugin Resource: This test creates a pod that requests the first resource in `devicePlugin.resources`
+- RDMA Traffic: This test creates a pod that test loopback RDMA traffic with `rping`
+
+Run the helm test with following command after deploying network operator with helm
+```
+$ helm test -n network-operator network-operator --timeout=5m
+```
+Notes:
+- Test will keeping running endlessly if pod creating failed so it is recommended to use `--timeout` which fails test after exceeding given timeout
+- Default PF to run test is `ens2f0` to override it add `--set test.pf=<pf_name>` to `helm install/upgrade`
+- Tests should be executed after `NicClusterPolicy` custom resource state is `Ready`
+- In case of a test failed it is possible to collect the logs with `kubectl logs -n <namespace> <test-pod-name>`
+
 ## Chart parameters
 
 In order to tailor the deployment of the network operator to your cluster needs

--- a/deployment/network-operator/templates/tests/test-dev-plugin.yaml
+++ b/deployment/network-operator/templates/tests/test-dev-plugin.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.deployCR .Values.devicePlugin.deploy  }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-dev-plugin-test"
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - image: mellanox/rping-test
+      name: "{{ .Release.Name }}-dev-plugin-test"
+      securityContext:
+        capabilities:
+          add: [ "IPC_LOCK" ]
+      resources:
+        requests:
+          rdma/{{ (index .Values.devicePlugin.resources 0).name }}: '1'
+        limits:
+          rdma/{{ (index .Values.devicePlugin.resources 0).name }}: '1'
+      command:
+        - sh
+        - -c
+        - |
+          ls -l /dev/infiniband /sys/class/net /sys/class/infiniband
+          if [[ "$(ls /dev/infiniband/ | wc -l)" -lt 4 ]]; then echo "Not all RDMA resouces mounted" >&2; exit 1; fi
+{{- end }}

--- a/deployment/network-operator/templates/tests/test-rping.yaml
+++ b/deployment/network-operator/templates/tests/test-rping.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.deployCR .Values.devicePlugin.deploy .Values.secondaryNetwork.deploy .Values.secondaryNetwork.multus.deploy .Values.secondaryNetwork.cniPlugins.deploy }}
+apiVersion: mellanox.com/v1alpha1
+kind: MacvlanNetwork
+metadata:
+  name: "{{ .Release.Name }}-rping-macvlan-network-test"
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+spec:
+  networkNamespace: "{{ .Release.Namespace }}"
+  mode: "bridge"
+  master: "{{ .Values.test.pf }}"
+  mtu: 1500
+  ipam: |
+    {
+      "type": "static",
+      "addresses": [{ "address": "10.10.0.1/24" }]
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-rping-test"
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    k8s.v1.cni.cncf.io/networks: "{{ .Release.Name }}-rping-macvlan-network-test"
+spec:
+  restartPolicy: Never
+  containers:
+    - image: mellanox/rping-test
+      name: "{{ .Release.Name }}-rping-test"
+      securityContext:
+        capabilities:
+          add: [ "IPC_LOCK" ]
+      resources:
+        requests:
+          rdma/{{ (index .Values.devicePlugin.resources 0).name }}: '1'
+        limits:
+          rdma/{{ (index .Values.devicePlugin.resources 0).name }}: '1'
+      command:
+        - sh
+        - -c
+        - |
+          ls -l /dev/infiniband /sys/class/net /sys/class/infiniband
+          ip addr show net1
+          rping -svd &
+          rping -cvd -a 10.10.0.1 -C 1
+{{- end }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -120,3 +120,6 @@ secondaryNetwork:
     image: whereabouts
     repository: dougbtv
     version: v0.3
+
+test:
+  pf: ens2f0


### PR DESCRIPTION
This PR bring 2 helm chart tests for network operator that tests device plugin resources and rping for deployment