### PR TITLE
Mount host /usr directory to MOFED pod

### DIFF
--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -77,6 +77,9 @@ spec:
               mountPath: /etc/network
             - name: host-etc
               mountPath: /host/etc
+            - name: host-usr
+              mountPath: /host/usr
+
             - name: host-udev
               mountPath: /host/lib/udev
           startupProbe:
@@ -114,6 +117,9 @@ spec:
         - name: host-etc
           hostPath:
             path: /etc
+        - name: host-usr
+          hostPath:
+            path: /usr
         - name: host-udev
           hostPath:
             path: /lib/udev


### PR DESCRIPTION
We need to be able to get host OS version from pod to install
correct versions of packages during driver deployment.

/usr directory is needed because /etc/os-release file is a symlink:
/etc/os-release -> ../usr/lib/os-release

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>