### PR TITLE
Align the skip-drain label for the operator with the common upgrade lib

### DIFF
--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -455,7 +455,7 @@ spec:
                 kubectl.kubernetes.io/default-container: manager
               labels:
                 control-plane: controller-manager
-                nvidia.com/ofed-upgrade.skip-drain: "true"
+                nvidia.com/ofed-driver-upgrade-drain.skip: "true"
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
-        nvidia.com/ofed-upgrade.skip-drain: "true"
+        nvidia.com/ofed-driver-upgrade-drain.skip: "true"
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        nvidia.com/ofed-upgrade.skip-drain: "true"
+        nvidia.com/ofed-driver-upgrade-drain.skip: "true"
         name: network-operator
     spec:
       nodeSelector:

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       labels:
-        nvidia.com/ofed-upgrade.skip-drain: "true"
+        nvidia.com/ofed-driver-upgrade-drain.skip: "true"
         {{- include "network-operator.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.operator.nodeSelector }}


### PR DESCRIPTION
Fix for https://github.com/Mellanox/network-operator/issues/496

When the upgrade functionality was extracted into a separate upgrade library, the pod label for skipping drain was changed (https://github.com/NVIDIA/k8s-operator-libs/blob/89451d4d7524278f985a7e813d654084c9e5d146/pkg/upgrade/consts.go#L23). The operator's spec was not aligned to use this new label.

This label is required for the operator, when deployed on a single-node cluster, where operator runs on the same node as the ofed driver container. Without this label, the operator pod would drain itself, thus breaking the complete network-operator deployment.

With this label, the pod is omitted during the drain (https://github.com/NVIDIA/k8s-operator-libs/blob/89451d4d7524278f985a7e813d654084c9e5d146/pkg/upgrade/upgrade_state.go#L603)