### PR TITLE
Support delete of resources

### DIFF
--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -53,6 +53,7 @@ type NicClusterPolicyReconciler struct {
 	stateManager state.Manager
 }
 
+// In case of adding support for additional types, also update in getSupportedGVKs func in pkg/state/state_skel.go
 //nolint
 // +kubebuilder:rbac:groups=mellanox.com,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/nicclusterpolicy_controller_test.go
+++ b/controllers/nicclusterpolicy_controller_test.go
@@ -1,0 +1,141 @@
+/*
+2023 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers //nolint:dupl
+
+import (
+	goctx "context"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
+	"github.com/Mellanox/network-operator/pkg/consts"
+)
+
+//nolint:dupl
+var _ = Describe("NicClusterPolicyReconciler Controller", func() {
+
+	Context("When NicClusterPolicy CR is created", func() {
+		It("should create whereabouts and delete it after un-setting CR value", func() {
+			By("Check NicClusterPolicy with whereabouts")
+			cr := mellanoxv1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nic-cluster-policy",
+					Namespace: "",
+				},
+				Spec: mellanoxv1alpha1.NicClusterPolicySpec{
+					SecondaryNetwork: &mellanoxv1alpha1.SecondaryNetworkSpec{
+						IpamPlugin: &mellanoxv1alpha1.ImageSpec{
+							Image:            "whereabouts",
+							Repository:       "ghcr.io/k8snetworkplumbingwg",
+							Version:          "v0.5.4-amd64",
+							ImagePullSecrets: []string{},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(goctx.TODO(), &cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			ncp := &mellanoxv1alpha1.NicClusterPolicy{}
+			err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: cr.GetNamespace(), Name: cr.GetName()}, ncp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check DS created with state label")
+			Eventually(func() bool {
+				ds := &appsv1.DaemonSet{}
+				err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "whereabouts"}, ds)
+				if err != nil {
+					return false
+				}
+				l, ok := ds.Labels[consts.StateLabel]
+				if !ok {
+					return false
+				}
+				return l == "state-whereabouts-cni"
+			}, timeout*3, interval).Should(BeTrue())
+
+			By("Check SA created with state label")
+			Eventually(func() bool {
+				ds := &corev1.ServiceAccount{}
+				err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "whereabouts"}, ds)
+				if err != nil {
+					return false
+				}
+				l, ok := ds.Labels[consts.StateLabel]
+				if !ok {
+					return false
+				}
+				return l == "state-whereabouts-cni"
+			}, timeout*3, interval).Should(BeTrue())
+
+			By("Update CR to remove whereabout")
+			ncp = &mellanoxv1alpha1.NicClusterPolicy{}
+			err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: cr.GetNamespace(), Name: cr.GetName()}, ncp)
+			Expect(err).NotTo(HaveOccurred())
+
+			ncp.Spec.SecondaryNetwork = nil
+			err = k8sClient.Update(goctx.TODO(), ncp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check DS is deleted")
+			Eventually(func() bool {
+				ds := &appsv1.DaemonSet{}
+				err := k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "whereabouts"}, ds)
+				return errors.IsNotFound(err)
+			}, timeout*3, interval).Should(BeTrue())
+
+			By("Check SA is deleted")
+			Eventually(func() bool {
+				sa := &corev1.ServiceAccount{}
+				err := k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "whereabouts"}, sa)
+				return errors.IsNotFound(err)
+			}, timeout*3, interval).Should(BeTrue())
+
+			By("Delete NicClusterPolicy")
+			err = k8sClient.Delete(goctx.TODO(), &cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Unsupported name", func() {
+			cr := mellanoxv1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "",
+				},
+			}
+			err := k8sClient.Create(goctx.TODO(), &cr)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() string {
+				found := &mellanoxv1alpha1.NicClusterPolicy{}
+				err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: cr.GetNamespace(), Name: cr.GetName()}, found)
+				Expect(err).NotTo(HaveOccurred())
+				return string(found.Status.State)
+			}, timeout*3, interval).Should(BeEquivalentTo(mellanoxv1alpha1.StateIgnore))
+
+			err = k8sClient.Delete(goctx.TODO(), &cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -131,6 +131,7 @@ rules:
       - ""
     resources:
       - nodes
+      - serviceaccounts
     verbs:
       - get
       - list
@@ -169,6 +170,8 @@ rules:
     resources:
       - clusterrolebindings
       - clusterroles
+      - roles
+      - rolebindings
     verbs:
       - create
       - delete

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -31,4 +31,5 @@ const (
 const (
 	NicClusterPolicyResourceName = "nic-cluster-policy"
 	OfedDriverLabel              = "nvidia.com/ofed-driver"
+	StateLabel                   = "nvidia.network-operator.state"
 )

--- a/pkg/state/state_cni_plugins.go
+++ b/pkg/state/state_cni_plugins.go
@@ -76,10 +76,7 @@ func (s *stateCNIPlugins) Sync(customResource interface{}, infoCatalog InfoCatal
 	if cr.Spec.SecondaryNetwork == nil || cr.Spec.SecondaryNetwork.CniPlugins == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		// TODO: Support the latter case
-		log.V(consts.LogLevelInfo).Info("Secondary Network Container Networking CNI Plugins spec in CR is nil, no " +
-			"action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	objs, err := s.getManifestObjects(cr)

--- a/pkg/state/state_ib_kubernetes.go
+++ b/pkg/state/state_ib_kubernetes.go
@@ -79,8 +79,7 @@ func (s *stateIBKubernetes) Sync(customResource interface{}, infoCatalog InfoCat
 	if cr.Spec.IBKubernetes == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		log.V(consts.LogLevelInfo).Info("ib-kubernetes spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 
 	nodeInfo := infoCatalog.GetNodeInfoProvider()

--- a/pkg/state/state_ipoib_cni.go
+++ b/pkg/state/state_ipoib_cni.go
@@ -79,9 +79,7 @@ func (s *stateIPoIBCNI) Sync(customResource interface{}, infoCatalog InfoCatalog
 	if cr.Spec.SecondaryNetwork == nil || cr.Spec.SecondaryNetwork.IPoIB == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		// TODO: Support the latter case
-		log.V(consts.LogLevelInfo).Info("Secondary Network IPoIBCNI spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	nodeInfo := infoCatalog.GetNodeInfoProvider()

--- a/pkg/state/state_multus_cni.go
+++ b/pkg/state/state_multus_cni.go
@@ -73,9 +73,7 @@ func (s *stateMultusCNI) Sync(customResource interface{}, infoCatalog InfoCatalo
 	if cr.Spec.SecondaryNetwork == nil || cr.Spec.SecondaryNetwork.Multus == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		// TODO: Support the latter case
-		log.V(consts.LogLevelInfo).Info("Secondary Network Multus spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	objs, err := s.getManifestObjects(cr)

--- a/pkg/state/state_nv_peer.go
+++ b/pkg/state/state_nv_peer.go
@@ -77,9 +77,7 @@ func (s *stateNVPeer) Sync(customResource interface{}, infoCatalog InfoCatalog) 
 	if cr.Spec.NVPeerDriver == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		// TODO: Support the latter case
-		log.V(consts.LogLevelInfo).Info("NV Peer driver spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	nodeInfo := infoCatalog.GetNodeInfoProvider()

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -247,9 +247,7 @@ func (s *stateOFED) Sync(customResource interface{}, infoCatalog InfoCatalog) (S
 	if cr.Spec.OFEDDriver == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		// TODO: Support the latter case
-		log.V(consts.LogLevelInfo).Info("OFED driver spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	nodeInfo := infoCatalog.GetNodeInfoProvider()

--- a/pkg/state/state_pod_security_policy.go
+++ b/pkg/state/state_pod_security_policy.go
@@ -73,8 +73,7 @@ func (s *statePodSecurityPolicy) Sync(customResource interface{}, infoCatalog In
 	if cr.Spec.PSP == nil || !cr.Spec.PSP.Enabled {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		log.V(consts.LogLevelInfo).Info("pod security policy is not enabled, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 
 	objs, err := s.getManifestObjects()

--- a/pkg/state/state_shared_dp.go
+++ b/pkg/state/state_shared_dp.go
@@ -79,8 +79,7 @@ func (s *stateSharedDp) Sync(customResource interface{}, infoCatalog InfoCatalog
 	if cr.Spec.RdmaSharedDevicePlugin == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		log.V(consts.LogLevelInfo).Info("Device plugin spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	nodeInfo := infoCatalog.GetNodeInfoProvider()

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -81,8 +81,7 @@ func (s *stateSriovDp) Sync(customResource interface{}, infoCatalog InfoCatalog)
 	if cr.Spec.SriovDevicePlugin == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		log.V(consts.LogLevelInfo).Info("Device plugin spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	nodeInfo := infoCatalog.GetNodeInfoProvider()

--- a/pkg/state/state_whereabouts_cni.go
+++ b/pkg/state/state_whereabouts_cni.go
@@ -73,9 +73,7 @@ func (s *stateWhereaboutsCNI) Sync(customResource interface{}, infoCatalog InfoC
 	if cr.Spec.SecondaryNetwork == nil || cr.Spec.SecondaryNetwork.IpamPlugin == nil {
 		// Either this state was not required to run or an update occurred and we need to remove
 		// the resources that where created.
-		// TODO: Support the latter case
-		log.V(consts.LogLevelInfo).Info("Secondary Network Whereabouts spec in CR is nil, no action required")
-		return SyncStateIgnore, nil
+		return s.handleStateObjectsDeletion()
 	}
 	// Fill ManifestRenderData and render objects
 	objs, err := s.getManifestObjects(cr)


### PR DESCRIPTION
In case the user deletes a subsection of the
NicClusterPolicy, created resources needs to be deleted.

The state of the stage will be `notReady` until all resources are deleted. Then it will move to `ignore`.