### PR TITLE
Do not deploy SR-IOV Device Plugin by default

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -384,7 +384,7 @@ resources:
 
 | Name | Type | Default | description |
 | ---- | ---- | ------- | ----------- |
-| `sriovDevicePlugin.deploy` | bool | `true` | Deploy SR-IOV Network device plugin  |
+| `sriovDevicePlugin.deploy` | bool | `false` | Deploy SR-IOV Network device plugin  |
 | `sriovDevicePlugin.repository` | string | `ghcr.io/k8snetworkplumbingwg` | SR-IOV Network device plugin image repository |
 | `sriovDevicePlugin.image` | string | `sriov-network-device-plugin` | SR-IOV Network device plugin image name  |
 | `sriovDevicePlugin.version` | string | `a765300344368efbf43f71016e9641c58ec1241b` | SR-IOV Network device plugin version  |

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -150,7 +150,7 @@ rdmaSharedDevicePlugin:
       vendors: [15b3]
 
 sriovDevicePlugin:
-  deploy: true
+  deploy: false
   image: sriov-network-device-plugin
   repository: ghcr.io/k8snetworkplumbingwg
   version: a765300344368efbf43f71016e9641c58ec1241b


### PR DESCRIPTION
Macvlan Network with RDMA Shared Device Plugin should be deployed
by default.

HostDevice Network is be disabled in the default configuration now.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>