### PR TITLE
Use Kubernetes-specific image for SR-IOV Network operator by default

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -42,7 +42,7 @@ resources: {}
 
 # Image URIs for sriov-network-operator components
 images:
-  operator: mellanox/sriov-operator:7ad0f8e
+  operator: mellanox/sriov-operator:7ad0f8e-rel1
   sriovConfigDaemon: mellanox/sriov-operator-daemon:4.8
   sriovCni: nfvpe/sriov-cni:v2.6
   ibSriovCni: mellanox/ib-sriov-cni:faa9e36


### PR DESCRIPTION
Closes: #167