### PR TITLE
Add status printer column for custom resources

### DIFF
--- a/api/v1alpha1/macvlannetwork_types.go
+++ b/api/v1alpha1/macvlannetwork_types.go
@@ -55,6 +55,7 @@ type MacvlanNetworkStatus struct {
 // kubebuilder:object:generate
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.state`,priority=0
 
 // MacvlanNetwork is the Schema for the macvlannetworks API
 type MacvlanNetwork struct {

--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -123,6 +123,7 @@ type NicClusterPolicyStatus struct {
 // kubebuilder:object:generate
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.state`,priority=0
 
 // NicClusterPolicy is the Schema for the nicclusterpolicies API
 type NicClusterPolicy struct {

--- a/config/crd/bases/mellanox.com_macvlannetworks.yaml
+++ b/config/crd/bases/mellanox.com_macvlannetworks.yaml
@@ -16,7 +16,11 @@ spec:
     singular: macvlannetwork
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MacvlanNetwork is the Schema for the macvlannetworks API

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -16,7 +16,11 @@ spec:
     singular: nicclusterpolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NicClusterPolicy is the Schema for the nicclusterpolicies API


### PR DESCRIPTION
This commit adds a `status` printer column which
reflects the global state of `NicClusterPolicy` and `MacvlanNetwork` CR instance.

Example:
```
$> kubectl get nicclusterpolicy
NAME                 STATUS
nic-cluster-policy   ready
```