### PR TITLE
Update YAMLs to support k8s (kubeadm) new control-plane labels

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,6 +32,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
       serviceAccountName: network-operator
       containers:
         - name: network-operator

--- a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
@@ -22,6 +22,10 @@ spec:
       nodeSelector:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.operator.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}

--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -3,8 +3,22 @@ operator:
     - key: "node-role.kubernetes.io/master"
       operator: "Exists"
       effect: "NoSchedule"
-  nodeSelector:
-    node-role.kubernetes.io/master: ""
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+  nodeSelector: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [ "" ]
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: In
+                values: [ "" ]
   nameOverride: ""
   fullnameOverride: ""
   resourcePrefix: "openshift.io"

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -68,8 +68,19 @@ sriov-network-operator:
       - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
         effect: "NoSchedule"
-    nodeSelector:
-      node-role.kubernetes.io/master: ""
+    nodeSelector: {}
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "node-role.kubernetes.io/master"
+                  operator: In
+                  values: [ "" ]
+            - matchExpressions:
+                - key: "node-role.kubernetes.io/control-plane"
+                  operator: In
+                  values: [ "" ]
     nameOverride: ""
     fullnameOverride: ""
     resourcePrefix: "nvidia.com"

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -39,6 +39,10 @@ node-feature-discovery:
         operator: "Equal"
         value: ""
         effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
       - key: "nvidia.com/gpu"
         operator: "Equal"
         value: "present"
@@ -59,6 +63,9 @@ sriov-network-operator:
   operator:
     tolerations:
       - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
         effect: "NoSchedule"
     nodeSelector:
@@ -88,6 +95,10 @@ operator:
       operator: "Equal"
       value: ""
       effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Equal"
+      value: ""
+      effect: "NoSchedule"
   nodeSelector: {}
   affinity:
     nodeAffinity:
@@ -98,6 +109,12 @@ operator:
               - key: "node-role.kubernetes.io/master"
                 operator: In
                 values: [""]
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: In
+                values: [ "" ]
   repository: nvcr.io/nvidia/cloud-native
   image: network-operator
   imagePullSecrets: []

--- a/manifests/stage-container-networking-plugins/0010-container-networking-plugins-ds.yml
+++ b/manifests/stage-container-networking-plugins/0010-container-networking-plugins-ds.yml
@@ -45,6 +45,8 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/master
                     operator: DoesNotExist
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
         {{- else }}
           {{- .NodeAffinity | yaml | nindent 10 }}
         {{- end}}

--- a/manifests/stage-multus-cni/0050-multus-ds.yml
+++ b/manifests/stage-multus-cni/0050-multus-ds.yml
@@ -29,6 +29,8 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/master
                     operator: DoesNotExist
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
         {{- else }}
           {{- .NodeAffinity | yaml | nindent 10 }}
         {{- end }}

--- a/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
@@ -32,6 +32,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -35,6 +35,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/stage-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -34,6 +34,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule

--- a/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
+++ b/manifests/stage-sriov-device-plugin/0030-sriov-dp-daemonset.yml
@@ -44,6 +44,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -44,6 +44,8 @@ spec:
               - matchExpressions:
                   - key: "node-role.kubernetes.io/master"
                     operator: DoesNotExist
+                  - key: "node-role.kubernetes.io/control-plane"
+                    operator: DoesNotExist
         {{- else }}
           {{- .NodeAffinity | yaml | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
with Kubernetes 1.24, master nodes are now
labeld and tainted as `node-role.kubernetes.io/control-plane`

Support this in Network operator by:

- Extending tolerations in relevant deployment files
- adjusting node affinity in relevant deployment files

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>