### PR TITLE
Modify network-operator namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/Mellanox/network-operator)](https://goreportcard.com/report/github.com/Mellanox/network-operator)
 [![Build Status](https://travis-ci.com/Mellanox/network-operator.svg?branch=master)](https://travis-ci.com/Mellanox/network-operator)
 
-- [Nvidia Mellanox Network Operator](#nvidia-mellanox-network-operator)
+- [Nvidia Network Operator](#nvidia-network-operator)
   * [Prerequisites](#prerequisites)
     + [Kubernetes Node Feature Discovery (NFD)](#kubernetes-node-feature-discovery--nfd-)
   * [Resource Definitions](#resource-definitions)
@@ -20,8 +20,8 @@
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
-# Nvidia Mellanox Network Operator
-Nvidia Mellanox Network Operator leverages [Kubernetes CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+# Nvidia Network Operator
+Nvidia Network Operator leverages [Kubernetes CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 and [Operator SDK](https://github.com/operator-framework/operator-sdk) to manage Networking related Components in order to enable Fast networking,
 RDMA and GPUDirect for workloads in a Kubernetes cluster.
 
@@ -33,7 +33,7 @@ RDMA and GPUDirect RDMA workloads in a kubernetes cluster including:
 
 ## Prerequisites
 ### Kubernetes Node Feature Discovery (NFD)
-Mellanox Network operator relies on Node labeling to get the cluster to the desired state.
+Nvidia Network operator relies on Node labeling to get the cluster to the desired state.
 [Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery) `v0.6.0-233-g3e00bfb` or newer is expected to be deployed to provide the appropriate labeling:
 
 - PCI vendor and device information
@@ -89,7 +89,7 @@ apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
   name: nic-cluster-policy
-  namespace: mlnx-network-operator
+  namespace: nvidia-network-operator
 spec:
   ofedDriver:
     image: mofed

--- a/deploy/operator-ns.yaml
+++ b/deploy/operator-ns.yaml
@@ -14,4 +14,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mlnx-network-operator
+  name: nvidia-network-operator

--- a/deploy/operator-resources-ns.yaml
+++ b/deploy/operator-resources-ns.yaml
@@ -14,4 +14,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mlnx-network-operator-resources
+  name: nvidia-network-operator-resources

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: network-operator
-  namespace: mlnx-network-operator
+  namespace: nvidia-network-operator
 spec:
   replicas: 1
   selector:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -16,7 +16,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: network-operator
-  namespace: mlnx-network-operator
+  namespace: nvidia-network-operator
 rules:
   - apiGroups:
       - events.k8s.io
@@ -102,7 +102,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: network-operator
-  namespace: mlnx-network-operator-resources
+  namespace: nvidia-network-operator-resources
 rules:
   - apiGroups:
       - ""

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -15,11 +15,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: network-operator
-  namespace: mlnx-network-operator
+  namespace: nvidia-network-operator
 subjects:
   - kind: ServiceAccount
     name: network-operator
-    namespace: mlnx-network-operator
+    namespace: nvidia-network-operator
 roleRef:
   kind: Role
   name: network-operator
@@ -29,11 +29,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: network-operator
-  namespace: mlnx-network-operator-resources
+  namespace: nvidia-network-operator-resources
 subjects:
   - kind: ServiceAccount
     name: network-operator
-    namespace: mlnx-network-operator
+    namespace: nvidia-network-operator
 roleRef:
   kind: Role
   name: network-operator
@@ -46,7 +46,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: network-operator
-  namespace: mlnx-network-operator
+  namespace: nvidia-network-operator
 roleRef:
   kind: ClusterRole
   name: network-operator

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: network-operator
-  namespace: mlnx-network-operator
+  namespace: nvidia-network-operator

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -1,10 +1,10 @@
-# Nvidia Mellanox Network Operator Helm Chart
+# Nvidia Network Operator Helm Chart
 
-Nvidia Mellanox Network Operator Helm Chart provides an easy way to install, configure and manage
+Nvidia Network Operator Helm Chart provides an easy way to install, configure and manage
 the lifecycle of Nvidia Mellanox network operator.
 
-## Nvidia Mellanox Network Operator
-Nvidia Mellanox Network Operator leverages [Kubernetes CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+## Nvidia Network Operator
+Nvidia Network Operator leverages [Kubernetes CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 and [Operator SDK](https://github.com/operator-framework/operator-sdk) to manage Networking related Components in order to enable Fast networking, 
 RDMA and GPUDirect for workloads in a Kubernetes cluster.
 Network Operator works in conjunction with [GPU-Operator](https://github.com/NVIDIA/gpu-operator) to enable GPU-Direct RDMA

--- a/deployment/network-operator/templates/NOTES.txt
+++ b/deployment/network-operator/templates/NOTES.txt
@@ -1,4 +1,4 @@
 Get Network Operator deployed resources by running the following commands:
 
 $ kubectl -n {{ .Release.Namespace }} get pods
-$ kubectl -n mlnx-network-operator-resources get pods
+$ kubectl -n nvidia-network-operator-resources get pods

--- a/deployment/network-operator/templates/operator-resources-ns.yaml
+++ b/deployment/network-operator/templates/operator-resources-ns.yaml
@@ -16,4 +16,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mlnx-network-operator-resources
+  name: nvidia-network-operator-resources

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -104,7 +104,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: {{ include "network-operator.fullname" . }}
-  namespace: mlnx-network-operator-resources
+  namespace: nvidia-network-operator-resources
 rules:
   - apiGroups:
       - ""

--- a/deployment/network-operator/templates/role_binding.yaml
+++ b/deployment/network-operator/templates/role_binding.yaml
@@ -31,7 +31,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "network-operator.fullname" . }}
-  namespace: mlnx-network-operator-resources
+  namespace: nvidia-network-operator-resources
 subjects:
   - kind: ServiceAccount
     name: {{ include "network-operator.fullname" . }}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -29,7 +29,7 @@ const (
 )
 
 const (
-	NetworkOperatorResourceNamespace = "mlnx-network-operator-resources"
+	NetworkOperatorResourceNamespace = "nvidia-network-operator-resources"
 	NicClusterPolicyResourceName     = "nic-cluster-policy"
 )
 


### PR DESCRIPTION
This commit modifies network operator namespaces
to be prefixed with `nvidia` instead of `mlnx`

In addition modify operator name in README to be
"nvidia network operator" instead of
"nvidia mellanox network operator" as that is its
marketing name.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>