### PR TITLE
Add new sriov-device-plugin service account for OpenShift

### DIFF
--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -95,7 +95,7 @@ func (r *NicClusterPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Create a new State service catalog
 	sc := state.NewInfoCatalog()
 	if instance.Spec.OFEDDriver != nil || instance.Spec.NVPeerDriver != nil ||
-		instance.Spec.RdmaSharedDevicePlugin != nil {
+		instance.Spec.RdmaSharedDevicePlugin != nil || instance.Spec.SriovDevicePlugin != nil {
 		// Create node infoProvider and add to the service catalog
 		reqLogger.V(consts.LogLevelInfo).Info("Creating Node info provider")
 		nodeList := &corev1.NodeList{}

--- a/manifests/stage-sriov-device-plugin/0021_role.openshift.yaml
+++ b/manifests/stage-sriov-device-plugin/0021_role.openshift.yaml
@@ -1,0 +1,16 @@
+{{if eq .RuntimeSpec.OSName "rhcos"}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sriov-device-plugin
+  namespace: {{ .RuntimeSpec.Namespace }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+{{end}}

--- a/manifests/stage-sriov-device-plugin/0022_rolebinding.openshift.yaml
+++ b/manifests/stage-sriov-device-plugin/0022_rolebinding.openshift.yaml
@@ -1,0 +1,18 @@
+{{if eq .RuntimeSpec.OSName "rhcos"}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sriov-device-plugin
+  namespace: {{ .RuntimeSpec.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sriov-device-plugin
+  namespace: {{ .RuntimeSpec.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: sriov-device-plugin
+  namespace: {{ .RuntimeSpec.Namespace }}
+userNames:
+- system:serviceaccount:{{ .RuntimeSpec.Namespace }}:sriov-device-plugin
+{{end}}

--- a/manifests/stage-sriov-device-plugin/0023_scc.openshift.yaml
+++ b/manifests/stage-sriov-device-plugin/0023_scc.openshift.yaml
@@ -1,0 +1,49 @@
+{{if eq .RuntimeSpec.OSName "rhcos"}}
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:nodes
+- system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+
+  name: sriov-device-plugin
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .RuntimeSpec.Namespace }}:sriov-device-plugin
+volumes:
+- '*'
+{{end}}


### PR DESCRIPTION
Service accounts are required in each project to run builds,
deployments, and other pods.

This patch also adds RBAC roles & clusterroles for SR-IOV
device plugin stage.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>