### PR TITLE
Add minimum validation for Ofed upgrade

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -144,6 +144,7 @@ type DrainSpec struct {
 	// TimeoutSecond specifies the length of time in seconds to wait before giving up drain, zero means infinite
 	// +optional
 	// +kubebuilder:default:=0
+	// +kubebuilder:validation:Minimum:=0
 	TimeoutSecond int `json:"timeoutSeconds,omitempty"`
 	// DeleteEmptyDir indicates if should continue even if there are pods using emptyDir
 	// (local data that will be deleted when the node is drained)
@@ -163,6 +164,7 @@ type OfedUpgradePolicySpec struct {
 	// 0 means no limit, all nodes will be upgraded in parallel
 	// +optional
 	// +kubebuilder:default:=1
+	// +kubebuilder:validation:Minimum:=0
 	MaxParallelUpgrades int        `json:"maxParallelUpgrades,omitempty"`
 	DrainSpec           *DrainSpec `json:"drain,omitempty"`
 }

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -470,6 +470,7 @@ spec:
                             description: TimeoutSecond specifies the length of time
                               in seconds to wait before giving up drain, zero means
                               infinite
+                            minimum: 0
                             type: integer
                         type: object
                       maxParallelUpgrades:
@@ -477,6 +478,7 @@ spec:
                         description: MaxParallelUpgrades indicates how many nodes
                           can be upgraded in parallel 0 means no limit, all nodes
                           will be upgraded in parallel
+                        minimum: 0
                         type: integer
                     type: object
                   version:

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -470,6 +470,7 @@ spec:
                             description: TimeoutSecond specifies the length of time
                               in seconds to wait before giving up drain, zero means
                               infinite
+                            minimum: 0
                             type: integer
                         type: object
                       maxParallelUpgrades:
@@ -477,6 +478,7 @@ spec:
                         description: MaxParallelUpgrades indicates how many nodes
                           can be upgraded in parallel 0 means no limit, all nodes
                           will be upgraded in parallel
+                        minimum: 0
                         type: integer
                     type: object
                   version:


### PR DESCRIPTION
Add minimum validation for Ofed Upgrade parameters
in NicClusterPolicy CRD. (TimeoutSecond, MaxParallelUpgrades)

Signed-off-by: Fred Rolland <frolland@nvidia.com>