### PR TITLE
Set maxParallelUpgrades as 1 by default to be least disruptive.

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -168,9 +168,9 @@ ofedDriver:
     # global switch for automatic upgrade feature
     # if set to false all other options are ignored
     autoUpgrade: false
-    # how many nodes can be upgraded in parallel
+    # how many nodes can be upgraded in parallel (default: 1)
     # 0 means no limit, all nodes will be upgraded in parallel
-    maxParallelUpgrades: 0
+    maxParallelUpgrades: 1
     # options for node drain (`kubectl drain`) before the driver reload
     # if auto upgrade is enabled but drain.enable is false,
     # then driver POD will be reloaded immediately without


### PR DESCRIPTION
Signed-off-by: Shiva Krishna, Merla <smerla@nvidia.com>