### PR TITLE
Update MOFED driver image format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Mellanox/network-operator
 go 1.18
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/caarlos0/env/v6 v6.4.0
 	github.com/go-logr/logr v0.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}-{{ .CrSpec.Version }}:{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.CPUArch }}
+        - image: {{ .RuntimeSpec.MOFEDImageName }}
           imagePullPolicy: IfNotPresent
           name: mofed-container
           securityContext:

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -1,0 +1,72 @@
+/*
+  2022 NVIDIA CORPORATION & AFFILIATES
+
+  Licensed under the Apache License, Version 2.0 (the License);
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an AS IS BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package state
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Mellanox/network-operator/api/v1alpha1"
+	"github.com/Mellanox/network-operator/pkg/nodeinfo"
+)
+
+var _ = Describe("MOFED state test", func() {
+	var stateOfed stateOFED
+
+	BeforeEach(func() {
+		stateOfed = stateOFED{}
+	})
+
+	Context("getMofedDriverImageName", func() {
+		nodeAttr := make(map[nodeinfo.AttributeType]string)
+		nodeAttr[nodeinfo.AttrTypeCPUArch] = "amd64"
+		nodeAttr[nodeinfo.AttrTypeOSName] = "ubuntu"
+		nodeAttr[nodeinfo.AttrTypeOSVer] = "20.04"
+
+		cr := &v1alpha1.NicClusterPolicy{
+			Spec: v1alpha1.NicClusterPolicySpec{
+				OFEDDriver: &v1alpha1.OFEDDriverSpec{
+					ImageSpec: v1alpha1.ImageSpec{
+						Image:      "mofed",
+						Repository: "nvcr.io/mellanox",
+					},
+				},
+			},
+		}
+
+		It("generates old image format", func() {
+			cr.Spec.OFEDDriver.Version = "5.6-1.0.0.0"
+			imageName := stateOfed.getMofedDriverImageName(cr, nodeAttr)
+			Expect(imageName).To(Equal("nvcr.io/mellanox/mofed-5.6-1.0.0.0:ubuntu20.04-amd64"))
+		})
+		It("generates new image format", func() {
+			cr.Spec.OFEDDriver.Version = "5.7-1.0.0.0"
+			imageName := stateOfed.getMofedDriverImageName(cr, nodeAttr)
+			Expect(imageName).To(Equal("nvcr.io/mellanox/mofed:5.7-1.0.0.0-ubuntu20.04-amd64"))
+		})
+		It("generates new image format double digit minor", func() {
+			cr.Spec.OFEDDriver.Version = "5.10-0.0.0.1"
+			imageName := stateOfed.getMofedDriverImageName(cr, nodeAttr)
+			Expect(imageName).To(Equal("nvcr.io/mellanox/mofed:5.10-0.0.0.1-ubuntu20.04-amd64"))
+		})
+		It("return new image format in case of a bad version", func() {
+			cr.Spec.OFEDDriver.Version = "1.1.1.1.1"
+			imageName := stateOfed.getMofedDriverImageName(cr, nodeAttr)
+			Expect(imageName).To(Equal("nvcr.io/mellanox/mofed:1.1.1.1.1-ubuntu20.04-amd64"))
+		})
+	})
+})

--- a/pkg/state/state_suite_test.go
+++ b/pkg/state/state_suite_test.go
@@ -21,7 +21,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+var _ = BeforeSuite(func() {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+})
 
 func TestState(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
starting with MOFED driver version  5.7
the mofed driver container image name format
will change from:
  `<image-repo>/<image-name>-<driver-ver>:<os-name><os-ver>-<cpu-arch>`
to:
  `<image-repo>/<image-name>:<driver-ver>-<os-name><os-ver>-<cpu-arch>`

- Support both formats depending on the driver version
  in state ofed.
- Add unit test for the newly added logic

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>