### PR TITLE
Add support for host OFED to peer-mem POD

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -78,8 +78,11 @@ spec:
             - name: NO_PROXY
               value: {{ .RuntimeSpec.NoProxy }}
           volumeMounts:
-            - name: run-mlnx-ofed
-              mountPath: /run/mellanox/drivers
+            - name: mlnx-ofed-usr-src
+              mountPath: /run/mellanox/drivers/usr/src
+              mountPropagation: HostToContainer
+            - name: mlnx-ofed-lib-modules
+              mountPath: /run/mellanox/drivers/lib/modules
               mountPropagation: HostToContainer
             - name: run-nvidia
               mountPath: /run/nvidia/drivers
@@ -110,11 +113,14 @@ spec:
       volumes:
         {{ $ofedPath := "/run/mellanox/drivers" }}
         {{ if .RuntimeSpec.UseHostOFED }}
-          {{ $ofedPath = "/" }}
+          {{ $ofedPath = "" }}
         {{end}}
-        - name: run-mlnx-ofed
+        - name: mlnx-ofed-usr-src
           hostPath:
-            path: {{ $ofedPath }}
+            path: {{ $ofedPath }}/usr/src
+        - name: mlnx-ofed-lib-modules
+          hostPath:
+            path: {{ $ofedPath }}/lib/modules
         - name: run-nvidia
           hostPath:
             path: {{ .CrSpec.GPUDriverSourcePath }}

--- a/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0010_nv-peer-mem-driver-ds.yaml
@@ -108,9 +108,13 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: 1
       volumes:
+        {{ $ofedPath := "/run/mellanox/drivers" }}
+        {{ if .RuntimeSpec.UseHostOFED }}
+          {{ $ofedPath = "/" }}
+        {{end}}
         - name: run-mlnx-ofed
           hostPath:
-            path: /run/mellanox/drivers
+            path: {{ $ofedPath }}
         - name: run-nvidia
           hostPath:
             path: {{ .CrSpec.GPUDriverSourcePath }}

--- a/pkg/state/state_nv_peer.go
+++ b/pkg/state/state_nv_peer.go
@@ -47,12 +47,13 @@ type stateNVPeer struct {
 
 type nvPeerRuntimeSpec struct {
 	runtimeSpec
-	CPUArch    string
-	OSName     string
-	OSVer      string
-	HTTPProxy  string
-	HTTPSProxy string
-	NoProxy    string
+	CPUArch     string
+	OSName      string
+	OSVer       string
+	HTTPProxy   string
+	HTTPSProxy  string
+	NoProxy     string
+	UseHostOFED bool
 }
 
 type nvPeerManifestRenderData struct {
@@ -146,6 +147,7 @@ func (s *stateNVPeer) getManifestObjects(
 			HTTPProxy:   os.Getenv(consts.HTTPProxy),
 			HTTPSProxy:  os.Getenv(consts.HTTPSProxy),
 			NoProxy:     os.Getenv(consts.NoProxy),
+			UseHostOFED: cr.Spec.OFEDDriver == nil,
 		},
 	}
 	// render objects


### PR DESCRIPTION
Autoselect right path of OFED src for nv-peer-mem POD

Based on the fact that Mellanox OFED driver POD is deployed or not,
network-operator will select the right OFED src path for nv-peer-mem POD.
If OFED driver POD doesn't exist, OFED from the host will be used.


~~Add additional option `nvPeerDriver.ofedDriverSourcePath` to
NicClusterPolicy CR. Default value points to the location
in which `Mellanox OFED driver` POD will install the driver.
If the option set to an empty string, then Mellanox OFED driver
from the host OS will be used~~

Fixes #76 