### PR TITLE
Add labels to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,28 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8-micro:8.5
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+ARG VCS_BRANCH
+
+LABEL version=$VERSION
+LABEL vcs-type="git"
+LABEL vcs-branch=$VCS_BRANCH
+LABEL vcs-ref=$VCS_REF
+LABEL build-date=$BUILD_DATE
+LABEL io.k8s.display-name="NVIDIA Network Operator"
+LABEL name="NVIDIA Network Operator"
+LABEL vendor="NVIDIA"
+LABEL release="N/A"
+LABEL summary="Deploy and manage NVIDIA networking resources in Kubernetes"
+LABEL description="NVIDIA Network Operator"
+LABEL io.k8s.description="NVIDIA Network Operator"
+LABEL maintainer="NVIDIA nvidia-network-operator-support@nvidia.com"
+LABEL url="https://github.com/Mellanox/network-operator"
+LABEL org.label-schema.vcs-url="https://github.com/Mellanox/network-operator"
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY manifests/ manifests/


### PR DESCRIPTION
Adding labels to container image to enhance debuggability.

```bash
$ skopeo inspect docker://quay.io/frollandnvidia/network-operator:test | jq .Labels

{
  "architecture": "x86_64",
  "build-date": "2022-03-15T12:36:09UTC",
  "com.redhat.build-host": "cpt-1002.osbs.prod.upshift.rdu2.redhat.com",
  "com.redhat.component": "ubi8-micro-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "NVIDIA Network Operator",
  "distribution-scope": "public",
  "io.buildah.version": "1.23.1",
  "io.k8s.description": "NVIDIA Network Operator",
  "io.k8s.display-name": "NVIDIA Network Operator",
  "io.openshift.expose-services": "",
  "maintainer": "NVIDIA nvidia-network-operator-support@nvidia.com",
  "name": "NVIDIA Network Operator",
  "org.label-schema.vcs-url": "https://github.com/Mellanox/network-operator",
  "release": "N/A",
  "summary": "Deploy and manage NVIDIA networking resources in Kubernetes",
  "url": "https://github.com/Mellanox/network-operator",
  "vcs-branch": "docker-label",
  "vcs-ref": "ab57d12",
  "vcs-type": "git",
  "vendor": "NVIDIA",
  "version": "v1.2.0-beta.1-5-gab57d12"
}

```

Signed-off-by: Fred Rolland <frolland@nvidia.com>