### PR TITLE
Allow network-operator to list controllerrevisions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,7 @@ rules:
   - deployments
   - replicasets
   - statefulsets
+  - controllerrevisions
   verbs:
   - create
   - delete

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -143,6 +143,7 @@ rules:
     resources:
       - daemonsets
       - deployments
+      - controllerrevisions
     verbs:
       - get
       - list


### PR DESCRIPTION
Common driver upgrade lib now uses controller revision hashes of daemon sets and pod to determine whether the driver on the node requires upgrade.
Adding the permission to get them for network-operator's cluster role

https://github.com/NVIDIA/k8s-operator-libs/commit/80ee54959934887f5f478ef80ed995938f94250b