### PR TITLE
Pass http_proxy and https_proxy environments to containers

### DIFF
--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -74,6 +74,14 @@ spec:
             - name: HTTPS_PROXY
               value: {{ .Values.proxy.httpsProxy }}
             {{- end }}
+            {{- if .Values.proxy.httpProxy | empty | not }}
+            - name: http_proxy
+              value: {{ .Values.proxy.httpProxy }}
+            {{- end }}
+            {{- if .Values.proxy.httpsProxy | empty | not }}
+            - name: https_proxy
+              value: {{ .Values.proxy.httpsProxy }}
+            {{- end }}
             {{- if .Values.proxy.noProxy | empty | not }}
             - name: NO_PROXY
               value: {{ .Values.proxy.noProxy }}

--- a/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
+++ b/manifests/stage-nv-peer-mem-driver/0050_nv-peer-mem-driver-ds.yaml
@@ -79,6 +79,10 @@ spec:
               value: {{ .RuntimeSpec.HTTPProxy }}
             - name: HTTPS_PROXY
               value: {{ .RuntimeSpec.HTTPSProxy }}
+            - name: http_proxy
+              value: {{ .RuntimeSpec.HTTPProxy }}
+            - name: https_proxy
+              value: {{ .RuntimeSpec.HTTPSProxy }}
             - name: NO_PROXY
               value: {{ .RuntimeSpec.NoProxy }}
           volumeMounts:

--- a/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0050_ofed-driver-ds.yaml
@@ -66,6 +66,10 @@ spec:
               value: {{ .RuntimeSpec.HTTPProxy }}
             - name: HTTPS_PROXY
               value: {{ .RuntimeSpec.HTTPSProxy }}
+            - name: http_proxy
+              value: {{ .RuntimeSpec.HTTPProxy }}
+            - name: https_proxy
+              value: {{ .RuntimeSpec.HTTPSProxy }}
             - name: NO_PROXY
               value: {{ .RuntimeSpec.NoProxy }}
           {{- if .CrSpec.Env }}


### PR DESCRIPTION
There are no strict rules how these environment variables shold
be named: upper-case or lower-case. To support all scenarios
let's pass both of them into containers witch requires internet
access.

Signed-off-by: Ivan Kolodiazhny <ikolodiazhny@nvidia.com>