### PR TITLE
update psp permissions in clusterrole

### DIFF
--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -227,6 +227,7 @@ rules:
       - get
       - update
       - list
+      - watch
   - apiGroups:
       - policy
     resources:


### PR DESCRIPTION
The kube client used in the Network Operators seems to perfom Watch operations on the resources. If the `watch` permission isn't provided, the pod logs get inundated with the following errors:

```
reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.PodSecurityPolicy: unknown (get podsecuritypolicies.policy)
```