### PR TITLE
Change updateStrategy for OFED DaemonSet

### DIFF
--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -19,6 +19,8 @@ metadata:
   name: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-ds
   namespace: {{ .RuntimeSpec.Namespace }}
 spec:
+  updateStrategy:
+    type: OnDelete
   selector:
     matchLabels:
       app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}


### PR DESCRIPTION
updateStrategy for OFED DaemonSet changed to "OnDelete"
If OnDelete update strategy is used and DaemonSet template
updated then new DaemonSet pods will only be created when you
manually delete old DaemonSet pods.
If affinity rule or nodeSelector changed, PODs will be added
or removed automatically.

This change is required to be able to implement a rolling upgrade
for environments with the containerized driver.
Steps to apply driver upgrade:
1. Update OFED DaemonSet with new image version (this will not
trigger automatic PODs removal and driver reloading)
2. Remove PODs with secondary network from some set of nodes
3. Manually delete OFED PODs from nodes that have no
PODs with secondary networking.

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>