### PR TITLE
Bump NFD version to v0.10.1

### DIFF
--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: nfd.enabled
   name: node-feature-discovery
   repository: "http://kubernetes-sigs.github.io/node-feature-discovery/charts"
-  version: 0.8.2
+  version: 0.10.1
 - condition: sriovNetworkOperator.enabled
   name: sriov-network-operator
   repository: "https://k8snetworkplumbingwg.github.io/helm-charts/release"

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -29,6 +29,8 @@ sriovNetworkOperator:
 node-feature-discovery:
   image:
     pullPolicy: IfNotPresent
+  nodeFeatureRule:
+    createCRD: false
   master:
     instance: "nvidia.networking"
   worker:
@@ -41,15 +43,15 @@ node-feature-discovery:
         operator: "Equal"
         value: "present"
         effect: "NoSchedule"
-    config: |
+    config:
       sources:
-          pci:
-            deviceClassWhitelist:
-              - "02"
-              - "0200"
-              - "0207"
-            deviceLabelFields:
-              - vendor
+        pci:
+          deviceClassWhitelist:
+            - "02"
+            - "0200"
+            - "0207"
+          deviceLabelFields:
+            - vendor
 
 
 # SR-IOV Network Operator chart related values


### PR DESCRIPTION
The latest GPU Operator uses NFD v0.10.1 so it's goot to keep
versions synced

Closes: #325
Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>