### PR TITLE
Increase memory and cpu limits for whereabouts DaemonSet.

### DIFF
--- a/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/stage-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -70,10 +70,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "100Mi"
           limits:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "200Mi"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
This required to prevent failure of whereabouts
pod with "out of memory" error on some
environments.

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>
(cherry picked from commit ff3c0ffb2463f9cee80f42b94f40e4f38f7be40e)