### PR TITLE
Allow network-operator to list controllerrevisions in openshift

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,11 +81,26 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - controllerrevisions
   - daemonsets
   - deployments
   - replicasets
   - statefulsets
-  - controllerrevisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
   verbs:
   - create
   - delete

--- a/controllers/upgrade_controller.go
+++ b/controllers/upgrade_controller.go
@@ -63,7 +63,7 @@ const UpgradeStateAnnotation = "nvidia.com/ofed-upgrade-state"
 // +kubebuilder:rbac:groups=mellanox.com,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=list
-// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets;controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
The previous PR https://github.com/Mellanox/network-operator/pull/490 didn't contain a fix for the openshift clusters