### PR TITLE
fix trivial typo

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -340,7 +340,7 @@ rdmaSharedDevicePlugin:
 Network Operator deployment with:
 - RDMA device plugin, single RDMA resource mapped to `ib0`
 - Secondary network
-    - Mutlus CNI
+    - Multus CNI
     - Containernetworking-plugins CNI plugins
     - Whereabouts IPAM CNI Plugin
 


### PR DESCRIPTION
mutlus -> multus

Signed-off-by: Chad Dougherty <crd@acm.org>