### PR TITLE
Update golang to 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: checkout
         uses: actions/checkout@v3
       - name: lint
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: checkout
         uses: actions/checkout@v3
       - name: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ GOLANGCI_LINT = $(TOOLSDIR)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.49.0
+GOLANGCI_LINT_VER = v1.52.2
 
 HADOLINT = $(TOOLSDIR)/hadolint
 HADOLINT_VER = v1.23.0

--- a/controllers/hostdevicenetwork_controller.go
+++ b/controllers/hostdevicenetwork_controller.go
@@ -55,7 +55,7 @@ type HostDeviceNetworkReconciler struct {
 // move the current state of the cluster closer to the desired state.
 //
 //nolint:dupl
-func (r *HostDeviceNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *HostDeviceNetworkReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("hostdevicenetwork", req.NamespacedName)
 	reqLogger.Info("Reconciling HostDeviceNetwork")
 

--- a/controllers/ipoibnetwork_controller.go
+++ b/controllers/ipoibnetwork_controller.go
@@ -56,7 +56,7 @@ type IPoIBNetworkReconciler struct {
 // move the current state of the cluster closer to the desired state.
 //
 //nolint:dupl
-func (r *IPoIBNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *IPoIBNetworkReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("ipoibnetwork", req.NamespacedName)
 	reqLogger.Info("Reconciling IPoIBNetwork")
 

--- a/controllers/macvlannetwork_controller.go
+++ b/controllers/macvlannetwork_controller.go
@@ -57,7 +57,7 @@ type MacvlanNetworkReconciler struct {
 // move the current state of the cluster closer to the desired state.
 //
 //nolint:dupl
-func (r *MacvlanNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MacvlanNetworkReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("macvlannetwork", req.NamespacedName)
 	reqLogger.Info("Reconciling MacvlanNetwork")
 

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -78,7 +78,7 @@ type NicClusterPolicyReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *NicClusterPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *NicClusterPolicyReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("nicclusterpolicy", req.NamespacedName)
 	reqLogger.V(consts.LogLevelInfo).Info("Reconciling NicClusterPolicy")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mellanox/network-operator
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
@@ -113,5 +113,3 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
-
-replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5F
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -296,6 +298,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0 h1:MjRRgZyTGo90G+UrwlDQjU+uG4Z7By65qvQxGoILT/8=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
+github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -655,6 +658,7 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858 h1:Dpdu/EMxGMFgq0CeYMh4fazTD2vtlZRYE7wyynxJb9U=
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/pkg/nodeinfo/node_info_test.go
+++ b/pkg/nodeinfo/node_info_test.go
@@ -29,7 +29,7 @@ type dummyFilter struct {
 	filtered []*corev1.Node
 }
 
-func (df *dummyFilter) Apply(nodes []*corev1.Node) []*corev1.Node {
+func (df *dummyFilter) Apply(_ []*corev1.Node) []*corev1.Node {
 	df.called = true
 	return df.filtered
 }

--- a/pkg/state/fake_manager.go
+++ b/pkg/state/fake_manager.go
@@ -35,7 +35,7 @@ func (m *fakeMananger) GetWatchSources() []*source.Kind {
 // SyncState reconciles the state of the system for the custom resource
 //
 //nolint:unused
-func (m *fakeMananger) SyncState(customResource interface{}, infoCatalog InfoCatalog) (Results, error) {
+func (m *fakeMananger) SyncState(_ interface{}, _ InfoCatalog) (Results, error) {
 	return Results{
 		Status:       SyncStateNotReady,
 		StatesStatus: nil,

--- a/pkg/state/fake_state.go
+++ b/pkg/state/fake_state.go
@@ -38,7 +38,7 @@ func (s *fakeState) Description() string {
 
 // Sync attempt to get the system to match the desired state which State represent.
 // a sync operation must be relatively short and must not block the execution thread.
-func (s *fakeState) Sync(customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *fakeState) Sync(_ interface{}, _ InfoCatalog) (SyncState, error) {
 	return s.syncState, nil
 }
 

--- a/pkg/state/state_cni_plugins.go
+++ b/pkg/state/state_cni_plugins.go
@@ -68,7 +68,7 @@ type CNIPluginsManifestRenderData struct {
 // a sync operation must be relatively short and must not block the execution thread.
 //
 //nolint:dupl
-func (s *stateCNIPlugins) Sync(customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *stateCNIPlugins) Sync(customResource interface{}, _ InfoCatalog) (SyncState, error) {
 	cr := customResource.(*mellanoxv1alpha1.NicClusterPolicy)
 	log.V(consts.LogLevelInfo).Info(
 		"Sync Custom resource", "State:", s.name, "Name:", cr.Name, "Namespace:", cr.Namespace)

--- a/pkg/state/state_multus_cni.go
+++ b/pkg/state/state_multus_cni.go
@@ -65,7 +65,7 @@ type MultusManifestRenderData struct {
 // a sync operation must be relatively short and must not block the execution thread.
 //
 //nolint:dupl
-func (s *stateMultusCNI) Sync(customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *stateMultusCNI) Sync(customResource interface{}, _ InfoCatalog) (SyncState, error) {
 	cr := customResource.(*mellanoxv1alpha1.NicClusterPolicy)
 	log.V(consts.LogLevelInfo).Info(
 		"Sync Custom resource", "State:", s.name, "Name:", cr.Name, "Namespace:", cr.Namespace)

--- a/pkg/state/state_pod_security_policy.go
+++ b/pkg/state/state_pod_security_policy.go
@@ -65,7 +65,7 @@ type podSecurityPolicyManifestRenderData struct {
 // a sync operation must be relatively short and must not block the execution thread.
 //
 //nolint:dupl
-func (s *statePodSecurityPolicy) Sync(customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *statePodSecurityPolicy) Sync(customResource interface{}, _ InfoCatalog) (SyncState, error) {
 	cr := customResource.(*mellanoxv1alpha1.NicClusterPolicy)
 	log.V(consts.LogLevelInfo).Info(
 		"Sync Custom resource", "State:", s.name, "Name:", cr.Name, "Namespace:", cr.Namespace)

--- a/pkg/state/state_sriov_dp_test.go
+++ b/pkg/state/state_sriov_dp_test.go
@@ -38,7 +38,7 @@ import (
 type dummyProvider struct {
 }
 
-func (p *dummyProvider) GetNodesAttributes(filters ...nodeinfo.Filter) []nodeinfo.NodeAttributes {
+func (p *dummyProvider) GetNodesAttributes(_ ...nodeinfo.Filter) []nodeinfo.NodeAttributes {
 	attr := nodeinfo.NodeAttributes{
 		Name:       "test",
 		Attributes: make(map[nodeinfo.AttributeType]string),

--- a/pkg/state/state_whereabouts_cni.go
+++ b/pkg/state/state_whereabouts_cni.go
@@ -65,7 +65,7 @@ type WhereaboutsManifestRenderData struct {
 // a sync operation must be relatively short and must not block the execution thread.
 //
 //nolint:dupl
-func (s *stateWhereaboutsCNI) Sync(customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *stateWhereaboutsCNI) Sync(customResource interface{}, _ InfoCatalog) (SyncState, error) {
 	cr := customResource.(*mellanoxv1alpha1.NicClusterPolicy)
 	log.V(consts.LogLevelInfo).Info(
 		"Sync Custom resource", "State:", s.name, "Name:", cr.Name, "Namespace:", cr.Namespace)


### PR DESCRIPTION
This PR include two related commits:
[Update golang to 1.20](https://github.com/Mellanox/network-operator/commit/303673d7937cc1d85701e3abe47b4e851b43d756)
[Update golangci lint to v1.52.2 and fix discovered problems](https://github.com/Mellanox/network-operator/commit/9f845ce815b1b0e72d0a60fa79127bc104fd0ba0)

closes https://github.com/Mellanox/network-operator/issues/456