### PR TITLE
Deploy default SriovNetworkNodePolicy by helm chart

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetworknodepolicy.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/sriovnetworknodepolicy.yaml
@@ -1,0 +1,10 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: default
+  namespace: {{ .Release.Namespace }}
+spec:
+  nicSelector: {}
+  nodeSelector: {}
+  numVfs: 0
+  resourceName: ""


### PR DESCRIPTION
The owner of SR-IOV Device Plugin daemonset is default policy so it will be deleted both with a defaut during helm uninstall procedure.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>