### PR TITLE
Set sriovNetworkOperator node selector in a helm chart in a safer manner

### DIFF
--- a/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
+++ b/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
@@ -25,6 +25,6 @@ spec:
   enableOperatorWebhook: false
   configDaemonNodeSelector:
     {{- $defaults := dict "beta.kubernetes.io/os" "linux" "network.nvidia.com/operator.mofed.wait" "false" }}
-    {{- $selectors := merge  $defaults .Values.sriovNetworkOperator.configDaemonNodeSelectorExtra}}
+    {{- $selectors := merge $defaults (.Values.sriovNetworkOperator.configDaemonNodeSelectorExtra | default dict  ) }}
     {{- toYaml $selectors | nindent 4 }}
 {{ end }}


### PR DESCRIPTION
If helm value sriovNetworkOperator.configDaemonNodeSelectorExtra map is manually
 removed from the default values.yaml, then
 wrong type for value error may occur while deploying helm chart.