### PR TITLE
Support extended selectors for sriov-device-plugin with helm deployment

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -393,6 +393,13 @@ to be associated with the resource. Refer to [SR-IOV Network Device Plugin Selec
 resources:
     - name: hostdev
       vendors: [15b3]
+    - name: ethernet_rdma
+      vendors: [15b3]
+      linkTypes: [ether]
+    - name: sriov_rdma
+      vendors: [15b3]
+      devices: [1018]
+      drivers: [mlx5_ib]
 ``` 
 
 >__Note__: The parameter listed are non-exhaustive, for the full list of chart parameters refer to

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -84,6 +84,12 @@ spec:
             "resourceName": {{ $element.name | quote }},
             "selectors": {
               "vendors": {{ $element.vendors | default list | toJson }},
+              "devices": {{ $element.devices | default list | toJson }},
+              "drivers": {{ $element.drivers | default list | toJson }},
+              "pfNames": {{ $element.pfNames | default list | toJson }},
+              "pciAddresses": {{ $element.pciAddresses | default list | toJson }},
+              "rootDevices": {{ $element.rootDevices | default list | toJson }},
+              "linkTypes": {{ $element.linkTypes | default list | toJson }},
               "isRdma": true
             }
           } {{- if ne $length (add1 $index) }},{{ end }}


### PR DESCRIPTION
Currently the SR-IOV Device Plugin resource definition can only select devices based on vendor ID. This creates problems in heterogeneous cluster deployments.
The proposed solution is to support all selectors from sriov-device-plugin.
The fix is intentionally aligned with the current implementation and not made more generic as that would require changing `values.yaml` and ensuring backwards compatibility with different versions of network-operator