### PR TITLE
Add Uncordon state in print

### DIFF
--- a/pkg/upgrade/upgrade_state.go
+++ b/pkg/upgrade/upgrade_state.go
@@ -110,7 +110,8 @@ func (m *ClusterUpgradeStateManager) ApplyState(ctx context.Context,
 		UpgradeStateUpgradeRequired, len(currentState.NodeStates[UpgradeStateUpgradeRequired]),
 		UpgradeStateDrain, len(currentState.NodeStates[UpgradeStateDrain]),
 		UpgradeStateDrainFailed, len(currentState.NodeStates[UpgradeStateDrainFailed]),
-		UpgradeStatePodRestart, len(currentState.NodeStates[UpgradeStatePodRestart]))
+		UpgradeStatePodRestart, len(currentState.NodeStates[UpgradeStatePodRestart]),
+		UpgradeStateUncordonRequired, len(currentState.NodeStates[UpgradeStateUncordonRequired]))
 
 	upgradesInProgress := len(currentState.NodeStates[UpgradeStateDrain]) +
 		len(currentState.NodeStates[UpgradeStatePodRestart]) +


### PR DESCRIPTION
In MOFED upgrade flow, add "uncordon-required" count
in state print.

Signed-off-by: Fred Rolland <frolland@nvidia.com>