### PR TITLE
Use stable extension API for CRDs

### DIFF
--- a/manifests/stage-whereabouts-cni/0010-whereabouts.cni.cncf.io_ippools.yaml
+++ b/manifests/stage-whereabouts-cni/0010-whereabouts.cni.cncf.io_ippools.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
The beta CustomResourceDefinition API (apiextensions.k8s.io/v1beta1)
is removed on Kubernetes v1.22, so we should not use it anymore.

Closes: #230

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>