### PR TITLE
Add additional nodeAffinity rule for nv-peer-mem-driver POD

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       - [HostDeviceNetwork spec](#hostdevicenetwork-spec)
         * [Example for HostDeviceNetwork resource:](#example-for-hostdevicenetwork-resource)
   * [System Requirements](#system-requirements)
+  * [Compatibility Notes](#compatibility-notes)
   * [Deployment Example](#deployment-example)
   * [Driver Containers](#driver-containers)
 
@@ -76,6 +77,7 @@ NICClusterPolicy CRD Spec includes the following sub-states/stages:
 and related configurations.
 - `nvPeerDriver`: [Nvidia Peer Memory client driver container](https://github.com/Mellanox/ofed-docker)
 to be deployed on RDMA & GPU supporting nodes (required for GPUDirect workloads).
+  For NVIDIA GPU driver version < 465. Check [compatibility notes](#compatibility-notes) for details
 - `SecondaryNetwork`: Specifies components to deploy in order to facilitate a secondary network in Kubernetes. It consists of the folowing optionally deployed components:
     - [Multus-CNI](https://github.com/intel/multus-cni): Delegate CNI plugin to support secondary networks in Kubernetes
     - CNI plugins: Currently only [containernetworking-plugins](https://github.com/containernetworking/plugins) is supported
@@ -289,6 +291,9 @@ Can be found at: `mellanox.com_v1alpha1_hostdevicenetwork_cr.yaml`
 
 ## Compatibility Notes
 * network-operator is compatible with NVIDIA GPU Operator v1.5.2 and above
+* network-operator will deploy nvPeerDriver POD on a node only if NVIDIA GPU driver version < 465.
+  Starting from v465 NVIDIA GPU driver includes a built-in nvidia_peermem module
+  which is a replacement for nv_peer_mem module. NVIDIA GPU operator manages nvidia_peermem module loading.
 
 ## Deployment Example
 Deployment of network-operator consists of:

--- a/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
@@ -146,3 +146,10 @@ spec:
                 operator: Gt
                 values:
                   - "0"
+              # cuda driver starting from v465 should include builtin nvidia_peermem module
+              # which should be used instead nv_peer_mem
+              # prevent scheduling nv-peer-mem-driver POD on nodes with cuda driver version >= 465
+              - key: nvidia.com/cuda.driver.major
+                operator: Lt
+                values:
+                  - "{{ .RuntimeSpec.MaxCudaVersion }}"

--- a/pkg/nodeinfo/filter.go
+++ b/pkg/nodeinfo/filter.go
@@ -82,3 +82,62 @@ func (b *NodeLabelFilterBuilder) Reset() *NodeLabelFilterBuilder {
 	b.filter = newNodeLabelFilter()
 	return b
 }
+
+// A node label filter which ignores label value. use NewNodeLabelNoValFilterBuilder to create instances
+type nodeLabelNoValFilter struct {
+	labels map[string]struct{}
+}
+
+// addLabel adds a label to nodeLabelFilter
+func (nlf *nodeLabelNoValFilter) addLabel(key string) {
+	nlf.labels[key] = struct{}{}
+}
+
+// Apply Filter on Nodes
+func (nlf *nodeLabelNoValFilter) Apply(nodes []*corev1.Node) (filtered []*corev1.Node) {
+NextIter:
+	for _, node := range nodes {
+		nodeLabels := node.GetLabels()
+		for k := range nlf.labels {
+			if _, ok := nodeLabels[k]; ok {
+				continue
+			}
+			// label not found on node or label value missmatch
+			continue NextIter
+		}
+		filtered = append(filtered, node)
+	}
+	return filtered
+}
+
+// newNodeLabelNoValFilter creates a new nodeLabelNoValFilter
+func newNodeLabelNoValFilter() nodeLabelNoValFilter {
+	return nodeLabelNoValFilter{labels: make(map[string]struct{})}
+}
+
+// NodeLabelNoValFilterBuilder is a builder for nodeLabelFilter
+type NodeLabelNoValFilterBuilder struct {
+	filter nodeLabelNoValFilter
+}
+
+// NewNodeLabelNoValFilterBuilderr returns a new NodeLabelNoValFilterBuilder
+func NewNodeLabelNoValFilterBuilderr() *NodeLabelNoValFilterBuilder {
+	return &NodeLabelNoValFilterBuilder{filter: newNodeLabelNoValFilter()}
+}
+
+// WithLabel adds a label for the Build process of the Label filter
+func (b *NodeLabelNoValFilterBuilder) WithLabel(key string) *NodeLabelNoValFilterBuilder {
+	b.filter.addLabel(key)
+	return b
+}
+
+// Build the Filter
+func (b *NodeLabelNoValFilterBuilder) Build() Filter {
+	return &b.filter
+}
+
+// Reset NodeLabelNoValFilterBuilder
+func (b *NodeLabelNoValFilterBuilder) Reset() *NodeLabelNoValFilterBuilder {
+	b.filter = newNodeLabelNoValFilter()
+	return b
+}

--- a/pkg/nodeinfo/filter_test.go
+++ b/pkg/nodeinfo/filter_test.go
@@ -31,10 +31,11 @@ var _ = Describe("NodeAttributes tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-1",
 				Labels: map[string]string{
-					NodeLabelOSName:        "ubuntu",
-					NodeLabelCPUArch:       "amd64",
-					NodeLabelKernelVerFull: "5.4.0-generic",
-					NodeLabelOSVer:         "20.04"},
+					NodeLabelOSName:           "ubuntu",
+					NodeLabelCPUArch:          "amd64",
+					NodeLabelKernelVerFull:    "5.4.0-generic",
+					NodeLabelOSVer:            "20.04",
+					NodeLabelCudaVersionMajor: "465"},
 			},
 		},
 		{
@@ -42,9 +43,10 @@ var _ = Describe("NodeAttributes tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-2",
 				Labels: map[string]string{
-					NodeLabelOSName:        "rhel",
-					NodeLabelCPUArch:       "x86_64",
-					NodeLabelKernelVerFull: "5.4.0-generic"},
+					NodeLabelOSName:           "rhel",
+					NodeLabelCPUArch:          "x86_64",
+					NodeLabelKernelVerFull:    "5.4.0-generic",
+					NodeLabelCudaVersionMajor: "460"},
 			},
 		},
 		{
@@ -111,6 +113,25 @@ var _ = Describe("NodeAttributes tests", func() {
 			Expect(len(filteredNodes)).To(Equal(2))
 			Expect(filteredNodes[0].Name).To(Equal("node-2"))
 			Expect(filteredNodes[1].Name).To(Equal("node-4"))
+		})
+	})
+
+	Context("Filter by labels without values", func() {
+		It("Should only return the relevant nodes", func() {
+			filter := NewNodeLabelNoValFilterBuilderr().
+				WithLabel(NodeLabelCudaVersionMajor).
+				Build()
+			filteredNodes := filter.Apply(nodes)
+			Expect(len(filteredNodes)).To(Equal(2))
+			Expect(filteredNodes[0].Name).To(Equal("node-1"))
+			Expect(filteredNodes[1].Name).To(Equal("node-2"))
+		})
+		It("Should return an empty list of nodes", func() {
+			filter := NewNodeLabelNoValFilterBuilderr().
+				WithLabel("unknown_label").
+				Build()
+			filteredNodes := filter.Apply(nodes)
+			Expect(filteredNodes).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
This rule prevents driver from deploying on node
which has NVIDIA GPU driver with version >= 465.
Starting from v465 NVIDIA GPU driver includes a built-in nvidia_peermem
module which is a replacement for nv_peer_mem module.
NVIDIA GPU operator manages nvidia_peermem module loading.

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>