### PR TITLE
Helm deployment fail when set deployCR and all NicClusterPolicy components are unset

### DIFF
--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */}}
-{{- if .Values.deployCR }}
+  {{- if and (or .Values.ofedDriver.deploy .Values.nvPeerDriver.deploy .Values.devicePlugin.deploy (and .Values.secondaryNetwork.deploy (or .Values.secondaryNetwork.cniPlugins.deploy .Values.secondaryNetwork.multus.deploy .Values.secondaryNetwork.ipamPlugin.deploy))) .Values.deployCR }}
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:


### PR DESCRIPTION
When set deployCR helm will render the NicClusterPolicy, when all components are unset the NicClusterPolicy spec will be empty which fails the deployment.

This PR make helm ensure that there is at least one component is required to deploy NicClusterPolicy

fixes #99 