### PR TITLE
Accept resource names for hostdevicenetwork either with or without prefix

### DIFF
--- a/manifests/stage-hostdevice-network/0010-hostdevice-net-cr.yml
+++ b/manifests/stage-hostdevice-network/0010-hostdevice-net-cr.yml
@@ -4,7 +4,7 @@ metadata:
   name: {{.HostDeviceNetworkName}}
   namespace: {{.CrSpec.NetworkNamespace}}
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: nvidia.com/{{.CrSpec.ResourceName}}
+    k8s.v1.cni.cncf.io/resourceName: {{.ResourceName}}
 spec:
   config: '{
   "cniVersion":"0.3.1",


### PR DESCRIPTION
Currently network operator doesn't allow deploying host device networks if the resource name start with "nvidia.com" prefix. The solution is to normalize all resource names for hostdevicenetwork state to start with a common prefix.