### PR TITLE
Add linters for helm charts and Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 script:
   - make scripts/check-manifests.sh
   - make lint
+  - make lint-dockerfile
   - make test-coverage
     #  - goveralls -coverprofile=network-operator.cover -service=travis-ci
   - make image

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - make scripts/check-manifests.sh
   - make lint
   - make lint-dockerfile
+  - make lint-helm
   - make test-coverage
     #  - goveralls -coverprofile=network-operator.cover -service=travis-ci
   - make image

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@
 # limitations under the License.
 FROM golang:alpine as builder
 
-ADD . /usr/src/network-operator
+COPY . /usr/src/network-operator
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --update --virtual build-dependencies build-base linux-headers git && \
-    cd /usr/src/network-operator && \
+WORKDIR /usr/src/network-operator
+RUN apk add --no-cache --virtual build-dependencies build-base linux-headers git && \
     make clean && \
     make build
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ BINARY_NAME=network-operator
 PACKAGE=network-operator
 ORG_PATH=github.com/Mellanox
 REPO_PATH=$(ORG_PATH)/$(PACKAGE)
+CHART_PATH=$(CURDIR)/deployment/$(PACKAGE)
 GOPATH?=$(CURDIR)/.gopath
 GOBIN =$(CURDIR)/bin
 TOOLSDIR=$(CURDIR)/bin
@@ -62,6 +63,9 @@ GOLANGCI_LINT_VER = v1.23.8
 
 HADOLINT = $(TOOLSDIR)/hadolint
 HADOLINT_VER = v1.23.0
+
+HELM = $(TOOLSDIR)/helm
+HELM_VER = v3.5.3
 
 TIMEOUT = 15
 Q = $(if $(filter 1,$V),,@)
@@ -118,6 +122,10 @@ $(HADOLINT): | $(TOOLSDIR) ; $(info  install hadolint...)
 	$Q curl -sSfL -o $(HADOLINT)  https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VER)/hadolint-Linux-x86_64
 	$Q chmod +x $(HADOLINT)
 
+$(HELM): | $(TOOLSDIR) ; $(info  install helm...)
+	$Q curl -sSfL https://get.helm.sh/helm-$(HELM_VER)-linux-amd64.tar.gz -o - | tar xz -C $(TOOLSDIR) --strip-components=1 linux-amd64/helm 
+	$Q chmod +x $(HADOLINT)
+
 # Tests
 
 .PHONY: lint
@@ -133,6 +141,10 @@ lint-dockerfile: $(HADOLINT) ; $(info  running Dockerfile lint with hadolint...)
 # DL3018 - allow installing apks without explicit version
 # DL3007 - allow using "latest" tag for images
 	$Q $(HADOLINT) --ignore DL3018 --ignore DL3007 Dockerfile
+
+.PHONY: lint-helm
+lint-helm: $(HELM) ; $(info  running lint with helm charts...) @ ## Run helm lint
+	$Q $(HELM) lint $(CHART_PATH)
 
 TEST_TARGETS := test-default test-bench test-short test-verbose test-race
 .PHONY: $(TEST_TARGETS) test-xml check test tests

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ORG_PATH=github.com/Mellanox
 REPO_PATH=$(ORG_PATH)/$(PACKAGE)
 GOPATH?=$(CURDIR)/.gopath
 GOBIN =$(CURDIR)/bin
+TOOLSDIR=$(CURDIR)/bin
 BUILDDIR=$(CURDIR)/build/_output
 BASE=$(GOPATH)/src/$(REPO_PATH)
 GOFILES=$(shell find . -name "*.go" | grep -vE "(\/vendor\/)|(_test.go)")
@@ -58,6 +59,10 @@ GOLANGCI_LINT = $(GOBIN)/golangci-lint
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
 GOLANGCI_LINT_VER = v1.23.8
+
+HADOLINT = $(TOOLSDIR)/hadolint
+HADOLINT_VER = v1.23.0
+
 TIMEOUT = 15
 Q = $(if $(filter 1,$V),,@)
 
@@ -87,7 +92,7 @@ $(BASE): ; $(info  setting GOPATH...)
 	@mkdir -p $(dir $@)
 	@ln -sf $(CURDIR) $@
 
-$(GOBIN):
+$(GOBIN) $(TOOLSDIR):
 	@mkdir -p $@
 
 $(BUILDDIR): | $(BASE) ; $(info Creating build directory...)
@@ -108,6 +113,11 @@ GOVERALLS = $(GOBIN)/goveralls
 $(GOBIN)/goveralls: | $(BASE) ; $(info  building goveralls...)
 	$Q go get github.com/mattn/goveralls
 
+
+$(HADOLINT): | $(TOOLSDIR) ; $(info  install hadolint...)
+	$Q curl -sSfL -o $(HADOLINT)  https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VER)/hadolint-Linux-x86_64
+	$Q chmod +x $(HADOLINT)
+
 # Tests
 
 .PHONY: lint
@@ -117,6 +127,12 @@ lint: | $(BASE) $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run go
 		test -z "$$($(GOLANGCI_LINT) run --timeout=10m | tee $(BASE)/test/lint.out)" || ret=1 ; \
 		cat $(BASE)/test/lint.out ; rm -rf $(BASE)/test ; \
 	 exit $$ret
+
+.PHONY: lint-dockerfile
+lint-dockerfile: $(HADOLINT) ; $(info  running Dockerfile lint with hadolint...) @ ## Run hadolint
+# DL3018 - allow installing apks without explicit version
+# DL3007 - allow using "latest" tag for images
+	$Q $(HADOLINT) --ignore DL3018 --ignore DL3007 Dockerfile
 
 TEST_TARGETS := test-default test-bench test-short test-verbose test-race
 .PHONY: $(TEST_TARGETS) test-xml check test tests


### PR DESCRIPTION
This PR adds Hadolint (https://github.com/hadolint/hadolint) linter for Dockerfiles and `helm lint` call  to  Makefile and CI.

Also, fix some style issues detected by the linter in Dockerfile.

Closes #116 
Closes #115