### PR TITLE
fix: Add field in the nicclusterpolicy helm template for nodeAffinity

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -317,6 +317,7 @@ We have introduced the following Chart parameters.
 | `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used                                    |
 | `operator.imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling Network Operator image                                  |
 | `deployCR` | bool | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters                                           |
+| `nodeAffinity` | yaml | `` | Override the node affinity for various Daemonsets deployed by network operator, e.g. whereabouts, multus, cni-plugins.  |
 
 #### imagePullSecrets customization
 To provide imagePullSecrets object references, you need to specify them using a following structure:
@@ -325,7 +326,6 @@ imagePullSecrets:
   - image-pull-secret1
   - image-pull-secret2
 ```
-
 
 ### NicClusterPolicy Custom resource parameters
 
@@ -460,6 +460,7 @@ Specifies components to deploy in order to facilitate a secondary network in Kub
 | `ipamPlugin.repository` | string | `ghcr.io/k8snetworkplumbingwg` | IPAM CNI Plugin image repository  |
 | `ipamPlugin.version` | string | `v0.5.1-amd64` | IPAM CNI Plugin image version  |
 | `ipamPlugin.imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling any of the IPAM CNI Plugin image |
+
 ## Deployment Examples
 
 As there are several parameters that are required to be provided to create the custom resource during

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -19,6 +19,10 @@ kind: NicClusterPolicy
 metadata:
   name: nic-cluster-policy
 spec:
+  {{- if .Values.nodeAffinity }}
+  nodeAffinity:
+{{ toYaml .Values.nodeAffinity | indent 4 }}
+  {{- end }}
   {{- if .Values.ofedDriver.deploy }}
   ofedDriver:
     image: {{ .Values.ofedDriver.image }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -242,5 +242,9 @@ secondaryNetwork:
     version: v0.5.2-amd64
     # imagePullSecrets: []
 
+# Can be set to nicclusterpolicy and override other ds node affinity,
+# e.g. https://github.com/Mellanox/network-operator/blob/master/manifests/stage-multus-cni/0050-multus-ds.yml#L26-L36
+#nodeAffinity:
+
 test:
   pf: ens2f0


### PR DESCRIPTION
fix: Add field in the nicclusterpolicy helm template to allow setting the nodeAffinity field

related issue: https://github.com/Mellanox/network-operator/issues/310 