### PR TITLE
Sign in to dockerhub in travis before building image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 
 before_script:
   - go get -u github.com/mattn/goveralls
+  - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
 
 script:
   - make scripts/check-manifests.sh


### PR DESCRIPTION
Added a before_script step for travis CI to sign in
to dockerhub to fix the issue with dockerhub pull rate
limit.

Signed-off-by: abdallahyas <abdallahyas@mellanox.com>