### PR TITLE
Fix SRIOV switchdev example

### DIFF
--- a/example/sriov-network/sriov-network-node-policy-switchdev.yaml
+++ b/example/sriov-network/sriov-network-node-policy-switchdev.yaml
@@ -17,7 +17,7 @@ metadata:
   name: example-sriov-node-policy-switchdev
   namespace: network-operator
 spec:
-  resourceName: sriov-switchdev
+  resourceName: sriovswitchdev
   nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable: "true"
   numVfs: 1


### PR DESCRIPTION
The resource name in the SRIOV switchdev example was not valid according to:
https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/v3.4.0/pkg/utils/utils.go#L274

Signed-off-by: Fred Rolland <frolland@nvidia.com>