### PR TITLE
downgrade multus cniVersion 0.3.1

### DIFF
--- a/manifests/stage-macvlan-network/0010-macvlan-net-cr.yml
+++ b/manifests/stage-macvlan-network/0010-macvlan-net-cr.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{.NetworkNamespace}}
 spec:
   config: '{
-  "cniVersion":"0.4.0",
+  "cniVersion":"0.3.1",
   "name":"{{.NetworkName}}",
   "type":"macvlan",
 {{- if .Master -}}

--- a/manifests/stage-multus-cni/0050-multus-ds.yml
+++ b/manifests/stage-multus-cni/0050-multus-ds.yml
@@ -40,7 +40,7 @@ spec:
           image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
           command: ["/entrypoint.sh"]
           args:
-            - "--cni-version=0.4.0"
+            - "--cni-version=0.3.1"
             # /tmp/multus-conf/00-multus.conf is where multus-cfg ConfigMap is mounted then entrypoint.sh copy it to
             # /host/etc/cni/net.d/00-multus.conf
             - "--multus-conf-file={{- if .CrSpec.Config -}}/tmp/multus-conf/00-multus.conf{{- else -}}auto{{- end -}}"


### PR DESCRIPTION
calico don't support cniVersion 0.4.0 therefore we need to downgrade cniVersion
to 0.3.1.

Signed-off-by: Moshe Levi <moshele@nvidia.com>