### PR TITLE
Add control-plane toleration for ib-kubernetes

### DIFF
--- a/manifests/stage-ib-kubernetes/0070-deployment.yaml
+++ b/manifests/stage-ib-kubernetes/0070-deployment.yaml
@@ -71,6 +71,13 @@ spec:
                     values:
                       - ib-kubernetes
               topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: ib-kubernetes
           image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}


### PR DESCRIPTION
We want to schedule ib-kubernetes pod onto the control plane, so in order to pass the control-plane taint, we need to add a corresponding toleration to the deployment spec

Signed-off-by: amaslennikov <amaslennikov@nvidia.com>