### PR TITLE
Fix imagePullSecrets for Network Operator

### DIFF
--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -44,7 +44,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}
       {{- if .Values.operator.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.operator.imagePullSecrets | indent 8 }}
+      imagePullSecrets:
+      {{- range .Values.operator.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
Network Operator has different format for imagePullSecrets
rather than other components. This patch fixes it.

Upgrade notice: you need to update your values.yaml file
manuallty if you use imagePullSecrets with old format.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>