### PR TITLE
Set priorityClassName instead of annotation

### DIFF
--- a/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
@@ -24,19 +24,11 @@ spec:
       app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app: nv-peer-mem-driver-{{ .RuntimeSpec.CPUArch }}-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
     spec:
+      priorityClassName: system-node-critical
       tolerations:
-        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-        # This, along with the annotation above marks this pod as a critical add-on.
-        - key: CriticalAddonsOnly
-          operator: Exists
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -26,20 +26,12 @@ spec:
       app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
         driver-pod: mofed-{{ .CrSpec.Version }}
     spec:
+      priorityClassName: system-node-critical
       tolerations:
-        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-        # This, along with the annotation above marks this pod as a critical add-on.
-        - key: CriticalAddonsOnly
-          operator: Exists
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -22,23 +22,15 @@ spec:
       app: rdma-shared-dp
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app: rdma-shared-dp
     spec:
+      priorityClassName: system-node-critical
       hostNetwork: true
 {{if eq .RuntimeSpec.OSName "rhcos"}}
       serviceAccountName: rdma-shared
 {{end}}
       tolerations:
-      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-      # This, along with the annotation above marks this pod as a critical add-on.
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule

--- a/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
+++ b/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
@@ -30,6 +30,7 @@ spec:
         tier: node
         app: sriovdp
     spec:
+      priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"
@@ -40,10 +41,6 @@ spec:
           {{- .NodeAffinity | yaml | nindent 10 }}
       {{- end }}
       tolerations:
-        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-        # This, along with the annotation above marks this pod as a critical add-on.
-        - key: CriticalAddonsOnly
-          operator: Exists
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
scheduler.alpha.kubernetes.io is deprecated in k8s v1.16+.
This emits a warning when deploying components which have
this annotation:

Warning: spec.template.metadata.annotations
[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+;
use the "priorityClassName" field instead

Closes issue: #304

Signed-off-by: Fred Rolland <frolland@nvidia.com>