### PR TITLE
Add nvPeerDriver.fromGPUDriver option to NicClusterPolicy CR

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -72,6 +72,8 @@ type NVPeerDriverSpec struct {
 	ImageSpec `json:""`
 	// GPU driver sources path - Optional
 	GPUDriverSourcePath string `json:"gpuDriverSourcePath,omitempty"`
+	// Allow to use builtin nvidia_peermem module from GPU driver
+	FromGPUDriver bool `json:"fromGPUDriver,omitempty"`
 }
 
 // DevicePluginSpec describes configuration options for device plugin

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -47,6 +47,10 @@ spec:
                 description: NVPeerDriverSpec describes configuration options for
                   NV Peer Memory driver
                 properties:
+                  fromGPUDriver:
+                    description: Allow to use builtin nvidia_peermem module from GPU
+                      driver
+                    type: boolean
                   gpuDriverSourcePath:
                     description: GPU driver sources path - Optional
                     type: string

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -47,6 +47,10 @@ spec:
                 description: NVPeerDriverSpec describes configuration options for
                   NV Peer Memory driver
                 properties:
+                  fromGPUDriver:
+                    description: Allow to use builtin nvidia_peermem module from GPU
+                      driver
+                    type: boolean
                   gpuDriverSourcePath:
                     description: GPU driver sources path - Optional
                     type: string

--- a/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
@@ -86,6 +86,8 @@ spec:
               value: {{ .RuntimeSpec.HTTPSProxy }}
             - name: NO_PROXY
               value: {{ .RuntimeSpec.NoProxy }}
+            - name: ALLOW_MOD_FROM_GPU_DRIVER
+              value: '{{ .CrSpec.FromGPUDriver }}'
           volumeMounts:
             - name: mlnx-ofed-usr-src
               mountPath: /run/mellanox/drivers/usr/src
@@ -107,7 +109,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                [sh, -c, 'lsmod | grep nv_peer_mem']
+                [sh, -c, 'lsmod | grep "nv_peer_mem\|nvidia_peermem"']
             periodSeconds: 30
             initialDelaySeconds: 30
             failureThreshold: 1
@@ -115,7 +117,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                [sh, -c, 'lsmod | grep nv_peer_mem']
+                [sh, -c, 'lsmod | grep "nv_peer_mem\|nvidia_peermem"']
             periodSeconds: 30
             initialDelaySeconds: 10
             failureThreshold: 1


### PR DESCRIPTION
Add nvPeerDriver.fromGPUDriver option to NicClusterPolicy CR

This option is passed as parameter to nvPeerDriver container.
If "fromGPUDriver" is true, nvPeerDriver container will try to use
nvidia_peermem module which is a part of
the GPU driver distro (in 465.x branch) instead of nv_peer_mem module
compiled from sources. If the option is true, but  GPU driver doesn't
provide nvidia_peermem module, then nv_peer_mem will be used.

Default value for the option is false, which means to use
nv_peer_mem module compiled from sources.


PR in ofed-docker repo which adds required logic to nvPeerMem container https://github.com/Mellanox/ofed-docker/pull/25