### PR TITLE
Use server-side apply to update objects

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 
 	mellanoxcomv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/controllers"
+	"github.com/Mellanox/network-operator/pkg/consts"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -107,7 +108,10 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	clientConf := ctrl.GetConfigOrDie()
+	clientConf.UserAgent = consts.KubernetesClientUserAgent
+
+	mgr, err := ctrl.NewManager(clientConf, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -32,4 +32,5 @@ const (
 	NicClusterPolicyResourceName = "nic-cluster-policy"
 	OfedDriverLabel              = "nvidia.com/ofed-driver"
 	StateLabel                   = "nvidia.network-operator.state"
+	KubernetesClientUserAgent    = "nvidia.network-operator"
 )

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/Mellanox/network-operator/pkg/consts"
 	"github.com/Mellanox/network-operator/pkg/nodeinfo"
@@ -164,10 +165,16 @@ func (s *stateSkel) checkDeleteSupported(obj *unstructured.Unstructured) {
 
 func (s *stateSkel) updateObj(obj *unstructured.Unstructured) error {
 	log.V(consts.LogLevelInfo).Info("Updating Object", "Namespace:", obj.GetNamespace(), "Name:", obj.GetName())
-	// Note: Some objects may require update of the resource version
-	// TODO: using Patch preserves runtime attributes. In the future consider using patch if relevant
-	desired := obj.DeepCopy()
-	if err := s.client.Update(context.TODO(), desired); err != nil {
+	applyPatchData, err := yaml.Marshal(obj)
+	if err != nil {
+		log.V(consts.LogLevelError).Error(err, "failed to encode apply patch data")
+		return err
+	}
+	patchUseForce := true
+	// use server-side apply
+	if err := s.client.Patch(context.TODO(), obj, client.RawPatch(types.ApplyPatchType, applyPatchData),
+		client.FieldOwner(consts.KubernetesClientUserAgent),
+		&client.PatchOptions{Force: &patchUseForce}); err != nil {
 		return errors.Wrap(err, "failed to update resource")
 	}
 	log.V(consts.LogLevelInfo).Info("Object updated successfully")
@@ -194,16 +201,6 @@ func (s *stateSkel) createOrUpdateObjs(
 		}
 		if !k8serrors.IsAlreadyExists(err) {
 			// Some error occurred
-			return err
-		}
-
-		currentObj := desiredObj.DeepCopy()
-		if err := s.getObj(currentObj); err != nil {
-			// Some error occurred
-			return err
-		}
-
-		if err := s.mergeObjects(desiredObj, currentObj); err != nil {
 			return err
 		}
 
@@ -267,44 +264,6 @@ func (s *stateSkel) deleteStateRelatedObjects() (bool, error) {
 		}
 	}
 	return found, nil
-}
-
-func (s *stateSkel) mergeObjects(updated, current *unstructured.Unstructured) error {
-	// Set resource version
-	// ResourceVersion must be passed unmodified back to the server.
-	// ResourceVersion helps the kubernetes API server to implement optimistic concurrency for PUT operations
-	// when two PUT requests are specifying the resourceVersion, one of the PUTs will fail.
-	updated.SetResourceVersion(current.GetResourceVersion())
-
-	gvk := updated.GroupVersionKind()
-	if gvk.Group == "" && gvk.Kind == "ServiceAccount" {
-		return s.mergeServiceAccount(updated, current)
-	}
-	return nil
-}
-
-// For Service Account, keep secrets if exists
-func (s *stateSkel) mergeServiceAccount(updated, current *unstructured.Unstructured) error {
-	curSecrets, ok, err := unstructured.NestedSlice(current.Object, "secrets")
-	if err != nil {
-		return err
-	}
-	if ok {
-		if err := unstructured.SetNestedField(updated.Object, curSecrets, "secrets"); err != nil {
-			return err
-		}
-	}
-
-	curImagePullSecrets, ok, err := unstructured.NestedSlice(current.Object, "imagePullSecrets")
-	if err != nil {
-		return err
-	}
-	if ok {
-		if err := unstructured.SetNestedField(updated.Object, curImagePullSecrets, "imagePullSecrets"); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // Iterate over objects and check for their readiness


### PR DESCRIPTION
Replace Update call (replace) to k8s API with server-side apply call to preserve fields which were set in runtime.

Fixes an issue with never ending synchronization
on k8s > 1.25

related issue #482 