### PR TITLE
Update namespace name in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -19,9 +19,9 @@ labels: bug
 
 **Logs**:
 - NicClusterPolicy CR spec and state:
-- Output of: `kubectl -n mlnx-network-operator-resources get -A`:
+- Output of: `kubectl -n nvidia-network-operator-resources get -A`:
 - Logs of Network Operator controller:
-- Logs of the various Pods in `mlnx-network-operator-resources` namespace:
+- Logs of the various Pods in `nvidia-network-operator-resources` namespace:
 - Helm Configuration (if applicable):
 
 **Environment**:


### PR DESCRIPTION
Commit b159be04a0b67c0e3cfddf510d3a128c4b330266 changed namespace
prefix from 'mlnx' to 'nvidia' so we need to adjust issue template
too.