### PR TITLE
Add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug encountered while using Network Operator
+labels: bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible.
+-->
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Logs**:
+- NicClusterPolicy CR spec and state:
+- Output of: `kubectl -n mlnx-network-operator-resources get -A`:
+- Logs of Network Operator controller:
+- Logs of the various Pods in `mlnx-network-operator-resources` namespace:
+- Helm Configuration (if applicable):
+
+**Environment**:
+- Kubernetes version (use `kubectl version`): 
+- Hardware configuration:
+  - Network adapter model and firmware version:
+- OS (e.g: `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to Network Operator
+labels: enhancement
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -1,0 +1,55 @@
+---
+name: New Release
+about: Propose a new release
+title: Release vx.y.z
+
+---
+
+## Release Checklist
+<!--
+Please do not remove items from the checklist
+-->
+- [ ] Network-operator related component versions in Helm chart are up to date. (otherwise, submit PR to update)
+  - [ ] node-feature-discovery
+  - [ ] SR-IOV Network Operator
+  - [ ] Manifest related component default versions
+- [ ] Example folder is up to date (otherwise submit PR to update)
+- [ ] Update network-operator Helm `Chart.yaml` with the release version (`appVersion`, `version` fields)
+  - [ ] Ensure Helm CI is passing on updated Chart.
+- [ ] Tag release
+- [ ] Create a new github release
+  - [ ] Release title: vx.y.z, Release description: Changelog from this issue
+  - [ ] Release artifacts for current release
+- [ ] Update gh-pages branch
+  - [ ] Create Helm package (master branch on release tag commit):
+    ```
+        > helm package deployments/network-operator
+    ```
+  - [ ] Place Helm package under gh-pages branch in `release` dir
+  - [ ] Update `index.yaml` file under gh-pages branch in `release` dir:
+    ```
+        > helm repo index . --url https://mellanox.github.io/network-operator/release
+    ```
+  - [ ] Update gh-pages branch README.md with `deployment/README.md` from master branch (on release tag commit)
+  - [ ] Submit PR against `gh-pages` branch:
+    ```
+        > git add <helm .tgz package> <release/index.yaml> <README.md>
+        > git commit --signoff -m "Release Network-Operator vx.y.z"
+        > git push ...
+    ```
+- [ ] Add a link to the release in this issue
+- [ ] Close this issue
+
+## Changelog
+### New Features
+<!--
+Describe new features introduced in this release here.
+-->
+### Bug Fixes
+<!--
+Describe bugfixes introduced in this release here.
+-->
+### Known Limitations
+<!--
+Describe notable known limitations with network-operator (if any) here.
+-->


### PR DESCRIPTION
This commit adds templates for possible issues
that can be opened against Network Operator project

- Bug report template: To be used when reporting
  a possible bug in network-operator
- Enhancement template: To be used when requesting
  an enhancement/feature of network operator
- Release template: To be used when creating a new release
  of network-operator. This includes a checklist of actions
  that should be done in order to release a new version
  of network-operator

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>