### PR TITLE
Fix panic in stateSriovDP.GetWatchSources

### DIFF
--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -125,6 +125,11 @@ func (s *stateSriovDp) getManifestObjects(
 	nodeInfo nodeinfo.Provider) ([]*unstructured.Unstructured, error) {
 	attrs := nodeInfo.GetNodesAttributes(
 		nodeinfo.NewNodeLabelFilterBuilder().WithLabel(nodeinfo.NodeLabelMlnxNIC, "true").Build())
+	if len(attrs) == 0 {
+		log.V(consts.LogLevelInfo).Info("No nodes with NVIDIA NICs where found in the cluster.")
+		return []*unstructured.Unstructured{}, nil
+	}
+
 	renderData := &sriovDpManifestRenderData{
 		CrSpec:              cr.Spec.SriovDevicePlugin,
 		NodeAffinity:        cr.Spec.NodeAffinity,


### PR DESCRIPTION
Panic may happen when sriov-device-plugin deployed
and there are no nodes with
`feature.node.kubernetes.io/pci-15b3.present` label in
the cluster

Fixes #267 

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>