### PR TITLE
Update node-feature-discovery deployment

### DIFF
--- a/deployment/network-operator/charts/node-feature-discovery/Chart.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: master
+appVersion: v0.6.0-233-g3e00bfb
 description: |
   Detects hardware features available on each node in a Kubernetes cluster, and advertises
   those features using node labels.

--- a/deployment/network-operator/charts/node-feature-discovery/Chart.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,8 +1,15 @@
 apiVersion: v2
-appVersion: v0.6.0
+appVersion: master
 description: |
   Detects hardware features available on each node in a Kubernetes cluster, and advertises
   those features using node labels.
 name: node-feature-discovery
+sources:
+ - https://github.com/kubernetes-sigs/node-feature-discovery
+home: https://github.com/kubernetes-sigs/node-feature-discovery
+keywords:
+  - feature-discovery
+  - feature-detection
+  - node-labels
 type: application
 version: 0.1.0

--- a/deployment/network-operator/charts/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/clusterrole.yaml
@@ -15,7 +15,7 @@
 */}}
 
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}
@@ -26,8 +26,12 @@ rules:
   - ""
   resources:
   - nodes
+  # when using command line flag --resource-labels to create extended resources
+  # you will need to uncomment "- nodes/status"
+  # - nodes/status
   verbs:
   - get
   - patch
   - update
+  - list
 {{- end }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@
 */}}
 
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/master.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/master.yaml
@@ -61,9 +61,9 @@ spec:
           resources:
             {{- toYaml .Values.master.resources | nindent 12 }}
           args:
-            { { - if .Values.master.instance | empty | not } }
+            {{- if .Values.master.instance | empty | not }}
             - "--instance={{ .Values.master.instance }}"
-            { { - end } }
+            {{- end }}
 ## Enable TLS authentication
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored

