### PR TITLE
Add additional nodeAffinity for nv-peer-mem-driver POD

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -99,3 +99,12 @@ spec:
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"
         nvidia.com/gpu.present: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.count
+                operator: Gt
+                values:
+                  - "0"

--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -44,6 +44,24 @@ spec:
           operator: Exists
           effect: NoSchedule
       hostNetwork: true
+      initContainers:
+      - name: gpu-driver-validation
+        image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c']
+        args: ["export SYS_LIBRARY_PATH=$(ldconfig -v 2>/dev/null | grep -v '^[[:space:]]' | cut -d':' -f1 | tr '[[:space:]]' ':'); \
+        export NVIDIA_LIBRARY_PATH=/run/nvidia/drivers/usr/lib/x86_64-linux-gnu/:/run/nvidia/drivers/usr/lib64; \
+        export LD_LIBRARY_PATH=${SYS_LIBRARY_PATH}:${NVIDIA_LIBRARY_PATH}; echo ${LD_LIBRARY_PATH}; \
+        export PATH=/run/nvidia/drivers/usr/bin/:${PATH}; \
+        until nvidia-smi; do echo waiting for nvidia drivers to be loaded; sleep 5; done"]
+        securityContext:
+          privileged: true
+          seLinuxOptions:
+            level: "s0"
+        volumeMounts:
+          - name: run-nvidia
+            mountPath: /run/nvidia/drivers
+            mountPropagation: HostToContainer
       containers:
         - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
We use `nvidia.com/gpu.present: "true"` label to select nodes on which we should deploy nv-peer-mem-driver POD. NFD manages this label, and it set label based on GPU PCI device presence. With current network-operator behavior, we can deploy `nv-peer-mem-driver` POD on nodes with no GPU driver, which will cause a crash of `nv-peer-mem-driver` POD.

The recent version of GPU operator put 'nvidia.com/gpu.count' label
on a node after initialization of GPU driver finished on it.
We can understand that node has GPU and GPU driver already deployed
on it by checking this label.
