### PR TITLE
Use labels to wait for MOFED pods

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -95,7 +95,9 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -173,7 +175,9 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
+      - update
   - apiGroups:
     - rbac.authorization.k8s.io
     resources:
@@ -207,7 +211,9 @@ rules:
   verbs:
     - get
     - list
+    - patch
     - watch
+    - update
 - apiGroups:
     - apps
   resources:
@@ -255,7 +261,9 @@ rules:
     - pods/status
   verbs:
     - get
+    - list
     - update
+    - watch
 - apiGroups:
     - ""
     - events.k8s.io

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -97,7 +97,9 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -175,7 +177,9 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
+      - update
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -209,7 +213,9 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
+      - update
   - apiGroups:
       - apps
     resources:
@@ -257,7 +263,9 @@ rules:
       - pods/status
     verbs:
       - get
+      - list
       - update
+      - watch
   - apiGroups:
       - ""
       - events.k8s.io

--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -31,6 +31,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+        driver-pod: mofed-{{ .CrSpec.Version }}
     spec:
       tolerations:
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.

--- a/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -81,3 +81,4 @@ spec:
             path: /dev/
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"
+        network.nvidia.com/operator.mofed.wait: "false"

--- a/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
+++ b/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
@@ -33,6 +33,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"
+        network.nvidia.com/operator.mofed.wait: "false"
       tolerations:
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
         # This, along with the annotation above marks this pod as a critical add-on.

--- a/pkg/nodeinfo/attributes.go
+++ b/pkg/nodeinfo/attributes.go
@@ -35,6 +35,7 @@ const (
 	NodeLabelCPUArch       = "kubernetes.io/arch"
 	NodeLabelMlnxNIC       = "feature.node.kubernetes.io/pci-15b3.present"
 	NodeLabelNvGPU         = "nvidia.com/gpu.present"
+	NodeLabelWaitOFED      = "network.nvidia.com/operator.mofed.wait"
 )
 
 type AttributeType int


### PR DESCRIPTION
Operator will add nvidia.com/ofed.wait=true label to node,
so device plugins pods (SR-IOV Device Plugin, RDMA Shared
Device Plugin) won't be cheduled to these nodes. All running
device plugins pods will be terminated.

Once OFED reach Running state nodes will have
nvidia.com/ofed.wait=false label, to allow Kubernetes schedule
device plugins pods to these nodes.

In case if OFED deployment is disabled label
nvidia.com/ofed.wait=false will be added to the nodes.

This patch will fix an issue with pods initializing orded after
node reboot.