### PR TITLE
Set a default timeout for node drain in OFED auto-upgrade config

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -143,7 +143,7 @@ type DrainSpec struct {
 	PodSelector string `json:"podSelector,omitempty"`
 	// TimeoutSecond specifies the length of time in seconds to wait before giving up drain, zero means infinite
 	// +optional
-	// +kubebuilder:default:=0
+	// +kubebuilder:default:=300
 	// +kubebuilder:validation:Minimum:=0
 	TimeoutSecond int `json:"timeoutSeconds,omitempty"`
 	// DeleteEmptyDir indicates if should continue even if there are pods using emptyDir

--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
                     "deleteEmptyDir": true,
                     "enable": true,
                     "force": true,
-                    "timeoutSeconds": 0
+                    "timeoutSeconds": 300
                 },
                 "maxParallelUpgrades": 1
               },

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -466,7 +466,7 @@ spec:
                               more details on label selectors, see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
                             type: string
                           timeoutSeconds:
-                            default: 0
+                            default: 300
                             description: TimeoutSecond specifies the length of time
                               in seconds to wait before giving up drain, zero means
                               infinite

--- a/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
+++ b/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
@@ -44,7 +44,7 @@ spec:
         enable: true
         force: false
         podSelector: ""
-        timeoutSeconds: 0
+        timeoutSeconds: 300
         deleteEmptyDir: false
   sriovDevicePlugin:
     image: sriov-device-plugin

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -466,7 +466,7 @@ spec:
                               more details on label selectors, see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
                             type: string
                           timeoutSeconds:
-                            default: 0
+                            default: 300
                             description: TimeoutSecond specifies the length of time
                               in seconds to wait before giving up drain, zero means
                               infinite

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -58,7 +58,7 @@ spec:
         enable: {{ .Values.ofedDriver.upgradePolicy.drain.enable | default true }}
         force: {{ .Values.ofedDriver.upgradePolicy.drain.force | default false }}
         podSelector: {{ .Values.ofedDriver.upgradePolicy.drain.podSelector}}
-        timeoutSeconds: {{ .Values.ofedDriver.upgradePolicy.drain.timeoutSeconds | default 0}}
+        timeoutSeconds: {{ .Values.ofedDriver.upgradePolicy.drain.timeoutSeconds }}
         deleteEmptyDir: {{ .Values.ofedDriver.upgradePolicy.drain.deleteEmptyDir | default false}}
     {{- end }}
   {{- end }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -179,7 +179,8 @@ ofedDriver:
       enable: true
       force: false
       podSelector: ""
-      timeoutSeconds: 0
+      # It's recommended to set a timeout to avoid infinite drain in case non-fatal error keeps happening on retries
+      timeoutSeconds: 300
       deleteEmptyDir: false
 
 nvPeerDriver:

--- a/docs/automatic-ofed-upgrade.md
+++ b/docs/automatic-ofed-upgrade.md
@@ -35,7 +35,8 @@ spec:
         # specify a label selector to filter pods on the node that need to be drained
         podSelector: ""
         # specify the length of time in seconds to wait before giving up drain, zero means infinite
-        timeoutSeconds: 0
+        # if not specified, the default is 300 seconds
+        timeoutSeconds: 300
         # specify if should continue even if there are pods using emptyDir
         deleteEmptyDir: false
 ```

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
@@ -26,7 +26,7 @@ spec:
         deleteEmptyDir: true
         enable: true
         force: true
-        timeoutSeconds: 0
+        timeoutSeconds: 300
       maxParallelUpgrades: 1
   sriovDevicePlugin:
     config: |

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -26,7 +26,7 @@ spec:
         deleteEmptyDir: true
         enable: true
         force: true
-        timeoutSeconds: 0
+        timeoutSeconds: 300
       maxParallelUpgrades: 1
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin


### PR DESCRIPTION
When attempting to drain a node, a non-fatal error might occur and the drain library will retry the action which caused this error in a few seconds (for example, evicting the pod violates the deployment's disruption budget).
If the error's cause is not fixed, there will be infinite retries unless the drain is terminated by timeout.
Since drain operation is disruptive and makes the node unschedulable, introducing the default timeout to avoid taking the node out of action indefinitely.

Signed-off-by: Alexander Maslennikov<amaslennikov@nvidia.com>