### PR TITLE
Change ib-kubernetes update strategy to Recreate

### DIFF
--- a/manifests/stage-ib-kubernetes/0070-deployment.yaml
+++ b/manifests/stage-ib-kubernetes/0070-deployment.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   progressDeadlineSeconds: 600
   strategy:
-    type: RollingUpdate
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -62,15 +62,6 @@ spec:
                     operator: In
                     values:
                       - "linux"
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                      - ib-kubernetes
-              topologyKey: kubernetes.io/hostname
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"


### PR DESCRIPTION
When RollingUpdate strategy is used, the old pod is only deleted when the new pod gets to the running state, to reduce the downtime. https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/
However, for ib-kubernetes we specified the anti affinity, which prevent two ib-kubernetes pods running on the same node. In this case, when the deployment is updated, the new pod is forever pending because the old one is not deleted.

To fix this, changing the update strategy to Recreate.

Signed-off-by: amaslennikov <amaslennikov@nvidia.com>