### PR TITLE
Log error in state manager

### DIFF
--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -22,6 +22,8 @@ nfd:
 psp:
   enabled: false
 
+upgradeCRDs: true
+
 sriovNetworkOperator:
   enabled: false
   # inject additional values to nodeSelector for config daemon

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -97,7 +97,7 @@ func (smgr *stateManager) SyncState(ctx context.Context, customResource interfac
 			statesReady = false
 		}
 
-		if result.Status == SyncStateError {
+		if result.ErrInfo != nil {
 			reqLogger.V(consts.LogLevelWarning).Error(result.ErrInfo, "Error while syncing state")
 		}
 	}


### PR DESCRIPTION
we should log error if it happend regardless
of SyncState.