### PR TITLE
Add initContainers for device plugins

### DIFF
--- a/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -45,6 +45,14 @@ spec:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+{{if .DeployInitContainer}}
+      initContainers:
+        - name: ofed-driver-validation
+          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          imagePullPolicy: IfNotPresent
+          command: [ 'sh', '-c' ]
+          args: [ "until lsmod | grep mlx5_core; do echo waiting for OFED drivers to be loaded; sleep 30; done" ]
+{{end}}
       containers:
       - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
         name: rdma-shared-dp

--- a/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
+++ b/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
@@ -45,6 +45,14 @@ spec:
           operator: Exists
           effect: NoSchedule
       serviceAccountName: sriov-device-plugin
+{{if .DeployInitContainer}}
+      initContainers:
+        - name: ofed-driver-validation
+          image: {{ .CrSpec.ImageSpec.Repository }}/{{ .CrSpec.ImageSpec.Image }}:{{ .CrSpec.ImageSpec.Version }}
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c']
+          args: ["until lsmod | grep mlx5_core; do echo waiting for OFED drivers to be loaded; sleep 30; done"]
+{{end}}
       containers:
         - name: kube-sriovdp
           image: {{ .CrSpec.ImageSpec.Repository }}/{{ .CrSpec.ImageSpec.Image }}:{{ .CrSpec.ImageSpec.Version }}

--- a/pkg/state/state_shared_dp.go
+++ b/pkg/state/state_shared_dp.go
@@ -59,8 +59,9 @@ type sharedDpRuntimeSpec struct {
 	OSName string
 }
 type sharedDpManifestRenderData struct {
-	CrSpec      *mellanoxv1alpha1.DevicePluginSpec
-	RuntimeSpec *sharedDpRuntimeSpec
+	CrSpec              *mellanoxv1alpha1.DevicePluginSpec
+	DeployInitContainer bool
+	RuntimeSpec         *sharedDpRuntimeSpec
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -135,7 +136,8 @@ func (s *stateSharedDp) getManifestObjects(
 	}
 
 	renderData := &sharedDpManifestRenderData{
-		CrSpec: cr.Spec.RdmaSharedDevicePlugin,
+		CrSpec:              cr.Spec.RdmaSharedDevicePlugin,
+		DeployInitContainer: cr.Spec.OFEDDriver != nil,
 		RuntimeSpec: &sharedDpRuntimeSpec{
 			runtimeSpec: runtimeSpec{consts.NetworkOperatorResourceNamespace},
 			OSName:      attrs[0].Attributes[nodeinfo.AttrTypeOSName],

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -54,8 +54,9 @@ type stateSriovDp struct {
 }
 
 type sriovDpManifestRenderData struct {
-	CrSpec      *mellanoxv1alpha1.DevicePluginSpec
-	RuntimeSpec *runtimeSpec
+	CrSpec              *mellanoxv1alpha1.DevicePluginSpec
+	DeployInitContainer bool
+	RuntimeSpec         *runtimeSpec
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -108,7 +109,8 @@ func (s *stateSriovDp) GetWatchSources() map[string]*source.Kind {
 func (s *stateSriovDp) getManifestObjects(
 	cr *mellanoxv1alpha1.NicClusterPolicy) ([]*unstructured.Unstructured, error) {
 	renderData := &sriovDpManifestRenderData{
-		CrSpec: cr.Spec.SriovDevicePlugin,
+		CrSpec:              cr.Spec.SriovDevicePlugin,
+		DeployInitContainer: cr.Spec.OFEDDriver != nil,
 		RuntimeSpec: &runtimeSpec{
 			Namespace: consts.NetworkOperatorResourceNamespace,
 		},


### PR DESCRIPTION
Both SR-IOV Device Plugin and RDMA Shared Device Plugin should
wait until OFED container is started if it's supposed to be
deployed.

During cluster scale-up Kubernetes schedules DaemonSet to new nodes
and we don't configure an order of pods in this case. To wait until
MOFED containder is ready we'll add initContainer with the same logic
as MOFED container has.

This will prevent us to run device plugin before MOFED started during
scale-up but it doesn't fix an issue if node was rebooted.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>