### PR TITLE
Sync ippools.whereabouts.cni.cncf.io CRD with upstream

### DIFF
--- a/manifests/stage-whereabouts-cni/0010-whereabouts.cni.cncf.io_ippools.yaml
+++ b/manifests/stage-whereabouts-cni/0010-whereabouts.cni.cncf.io_ippools.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -21,54 +22,55 @@ spec:
   names:
     kind: IPPool
     plural: ippools
-  scope: ""
-  validation:
-    openAPIV3Schema:
-      description: IPPool is the Schema for the ippools API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IPPoolSpec defines the desired state of IPPool
-          properties:
-            allocations:
-              additionalProperties:
-                description: IPAllocation represents metadata about the pod/container
-                  owner of a specific IP
-                properties:
-                  id:
-                    type: string
-                required:
-                - id
-                type: object
-              description: Allocations is the set of allocated IPs for the given range.
-                Its` indices are a direct mapping to the IP with the same index/offset
-                for the pool's range.
-              type: object
-            range:
-              description: Range is a RFC 4632/4291-style string that represents an
-                IP address and prefix length in CIDR notation
-              type: string
-          required:
-          - allocations
-          - range
-          type: object
-      type: object
-  version: v1alpha1
+  scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: IPPool is the Schema for the ippools API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPPoolSpec defines the desired state of IPPool
+              properties:
+                allocations:
+                  additionalProperties:
+                    description: IPAllocation represents metadata about the pod/container
+                      owner of a specific IP
+                    properties:
+                      id:
+                        type: string
+                      podref:
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  description: Allocations is the set of allocated IPs for the given range.
+                    Its` indices are a direct mapping to the IP with the same index/offset
+                    for the pool's range.
+                  type: object
+                range:
+                  description: Range is a RFC 4632/4291-style string that represents an
+                    IP address and prefix length in CIDR notation
+                  type: string
+              required:
+              - allocations
+              - range
+              type: object
+          type: object
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Commit 278613dea3cf054c4ea6a7cd62aed829ac709269 breaks CRD deployment.
This patch fixes the issue by syncing CRD with upstream version.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>