### PR TITLE
Update node labels regardless of state sync status

### DIFF
--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -117,11 +117,12 @@ func (r *NicClusterPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	// Create manager
 	managerStatus, err := r.stateManager.SyncState(instance, sc)
-	r.updateCrStatus(instance, managerStatus)
 
 	if err != nil {
-		return reconcile.Result{}, err
+		reqLogger.V(consts.LogLevelWarning).Info("Error occurred while syncing states", "error:", err)
 	}
+
+	r.updateCrStatus(instance, managerStatus)
 
 	err = r.updateNodeLabels(instance)
 	if err != nil {


### PR DESCRIPTION
This fixes the issue with mofed.wait label not being set to false when other issues in deployment occur
The proposed solution is to update node labels regardless of state sync status