### PR TITLE
Update sriov-network-operator crd and images

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
@@ -50,6 +50,8 @@ spec:
               interfaces:
                 items:
                   properties:
+                    eSwitchMode:
+                      type: string
                     linkType:
                       type: string
                     mtu:
@@ -116,6 +118,8 @@ spec:
                     deviceID:
                       type: string
                     driver:
+                      type: string
+                    eSwitchMode:
                       type: string
                     linkSpeed:
                       type: string

--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -42,8 +42,8 @@ resources: {}
 
 # Image URIs for sriov-network-operator components
 images:
-  operator: quay.io/openshift/origin-sriov-network-operator:4.8
-  sriovConfigDaemon: quay.io/openshift/origin-sriov-network-config-daemon:4.8
+  operator: mellanox/sriov-operator:4.8
+  sriovConfigDaemon: mellanox/sriov-operator-daemon:4.8
   sriovCni: nfvpe/sriov-cni:v2.5
   ibSriovCni: mellanox/ib-sriov-cni:v1.0.0
   # Upstream image nfvpe/sriov-device-plugin:v3.2 failing


### PR DESCRIPTION
Update sriov-network-operator crd to support switchdev and update operator and daemon images to be from harbor.mellanox