### PR TITLE
Change default startup probe time for ofed driver

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -328,7 +328,7 @@ Production cluster environment can deny direct access to the Internet and instea
 | `ofedDriver.version` | string | `5.5-1.0.3.2` | Mellanox OFED driver version |
 | `ofedDriver.imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling any of the Mellanox OFED driver image |
 | `ofedDriver.startupProbe.initialDelaySeconds` | int | 10 | Mellanox OFED startup probe initial delay |
-| `ofedDriver.startupProbe.periodSeconds` | int | 10 | Mellanox OFED startup probe interval |
+| `ofedDriver.startupProbe.periodSeconds` | int | 20 | Mellanox OFED startup probe interval |
 | `ofedDriver.livenessProbe.initialDelaySeconds` | int | 30 | Mellanox OFED liveness probe initial delay |
 | `ofedDriver.livenessProbe.periodSeconds` | int | 30 | Mellanox OFED liveness probe interval|
 | `ofedDriver.readinessProbe.initialDelaySeconds` | int | 10 | Mellanox OFED readiness probe initial delay |

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -119,7 +119,7 @@ ofedDriver:
   imagePullSecrets: []
   startupProbe:
     initialDelaySeconds: 10
-    periodSeconds: 10
+    periodSeconds: 20
   livenessProbe:
     initialDelaySeconds: 30
     periodSeconds: 30


### PR DESCRIPTION
In VM environments we see it can take up to 12 minutes
to complete driver compilation. Increase default stratup probe
retry period to 20s to allow for a total of 20 min before moving
the pod to failed state

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>