### PR TITLE
Change OLM installModes to SingleNamespace

### DIFF
--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -475,11 +475,11 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - sriov

--- a/config/manifests/bases/nvidia-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nvidia-network-operator.clusterserviceversion.yaml
@@ -51,11 +51,11 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - sriov


### PR DESCRIPTION
The `MultiNamespace` is making the Network Operator CSV installed in all namespaces.
Updates configuration to `OwnNamespace` and `SingleNamespace`, similar to GPU Operator.

Signed-off-by: Fred Rolland <frolland@nvidia.com>