### PR TITLE
[v23.5.x] Run CRD upgrade hook on helm chart install

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -180,7 +180,8 @@ helm search repo mellanox/network-operator -l
 
 ### Upgrade CRDs to compatible version
 
-The network-operator helm chart contains a pre-upgrade hook that will automatically upgrade required CRDs in the cluster.
+The network-operator helm chart contains a hook(pre-install, pre-upgrade)
+that will automatically upgrade required CRDs in the cluster.
 The hook is enabled by default. If you don't want to upgrade CRDs with helm automatically, 
 you can disable auto upgrade by setting `upgradeCRDs: false` in the helm chart values.
 Then you can follow the guide below to download and apply CRDs for the concrete version of the network-operator.
@@ -331,21 +332,20 @@ parameters.
 
 ### General parameters
 
-<<<<<<< HEAD
-| Name | Type   | Default | description                                                                                                                                                |
-| ---- |--------| ------- |------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `nfd.enabled` | bool   | `True` | deploy Node Feature Discovery                                                                                                                              |
-| `sriovNetworkOperator.enabled` | bool   | `False` | deploy SR-IOV Network Operator                                                                                                                             |
-| `upgradeCRDs`                                        | bool   | `True`                                   | enable CRDs upgrade with helm pre-upgrade hook                            |
-| `sriovNetworkOperator.configDaemonNodeSelectorExtra` | object     | `{"node-role.kubernetes.io/worker": ""}` | Additional nodeSelector for sriov-network-operator config daemon. These values will be added in addition to default values managed by the network-operator.|
-| `psp.enabled` | bool   | `False` | deploy Pod Security Policy                                                                                                                                 |
-| `imagePullSecrets` | list   | `[]` | An optional list of references to secrets to use for pulling any of the Network Operator image if it's not overrided                                       |
-| `operator.repository` | string | `nvcr.io/nvidia/cloud-native` | Network Operator image repository                                                                                                                          |
-| `operator.image` | string | `network-operator` | Network Operator image name                                                                                                                                |
-| `operator.tag` | string | `None` | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used                                                                          |
-| `operator.imagePullSecrets` | list   | `[]` | An optional list of references to secrets to use for pulling Network Operator image                                                                        |
-| `deployCR` | bool   | `false` | Deploy `NicClusterPolicy` custom resource according to provided parameters                                                                                 |
-| `nodeAffinity` | yaml   | `` | Override the node affinity for various Daemonsets deployed by network operator, e.g. whereabouts, multus, cni-plugins.                                     |
+| Name                                                 | Type   | Default                                  | description                                                                                                                                                 |
+|------------------------------------------------------|--------|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nfd.enabled`                                        | bool   | `True`                                   | deploy Node Feature Discovery                                                                                                                               |
+| `sriovNetworkOperator.enabled`                       | bool   | `False`                                  | deploy SR-IOV Network Operator                                                                                                                              |
+| `upgradeCRDs`                                        | bool   | `True`                                   | enable CRDs upgrade with helm pre-install and pre-upgrade hooks                                                                                             |
+| `sriovNetworkOperator.configDaemonNodeSelectorExtra` | object | `{"node-role.kubernetes.io/worker": ""}` | Additional nodeSelector for sriov-network-operator config daemon. These values will be added in addition to default values managed by the network-operator. |
+| `psp.enabled`                                        | bool   | `False`                                  | deploy Pod Security Policy                                                                                                                                  |
+| `imagePullSecrets`                                   | list   | `[]`                                     | An optional list of references to secrets to use for pulling any of the Network Operator image if it's not overrided                                        |
+| `operator.repository`                                | string | `nvcr.io/nvidia/cloud-native`            | Network Operator image repository                                                                                                                           |
+| `operator.image`                                     | string | `network-operator`                       | Network Operator image name                                                                                                                                 |
+| `operator.tag`                                       | string | `None`                                   | Network Operator image tag, if `None`, then the Chart's `appVersion` will be used                                                                           |
+| `operator.imagePullSecrets`                          | list   | `[]`                                     | An optional list of references to secrets to use for pulling Network Operator image                                                                         |
+| `deployCR`                                           | bool   | `false`                                  | Deploy `NicClusterPolicy` custom resource according to provided parameters                                                                                  |
+| `nodeAffinity`                                       | yaml   | ``                                       | Override the node affinity for various Daemonsets deployed by network operator, e.g. whereabouts, multus, cni-plugins.                                      |
 
 #### imagePullSecrets customization
 

--- a/deployment/network-operator/templates/upgrade-crd.yaml
+++ b/deployment/network-operator/templates/upgrade-crd.yaml
@@ -1,11 +1,54 @@
 {{- if .Values.upgradeCRDs }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "network-operator.fullname" . }}-hooks-sa
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-weight: "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "network-operator.fullname" . }}-hooks-role
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-weight: "0"
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "network-operator.fullname" . }}-hooks-binding
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-weight: "0"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "network-operator.fullname" . }}-hooks-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "network-operator.fullname" . }}-hooks-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: network-operator-upgrade-crd
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
   labels:
@@ -19,7 +62,7 @@ spec:
         {{- include "network-operator.labels" . | nindent 8 }}
         app.kubernetes.io/component: "network-operator"
     spec:
-      serviceAccountName: {{ include "network-operator.fullname" . }}
+      serviceAccountName: {{ include "network-operator.fullname" . }}-hooks-sa
       imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: upgrade-crd


### PR DESCRIPTION
This required to handle use-case when
network-operator upgrade is performed as:
step 1. uninstall an old version
step 2. install a new version



(cherry picked from commit 3eea75a3b980cbedb0f46ae062409d9efcb307e3)