### PR TITLE
helm deployment fail when setting multus config

### DIFF
--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -74,7 +74,7 @@ spec:
       repository: {{ .Values.secondaryNetwork.multus.repository }}
       version: {{ .Values.secondaryNetwork.multus.version }}
       {{- if .Values.secondaryNetwork.multus.config | empty | not }}
-      config: {{ .Values.secondaryNetwork.multus.config }}
+      config: {{ .Values.secondaryNetwork.multus.config | quote }}
       {{- end }}
     {{- end }}
     {{- if .Values.secondaryNetwork.ipamPlugin.deploy }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -114,7 +114,7 @@ secondaryNetwork:
     image: multus
     repository: nfvpe
     version: v3.6
-    config: ""
+    config: ''
   ipamPlugin:
     deploy: true
     image: whereabouts


### PR DESCRIPTION
Multus config 'secondaryNetwork.multus.config' is a string of json format, Helm has a behaviour of transforming string of json format json object instead of keeping it a string

This PR enforces string by using 'quote' helm rendering function

fixes #100 