### PR TITLE
[helm] fix nfd worker tolerations value

### DIFF
--- a/deployment/network-operator/charts/node-feature-discovery/values.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/values.yaml
@@ -207,7 +207,7 @@ worker:
 
   nodeSelector: {}
 
-  tolerations: {}
+  tolerations: []
 
   annotations: {}
 


### PR DESCRIPTION
the tolerations value is array therefore we need to pass
[] and not {}

Signed-off-by: Moshe Levi <moshele@nvidia.com>