### PR TITLE
Revert "server-side apply" patch and apply new fix for never-ending sync loop issue

### DIFF
--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -280,7 +280,7 @@ func (r *NicClusterPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		ctl = ctl.Watches(ws[i], &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &mellanoxv1alpha1.NicClusterPolicy{},
-		})
+		}, builder.WithPredicates(IgnoreSameContentPredicate{}))
 	}
 
 	return ctl.Complete(r)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ import (
 
 	mellanoxcomv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/controllers"
-	"github.com/Mellanox/network-operator/pkg/consts"
 	"github.com/Mellanox/network-operator/pkg/migrate"
 	// +kubebuilder:scaffold:imports
 )
@@ -110,10 +109,9 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	clientConf := ctrl.GetConfigOrDie()
-	clientConf.UserAgent = consts.KubernetesClientUserAgent
-
 	stopCtx := ctrl.SetupSignalHandler()
+
+	clientConf := ctrl.GetConfigOrDie()
 
 	mgr, err := ctrl.NewManager(clientConf, ctrl.Options{
 		Scheme:                 scheme,

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -32,5 +32,4 @@ const (
 	NicClusterPolicyResourceName = "nic-cluster-policy"
 	OfedDriverLabel              = "nvidia.com/ofed-driver"
 	StateLabel                   = "nvidia.network-operator.state"
-	KubernetesClientUserAgent    = "nvidia.network-operator"
 )


### PR DESCRIPTION
This PR reverts https://github.com/Mellanox/network-operator/pull/481

server-side apply may be problematic when we try to upgrade network-operator version

The new version of the operator may not clean fields set by the previous release.

Proposed solution: keep existing Create/Update logic for resource and fix for https://github.com/Mellanox/network-operator/issues/482 in a different way - try to ignore updates of the object if the content (excluding resourceVersion of the object and managedFileds) is the same.  

