### PR TITLE
Skip network-operator pod when draining nodes during OFED upgrade

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        nvidia.com/ofed-upgrade.skip-drain: "true"
     spec:
       securityContext:
         runAsUser: 65532

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       labels:
+        nvidia.com/ofed-upgrade.skip-drain: "true"
         name: network-operator
     spec:
       nodeSelector:

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       labels:
+        nvidia.com/ofed-upgrade.skip-drain: "true"
         {{- include "network-operator.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.operator.nodeSelector }}

--- a/pkg/upgrade/consts.go
+++ b/pkg/upgrade/consts.go
@@ -19,7 +19,8 @@ package upgrade
 const (
 	UpgradeStateAnnotation = "nvidia.com/ofed-upgrade-state"
 
-	OfedDriverLabel = "nvidia.com/ofed-driver"
+	OfedDriverLabel           = "nvidia.com/ofed-driver"
+	OfedUpgradeSkipDrainLabel = "nvidia.com/ofed-upgrade.skip-drain"
 
 	// UpgradeStateUnknown Node has this state when the upgrade flow is disabled or the node hasn't been processed yet
 	UpgradeStateUnknown = ""


### PR DESCRIPTION
We want to skip network-operator itself during the drain because the upgrade process might hang if the operator is evicted and can't be rescheduled to any other node, e.g. in a single-node cluster.
It's safe to do because the goal of the node draining during the upgrade is to evict pods that might use MOFED and network-operator doesn't use in its own pod.

Signed-off-by: amaslennikov <amaslennikov@nvidia.com>