### PR TITLE
Fix 'make bundle' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ endif
 
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(TAG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)


### PR DESCRIPTION
We need to download operator-sdk before bundle build action.

Signed-off-by: Ivan Kolodiazhny <ikolodiazhny@nvidia.com>