### PR TITLE
WIP. Move image build step to 'deploy' phase on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - make lint-helm
   - make test-coverage
     #  - goveralls -coverprofile=network-operator.cover -service=travis-ci
-  - make image
 
 before_deploy:
   - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
@@ -31,7 +30,9 @@ deploy:
   # Push image to Dockerhub on tag
   - provider: script
     skip_cleanup: true
-    script: bash scripts/docker-push.sh $IMAGE_NAME $TRAVIS_TAG $TRAVIS_CPU_ARCH
+    script:
+      - make image
+      - bash scripts/docker-push.sh $IMAGE_NAME $TRAVIS_TAG $TRAVIS_CPU_ARCH
     on:
       tags: true
       all_branches: true


### PR DESCRIPTION
We'll build image on Jenkins on each pull request.

Travis CI will build image only during deploy phase to not face
DockerHub image pull limit.

depends-on: kubernetes-ci#131