### PR TITLE
Update examples

### DIFF
--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -66,8 +66,3 @@ spec:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
       version: v0.6.1-amd64
-  nvPeerDriver:
-    image: nv-peer-mem-driver
-    repository: mellanox
-    version: 1.1-0
-    gpuDriverSourcePath: /run/nvidia/driver

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -60,7 +60,7 @@ spec:
                 "resourceName": "hostdev",
                 "selectors": {
                     "vendors": ["15b3"],
-                    "deviceIDs": ["101d"]
+                    "deviceIDs": ["101d"],
                     "isRdma": true
                 }
             }
@@ -80,8 +80,3 @@ spec:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
       version: v0.6.1-amd64
-  nvPeerDriver:
-    image: nv-peer-mem-driver
-    repository: mellanox
-    version: 1.1-0
-    gpuDriverSourcePath: /run/nvidia/driver


### PR DESCRIPTION
- Remove nv-peer-mem from examples as it is not recommended to deploy this driver using network-operator
- fix typo in sriov device plugin config