### PR TITLE
Update OCP deployment examples with OFED upgradePolicy

### DIFF
--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -52,6 +52,16 @@ metadata:
                 "initialDelaySeconds": 10,
                 "periodSeconds": 20
               },
+               "upgradePolicy": {
+                "autoUpgrade": false,
+                "drain": {
+                    "deleteEmptyDir": true,
+                    "enable": true,
+                    "force": true,
+                    "timeoutSeconds": 0
+                },
+                "maxParallelUpgrades": 1
+              },
               "version": "5.6-1.0.3.3"
             },
             "rdmaSharedDevicePlugin": {

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
@@ -19,7 +19,15 @@ spec:
   ofedDriver:
     image: mofed
     repository: mellanox
-    version: 5.5-1.0.3.2
+    version: 5.6-1.0.3.3
+    upgradePolicy:
+      autoUpgrade: false
+      drain:
+        deleteEmptyDir: true
+        enable: true
+        force: true
+        timeoutSeconds: 0
+      maxParallelUpgrades: 1
   sriovDevicePlugin:
     config: |
       {

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -19,7 +19,15 @@ spec:
   ofedDriver:
     image: mofed
     repository: mellanox
-    version: 5.5-1.0.3.2
+    version: 5.6-1.0.3.3
+    upgradePolicy:
+      autoUpgrade: false
+      drain:
+        deleteEmptyDir: true
+        enable: true
+        force: true
+        timeoutSeconds: 0
+      maxParallelUpgrades: 1
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: nvcr.io/nvidia/cloud-native


### PR DESCRIPTION
We need to set deleteEmptyDir=true and force=true for node draining
settings to work with default OCP installation.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>