### PR TITLE
Do not wait state group deployment in manager

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
@@ -130,6 +130,7 @@ spec:
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"
         nvidia.com/gpu.present: "true"
+        network.nvidia.com/operator.mofed.wait: "false"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
We manage deployment order in a manager only for NicClusterPolicy now.
It's not needed anymore since we use labeling mechanism to wait until
MOFED will be deployed.

There should not be any issues for parallel deployment of networking
stack (CNI plugins, Multus, Whereabouts, etc) and MOFED because they
don't depend on each other.

This patch improves deployment speed on a large environment and fixes
an issue if one MOFED pod block any other deployment on the other nodes.

Closes: #184