### PR TITLE
Stop using SelfLink

### DIFF
--- a/pkg/state/state_macvlan_network.go
+++ b/pkg/state/state_macvlan_network.go
@@ -115,9 +115,6 @@ func (s *stateMacvlanNetwork) Sync(customResource interface{}, _ InfoCatalog) (S
 	if err := s.getObj(netAttDef); err != nil {
 		return SyncStateError, errors.Wrap(err, "failed to get NetworkAttachmentDefinition")
 	}
-	// TODO handling MacvlanNetwork CR Status should be done in the controller
-	cr.Status.MacvlanNetworkAttachmentDef = netAttDef.GetSelfLink()
-
 	return syncState, nil
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,11 +17,14 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
+
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
 // GetFilesWithSuffix returns all files under a given base directory that have a specific suffix
@@ -52,4 +55,10 @@ func GetFilesWithSuffix(baseDir string, suffixes ...string) ([]string, error) {
 		return nil, errors.Wrapf(err, "error traversing directory tree")
 	}
 	return files, nil
+}
+
+func GetNetworkAttachmentDefLink(netAttDef *netattdefv1.NetworkAttachmentDefinition) (link string) {
+	link = fmt.Sprintf("%s/namespaces/%s/%s/%s",
+		netAttDef.APIVersion, netAttDef.Namespace, netAttDef.Kind, netAttDef.Name)
+	return
 }


### PR DESCRIPTION
Objects SelfLink was deprecated in Kubernetes v1.16 and will be
removed in v.1.21. SelfLink is disabled by default in v.1.20.

This implementation is a simplified version of the original one [1]
and uses public API which isn't supposed to be changed soon.

This patch also moves MacvlanNetwork status update to controller.

[1] https://github.com/kubernetes/kubernetes/blob/54449be03127f883e52df48b95adef36925ae2cf/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/namer.go#L105

Closes: #133
Closes: #59 