### PR TITLE
Increase memory and cpu limits for whereabouts DaemonSet.

### DIFF
--- a/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -63,10 +63,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "100Mi"
           limits:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "200Mi"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Increase memory and cpu limits for whereabouts DaemonSet.

This required to prevent failure of whereabouts
pod with "out of memory" error on some
environments.

fixes #517 