### PR TITLE
Bump go to 1.18 And Makefile cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
       contents: read
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.15.8'
+          go-version: '1.18'
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: lint
         run: make lint
   lint-docker:
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: lint Dockerfile
         run: make lint-dockerfile
   lint-helm:
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: lint helm chart
         run: make lint-helm
   unit-tests:
@@ -43,10 +43,10 @@ jobs:
       contents: read
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.15.8'
+          go-version: '1.18'
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: test
         run: make test-coverage

--- a/.gitignore
+++ b/.gitignore
@@ -5,15 +5,13 @@
 *.dll
 *.so
 *.dylib
-bin
-testbin/*
 
 # Test binary, build with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-build/_output/
+*.cover
 
 # Kubernetes Generated files - skip generated files, except for vendored files
 
@@ -30,4 +28,6 @@ deployment/network-operator/Chart.lock
 deployment/network-operator/charts/*.tgz
 
 # Folders
-.gopath
+bin
+testbin
+build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - exportloopref
     - funlen
       #- gochecknoinits
       #- goconst
@@ -67,7 +68,6 @@ linters:
     - gocognit
     - gofmt
     - goimports
-    - golint 
     - gomnd
     - goprintffuncname
     - gosec
@@ -78,8 +78,8 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -157,7 +157,7 @@ func (r *NicClusterPolicyReconciler) updateNodeLabels(cr *mellanoxv1alpha1.NicCl
 			if len(pod.Status.ContainerStatuses) != 0 && pod.Status.ContainerStatuses[0].Ready {
 				labelValue = "false"
 			}
-			patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, nodeinfo.NodeLabelWaitOFED, labelValue))
+			patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, nodeinfo.NodeLabelWaitOFED, labelValue))
 			err := r.Client.Patch(context.TODO(), &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: pod.Spec.NodeName,

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,14 @@
 module github.com/Mellanox/network-operator
 
-go 1.15
+go 1.18
 
 require (
 	github.com/caarlos0/env/v6 v6.4.0
 	github.com/go-logr/logr v0.3.0
-	github.com/googleapis/gnostic v0.5.3 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.11.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
@@ -18,6 +16,93 @@ require (
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.1
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.1 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
+	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-logr/zapr v0.2.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.3 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.4 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.11.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/spf13/cobra v1.1.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.26.0-rc.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	k8s.io/apiextensions-apiserver v0.20.1 // indirect
+	k8s.io/cli-runtime v0.20.2 // indirect
+	k8s.io/component-base v0.20.2 // indirect
+	k8s.io/klog/v2 v2.4.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
+	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect
+	sigs.k8s.io/kustomize v2.0.3+incompatible // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.2 // indirect
 )
 
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,6 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/caarlos0/env/v6 v6.4.0 h1:fUo2hQNR3O7Yb7E2sYy8cxY42BRvFxWa0G4XBMLJAQM=
 github.com/caarlos0/env/v6 v6.4.0/go.mod h1:MX/8qQ2zCofGGkb7FxjmDLOOjUylO2b7dbsIpN30bnY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -793,7 +792,6 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -27,7 +27,7 @@ package render
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"text/template"
@@ -36,6 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 	yamlConverter "sigs.k8s.io/yaml"
+)
+
+const (
+	maxBufSizeForYamlDecode = 4096
 )
 
 var ManifestFileSuffix = []string{"yaml", "yml", "json"}
@@ -100,7 +104,7 @@ func nindentPrefix(spaces int, prefix, v string) string {
 // renderFile renders a single file to a list of k8s unstructured objects
 func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData) ([]*unstructured.Unstructured, error) {
 	// Read file
-	txt, err := ioutil.ReadFile(filePath)
+	txt, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest file %s", filePath)
 	}
@@ -137,7 +141,7 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 		return out, nil
 	}
 
-	decoder := yamlDecoder.NewYAMLOrJSONDecoder(&rendered, 4096)
+	decoder := yamlDecoder.NewYAMLOrJSONDecoder(&rendered, maxBufSizeForYamlDecode)
 	for {
 		u := unstructured.Unstructured{}
 		if err := decoder.Decode(&u); err != nil {

--- a/pkg/state/fake_manager.go
+++ b/pkg/state/fake_manager.go
@@ -20,16 +20,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-// nolint:unused
+//nolint:unused
 type fakeMananger struct {
 	watchResources []*source.Kind
 }
 
+//nolint:unused
 // GetWatchSources gets Resources that should be watched by a Controller for this state manager
 func (m *fakeMananger) GetWatchSources() []*source.Kind {
 	return m.watchResources
 }
 
+//nolint:unused
 // SyncState reconciles the state of the system for the custom resource
 func (m *fakeMananger) SyncState(customResource interface{}, infoCatalog InfoCatalog) (Results, error) {
 	return Results{

--- a/pkg/upgrade/node_upgrade_state_provider.go
+++ b/pkg/upgrade/node_upgrade_state_provider.go
@@ -69,7 +69,7 @@ func (p *NodeUpgradeStateProviderImpl) ChangeNodeUpgradeState(
 
 	defer p.nodeMutex.Lock(node.Name)()
 
-	patchString := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s": "%s"}}}`, UpgradeStateAnnotation, newNodeState))
+	patchString := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: %q}}}`, UpgradeStateAnnotation, newNodeState))
 	patch := client.RawPatch(types.StrategicMergePatchType, patchString)
 	err := p.K8sClient.Patch(ctx, node, patch)
 	if err != nil {

--- a/pkg/upgrade/util.go
+++ b/pkg/upgrade/util.go
@@ -18,42 +18,43 @@ import (
 )
 
 type StringSet struct {
-	m map[string]bool
-	sync.RWMutex
+	m  map[string]bool
+	mu sync.RWMutex
 }
 
 func NewStringSet() *StringSet {
 	return &StringSet{
-		m: make(map[string]bool),
+		m:  make(map[string]bool),
+		mu: sync.RWMutex{},
 	}
 }
 
 // Add item to set
 func (s *StringSet) Add(item string) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.m[item] = true
 }
 
 // Remove deletes the specified item from the set
 func (s *StringSet) Remove(item string) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	delete(s.m, item)
 }
 
 // Has looks for item exists in the map
 func (s *StringSet) Has(item string) bool {
-	s.RLock()
-	defer s.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	_, ok := s.m[item]
 	return ok
 }
 
 // Clear removes all items from the set
 func (s *StringSet) Clear() {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.m = make(map[string]bool)
 }
 


### PR DESCRIPTION
This commit bumps go version to 1.18
as a result several changes were needed

- modify Makefile to support go install
- bump golangci lint as the current version did
  not support go 1.18
- update golangci yaml and remove deprecated linters
- update Dockerfile
- Address golangci issues discovered after version bump
- update go.mod (run go mod tidy)

In addition Perform some cleanups in Makefile
mainly getting rid of .gopath folder as it is not
really needed and causes issues when working with some
IDEs

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>