--- a/deployment/network-operator/charts/node-feature-discovery/templates/master.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/master.yaml
@@ -46,7 +46,7 @@ spec:
         - name: master
           securityContext:
             {{- toYaml .Values.master.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: 8080
@@ -58,9 +58,12 @@ spec:
                 fieldPath: spec.nodeName
           command:
             - "nfd-master"
-          
           resources:
             {{- toYaml .Values.master.resources | nindent 12 }}
+          args:
+            { { - if .Values.master.instance | empty | not } }
+            - "--instance={{ .Values.master.instance }}"
+            { { - end } }
 ## Enable TLS authentication
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
@@ -68,7 +71,6 @@ spec:
 ## Additional hardening can be enabled by specifying --verify-node-name in
 ## args, in which case every nfd-worker requires a individual node-specific
 ## TLS certificate.
-#          args:
 #            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
 #            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
 #            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"

--- a/deployment/network-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -1,5 +1,5 @@
 {{/*
-   Copyright 2020 NVIDIA
+   Copyright 2021 NVIDIA
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/deployment/network-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -1,0 +1,25 @@
+{{/*
+   Copyright 2020 NVIDIA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.worker.configmapName }}
+  labels:
+  {{- include "node-feature-discovery.labels" . | nindent 4 }}
+data:
+  nfd-worker.conf: |
+  {{ .Values.worker.config | indent 4 }}

--- a/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
@@ -59,6 +59,9 @@ spec:
         args:
         - "--sleep-interval=60s"
         - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
+        {{- with .Values.worker.options }}
+        - --options={{- toJson . }}
+        {{- end }}
 ## Enable TLS authentication (1/3)
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored

--- a/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/worker.yaml
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,30 +39,26 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "node-feature-discovery.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
       containers:
       - name: worker
         securityContext:
           {{- toYaml .Values.worker.securityContext | nindent 12 }}
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        resources:
+        {{- toYaml .Values.worker.resources | nindent 12 }}
         command:
         - "nfd-worker"
-        resources:
-          {{- toYaml .Values.worker.resources | nindent 12 }}
         args:
         - "--sleep-interval=60s"
         - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
-        {{- with .Values.worker.options }}
-        - --options={{- toJson . }}
-        {{- end }}
 ## Enable TLS authentication (1/3)
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
@@ -79,10 +75,16 @@ spec:
           readOnly: true
         - name: host-sys
           mountPath: "/host-sys"
+          readOnly: true
         - name: source-d
           mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+          readOnly: true
         - name: features-d
           mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+          readOnly: true
+        - name: nfd-worker-conf
+          mountPath: "/etc/kubernetes/node-feature-discovery"
+          readOnly: true
 ## Enable TLS authentication (2/3)
 #        - name: nfd-ca-cert
 #          mountPath: "/etc/kubernetes/node-feature-discovery/trust"
@@ -106,6 +108,12 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
+        - name: nfd-worker-conf
+          configMap:
+            name: {{ .Values.worker.configmapName }}
+            items:
+              - key: nfd-worker.conf
+                path: nfd-worker.conf
 ## Enable TLS authentication (3/3)
 #        - name: nfd-ca-cert
 #          configMap:

--- a/deployment/network-operator/charts/node-feature-discovery/values.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/values.yaml
@@ -17,8 +17,11 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: quay.io/kubernetes_incubator/node-feature-discovery
-  pullPolicy: IfNotPresent
+  repository: gcr.io/k8s-staging-nfd/node-feature-discovery
+  # This should be set to 'IfNotPresent' for released version
+  pullPolicy: Always
+  # tag, if defined will use the given image tag, else Chart.AppVersion will be used
+  # tag
 imagePullSecrets: []
   
 serviceAccount:
@@ -34,17 +37,18 @@ nameOverride: ""
 fullnameOverride: ""
 
 master:
+  instance:
   replicaCount: 1
 
   podSecurityContext: {}
     # fsGroup: 2000
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ "ALL" ]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
     # runAsUser: 1000
 
   service:
@@ -84,17 +88,109 @@ master:
                 values: [""]
 
 worker:
-  options: {}
+  configmapName: nfd-worker-conf
+  config: |### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
+    #core:
+    #  labelWhiteList:
+    #  noPublish: false
+    #  sleepInterval: 60s
+    #  sources: [all]
+    #sources:
+    #  cpu:
+    #    cpuid:
+    ##     NOTE: whitelist has priority over blacklist
+    #      attributeBlacklist:
+    #        - "BMI1"
+    #        - "BMI2"
+    #        - "CLMUL"
+    #        - "CMOV"
+    #        - "CX16"
+    #        - "ERMS"
+    #        - "F16C"
+    #        - "HTT"
+    #        - "LZCNT"
+    #        - "MMX"
+    #        - "MMXEXT"
+    #        - "NX"
+    #        - "POPCNT"
+    #        - "RDRAND"
+    #        - "RDSEED"
+    #        - "RDTSCP"
+    #        - "SGX"
+    #        - "SSE"
+    #        - "SSE2"
+    #        - "SSE3"
+    #        - "SSE4.1"
+    #        - "SSE4.2"
+    #        - "SSSE3"
+    #      attributeWhitelist:
+    #  kernel:
+    #    kconfigFile: "/path/to/kconfig"
+    #    configOpts:
+    #      - "NO_HZ"
+    #      - "X86"
+    #      - "DMI"
+    #  pci:
+    #    deviceClassWhitelist:
+    #      - "0200"
+    #      - "03"
+    #      - "12"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #      - "subsystem_vendor"
+    #      - "subsystem_device"
+    #  usb:
+    #    deviceClassWhitelist:
+    #      - "0e"
+    #      - "ef"
+    #      - "fe"
+    #      - "ff"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #  custom:
+    #    - name: "my.kernel.feature"
+    #      matchOn:
+    #        - loadedKMod: ["example_kmod1", "example_kmod2"]
+    #    - name: "my.pci.feature"
+    #      matchOn:
+    #        - pciId:
+    #            class: ["0200"]
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #        - pciId :
+    #            vendor: ["8086"]
+    #            device: ["1000", "1100"]
+    #    - name: "my.usb.feature"
+    #      matchOn:
+    #        - usbId:
+    #          class: ["ff"]
+    #          vendor: ["03e7"]
+    #          device: ["2485"]
+    #        - usbId:
+    #          class: ["fe"]
+    #          vendor: ["1a6e"]
+    #          device: ["089a"]
+    #    - name: "my.combined.feature"
+    #      matchOn:
+    #        - pciId:
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
 
   podSecurityContext: {}
     # fsGroup: 2000
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ "ALL" ]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
     # runAsUser: 1000
 
   resources: {}
@@ -111,39 +207,16 @@ worker:
 
   nodeSelector: {}
 
-  tolerations:
-  - key: "node-role.kubernetes.io/master"
-    operator: "Equal"
-    value: ""
-    effect: "NoSchedule"
+  tolerations: {}
 
   annotations: {}
-
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-              - key: "node-role.kubernetes.io/master"
-                operator: In
-                values: [""]
 
 ## RBAC parameteres
 ## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##
 rbac:
   create: true
-  ## Service Account for pods
-  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ##
-  serviceAccountName: default
+  serviceAccountName:
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}
-  ## RBAC API version
-  ##
-  apiVersion: v1
-  ## Podsecuritypolicy
-  ##
-  pspEnabled: false

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -24,6 +24,10 @@ sriovNetworkOperator:
 
 # Node Feature discovery chart related values
 node-feature-discovery:
+  image:
+    pullPolicy: IfNotPresent
+  master:
+    instance: "nvidia.networking"
   worker:
     tolerations:
       - key: "node-role.kubernetes.io/master"
@@ -34,15 +38,16 @@ node-feature-discovery:
         operator: "Equal"
         value: "present"
         effect: "NoSchedule"
-    options:
+    config: |
       sources:
-        pci:
-          deviceClassWhitelist:
-            - "02"
-            - "0200"
-            - "0207"
-          deviceLabelFields:
-            - vendor
+          pci:
+            deviceClassWhitelist:
+              - "02"
+              - "0200"
+              - "0207"
+            deviceLabelFields:
+              - vendor
+
 
 # General Operator related values
 # The operator element allows to deploy network operator from an alternate location


### PR DESCRIPTION
1. Use helm chart updated from NFD repo
2. network-operator specifies the latest build of the NFD
3. nfd-master '--instance' option is set to 'nvidia.networking' be default
