### PR TITLE
Change order of networking components rendering

### DIFF
--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -108,10 +108,10 @@ func newNicClusterPolicyStates(k8sAPIClient client.Client, scheme *runtime.Schem
 	}
 
 	return []Group{
+		NewStateGroup([]State{multusState, cniPluginsState, whereaboutState}),
 		NewStateGroup([]State{ofedState}),
 		NewStateGroup([]State{sriovDpState}),
 		NewStateGroup([]State{sharedDpState, nvPeerMemState}),
-		NewStateGroup([]State{multusState, cniPluginsState, whereaboutState}),
 	}, nil
 }
 


### PR DESCRIPTION
Getting Multus, CNI plugins and Whereabouts deployed befor OFED and
device plugins makes networking usable even if drivers are not
deployed by any reason.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>