### PR TITLE
Add sriovNetworkOperator.configDaemonNodeSelector to Helm values

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -331,18 +331,19 @@ parameters.
 
 ### General parameters
 
-| Name | Type | Default | description                                                                                                          |
-| ---- | ---- | ------- |----------------------------------------------------------------------------------------------------------------------|
-| `nfd.enabled` | bool | `True` | deploy Node Feature Discovery                                                                                        |
-| `sriovNetworkOperator.enabled` | bool | `False` | deploy SR-IOV Network Operator                                                                                       |
-| `psp.enabled` | bool | `False` | deploy Pod Security Policy                                                                                           |
-| `imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling any of the Network Operator image if it's not overrided |
-| `operator.repository` | string | `nvcr.io/nvidia/cloud-native` | Network Operator image repository                                                                                    |
-| `operator.image` | string | `network-operator` | Network Operator image name                                                                                          |
-| `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used                                    |
-| `operator.imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling Network Operator image                                  |
-| `deployCR` | bool | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters                                           |
-| `nodeAffinity` | yaml | `` | Override the node affinity for various Daemonsets deployed by network operator, e.g. whereabouts, multus, cni-plugins.  |
+| Name | Type   | Default | description                                                                                                                                                |
+| ---- |--------| ------- |------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nfd.enabled` | bool   | `True` | deploy Node Feature Discovery                                                                                                                              |
+| `sriovNetworkOperator.enabled` | bool   | `False` | deploy SR-IOV Network Operator                                                                                                                             |
+| `sriovNetworkOperator.configDaemonNodeSelectorExtra` | object     | `{"node-role.kubernetes.io/worker": ""}` | Additional nodeSelector for sriov-network-operator config daemon. These values will be added in addition to default values managed by the network-operator.|
+| `psp.enabled` | bool   | `False` | deploy Pod Security Policy                                                                                                                                 |
+| `imagePullSecrets` | list   | `[]` | An optional list of references to secrets to use for pulling any of the Network Operator image if it's not overrided                                       |
+| `operator.repository` | string | `nvcr.io/nvidia/cloud-native` | Network Operator image repository                                                                                                                          |
+| `operator.image` | string | `network-operator` | Network Operator image name                                                                                                                                |
+| `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used                                                                          |
+| `operator.imagePullSecrets` | list   | `[]` | An optional list of references to secrets to use for pulling Network Operator image                                                                        |
+| `deployCR` | bool   | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters                                                                                 |
+| `nodeAffinity` | yaml   | `` | Override the node affinity for various Daemonsets deployed by network operator, e.g. whereabouts, multus, cni-plugins.                                     |
 
 #### imagePullSecrets customization
 

--- a/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
+++ b/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
@@ -24,8 +24,7 @@ spec:
   enableInjector: false
   enableOperatorWebhook: false
   configDaemonNodeSelector:
-    beta.kubernetes.io/os: linux
-    node-role.kubernetes.io/worker: ""
-    network.nvidia.com/operator.mofed.wait: "false"
+    {{- $defaults := dict "beta.kubernetes.io/os" "linux" "network.nvidia.com/operator.mofed.wait" "false" }}
+    {{- $selectors := merge  $defaults .Values.sriovNetworkOperator.configDaemonNodeSelectorExtra}}
+    {{- toYaml $selectors | nindent 4 }}
 {{ end }}
-

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -24,6 +24,9 @@ psp:
 
 sriovNetworkOperator:
   enabled: false
+  # inject additional values to nodeSelector for config daemon
+  configDaemonNodeSelectorExtra:
+    node-role.kubernetes.io/worker: ""
 
 # Node Feature discovery chart related values
 node-feature-discovery:


### PR DESCRIPTION
This option allows to configure nodeSelector
for sriov-network-operator daemon

Examples:

**Defaults**
```
helm template -n test  --set sriovNetworkOperator.enabled=true  . | grep -A 30 SriovOperatorConfig
kind: SriovOperatorConfig
metadata:
  name: default
  namespace: test
spec:
  # Add fields here
  enableInjector: false
  enableOperatorWebhook: false
  configDaemonNodeSelector:
    beta.kubernetes.io/os: linux
    network.nvidia.com/operator.mofed.wait: "false"
    node-role.kubernetes.io/worker: ""
```

**unset  node-role.kubernetes.io/worker: ""**
```
helm template -n test     --set sriovNetworkOperator.enabled=true --set sriovNetworkOperator.configDaemonNodeSelectorExtra."node-role\.kubernetes\.io/worker"=null  . | grep -A 30 SriovOperatorConfig
kind: SriovOperatorConfig
metadata:
  name: default
  namespace: test
spec:
  # Add fields here
  enableInjector: false
  enableOperatorWebhook: false
  configDaemonNodeSelector:
    beta.kubernetes.io/os: linux
    network.nvidia.com/operator.mofed.wait: "false"
```

**can't overwrite default values**
```
helm template -n test --set sriovNetworkOperator.enabled=true --set sriovNetworkOperator.configDaemonNodeSelectorExtra."network\.nvidia\.com/operator\.mofed\.wait"=foobar  . | grep -A 30 SriovOperatorConfig
kind: SriovOperatorConfig
metadata:
  name: default
  namespace: test
spec:
  # Add fields here
  enableInjector: false
  enableOperatorWebhook: false
  configDaemonNodeSelector:
    beta.kubernetes.io/os: linux
    network.nvidia.com/operator.mofed.wait: "false"
    node-role.kubernetes.io/worker: ""
```