### PR TITLE
Fix helm chart to generate correct NicClusterPolicy

### DIFF
--- a/deployment/network-operator/templates/_helpers.tpl
+++ b/deployment/network-operator/templates/_helpers.tpl
@@ -70,141 +70,161 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 imagePullSecrets helpers
 */}}
 {{- define "network-operator.operator.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.operator.imagePullSecrets }}
 {{- range .Values.operator.imagePullSecrets }}
-  - name: {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  (dict "name" . ) }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - name: {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  (dict "name" . ) }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.ofed.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.ofedDriver.imagePullSecrets }}
 {{- range .Values.ofedDriver.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.nvPeerDriver.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.nvPeerDriver.imagePullSecrets }}
 {{- range .Values.nvPeerDriver.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.rdmaSharedDevicePlugin.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.rdmaSharedDevicePlugin.imagePullSecrets }}
 {{- range .Values.rdmaSharedDevicePlugin.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.sriovDevicePlugin.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.sriovDevicePlugin.imagePullSecrets }}
 {{- range .Values.sriovDevicePlugin.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.ibKubernetes.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.ibKubernetes.imagePullSecrets }}
 {{- range .Values.ibKubernetes.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.secondaryNetwork.cniPlugins.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.secondaryNetwork.cniPlugins.imagePullSecrets }}
 {{- range .Values.secondaryNetwork.cniPlugins.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.secondaryNetwork.multus.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.secondaryNetwork.multus.imagePullSecrets }}
 {{- range .Values.secondaryNetwork.multus.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.secondaryNetwork.ipamPlugin.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.secondaryNetwork.ipamPlugin.imagePullSecrets }}
 {{- range .Values.secondaryNetwork.ipamPlugin.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}
 
 {{- define "network-operator.nvIpam.imagePullSecrets" }}
+{{- $imagePullSecrets := list }}
 {{- if .Values.nvIpam.imagePullSecrets }}
 {{- range .Values.nvIpam.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- else }}
 {{- if .Values.imagePullSecrets }}
 {{- range .Values.imagePullSecrets }}
-  - {{ . }}
+{{- $imagePullSecrets  = append $imagePullSecrets  . }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $imagePullSecrets | toJson }}
 {{- end }}

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -44,7 +44,7 @@ spec:
     repoConfig:
       name: {{ .Values.ofedDriver.repoConfig.name }}
     {{- end }}
-    imagePullSecrets: {{ include "network-operator.ofed.imagePullSecrets" . | nindent 4 }}
+    imagePullSecrets: {{ include "network-operator.ofed.imagePullSecrets" . }}
     terminationGracePeriodSeconds: {{ .Values.ofedDriver.terminationGracePeriodSeconds }}
     startupProbe:
       initialDelaySeconds: {{ .Values.ofedDriver.startupProbe.initialDelaySeconds }}
@@ -62,7 +62,7 @@ spec:
       drain:
         enable: {{ .Values.ofedDriver.upgradePolicy.drain.enable | default true }}
         force: {{ .Values.ofedDriver.upgradePolicy.drain.force | default false }}
-        podSelector: {{ .Values.ofedDriver.upgradePolicy.drain.podSelector}}
+        podSelector: {{ .Values.ofedDriver.upgradePolicy.drain.podSelector | quote }}
         timeoutSeconds: {{ .Values.ofedDriver.upgradePolicy.drain.timeoutSeconds }}
         deleteEmptyDir: {{ .Values.ofedDriver.upgradePolicy.drain.deleteEmptyDir | default false}}
     {{- end }}
@@ -72,7 +72,7 @@ spec:
     image: {{ .Values.nvPeerDriver.image }}
     repository: {{ .Values.nvPeerDriver.repository }}
     version: {{ .Values.nvPeerDriver.version }}
-    imagePullSecrets: {{ include "network-operator.nvPeerDriver.imagePullSecrets" . | nindent 4 }}
+    imagePullSecrets: {{ include "network-operator.nvPeerDriver.imagePullSecrets" . }}
     gpuDriverSourcePath: {{ .Values.nvPeerDriver.gpuDriverSourcePath }}
   {{- end }}
   {{- if .Values.rdmaSharedDevicePlugin.deploy }}
@@ -81,7 +81,7 @@ spec:
     image: {{ .Values.rdmaSharedDevicePlugin.image }}
     repository: {{ .Values.rdmaSharedDevicePlugin.repository }}
     version: {{ .Values.rdmaSharedDevicePlugin.version }}
-    imagePullSecrets: {{ include "network-operator.rdmaSharedDevicePlugin.imagePullSecrets" . | nindent 4 }}
+    imagePullSecrets: {{ include "network-operator.rdmaSharedDevicePlugin.imagePullSecrets" . }}
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     config: |
@@ -109,7 +109,7 @@ spec:
     image: {{ .Values.sriovDevicePlugin.image }}
     repository: {{ .Values.sriovDevicePlugin.repository }}
     version: {{ .Values.sriovDevicePlugin.version }}
-    imagePullSecrets: {{ include "network-operator.sriovDevicePlugin.imagePullSecrets" . | nindent 4 }}
+    imagePullSecrets: {{ include "network-operator.sriovDevicePlugin.imagePullSecrets" . }}
     config: |
       {
         "resourceList": [
@@ -138,10 +138,10 @@ spec:
     image: {{ .Values.ibKubernetes.image }}
     repository: {{ .Values.ibKubernetes.repository }}
     version: {{ .Values.ibKubernetes.version }}
-    imagePullSecrets: {{ include "network-operator.ibKubernetes.imagePullSecrets" . | nindent 4 }}
+    imagePullSecrets: {{ include "network-operator.ibKubernetes.imagePullSecrets" . }}
     pKeyGUIDPoolRangeStart: {{ .Values.ibKubernetes.pKeyGUIDPoolRangeStart }}
     pKeyGUIDPoolRangeEnd: {{ .Values.ibKubernetes.pKeyGUIDPoolRangeEnd }}
-    ufmSecret: {{ .Values.ibKubernetes.ufmSecret }}
+    ufmSecret: {{ .Values.ibKubernetes.ufmSecret | quote }}
   {{- end }}
   {{- if .Values.secondaryNetwork.deploy }}
   secondaryNetwork:
@@ -150,14 +150,14 @@ spec:
       image: {{ .Values.secondaryNetwork.cniPlugins.image }}
       repository: {{ .Values.secondaryNetwork.cniPlugins.repository }}
       version: {{ .Values.secondaryNetwork.cniPlugins.version }}
-      imagePullSecrets: {{ include "network-operator.secondaryNetwork.cniPlugins.imagePullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{ include "network-operator.secondaryNetwork.cniPlugins.imagePullSecrets" . }}
     {{- end }}
     {{- if .Values.secondaryNetwork.multus.deploy }}
     multus:
       image: {{ .Values.secondaryNetwork.multus.image }}
       repository: {{ .Values.secondaryNetwork.multus.repository }}
       version: {{ .Values.secondaryNetwork.multus.version }}
-      imagePullSecrets: {{ include "network-operator.secondaryNetwork.multus.imagePullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{ include "network-operator.secondaryNetwork.multus.imagePullSecrets" . }}
       {{- if .Values.secondaryNetwork.multus.config | empty | not }}
       config: {{ .Values.secondaryNetwork.multus.config | quote }}
       {{- end }}
@@ -173,7 +173,7 @@ spec:
       image: {{ .Values.secondaryNetwork.ipamPlugin.image }}
       repository: {{ .Values.secondaryNetwork.ipamPlugin.repository }}
       version: {{ .Values.secondaryNetwork.ipamPlugin.version }}
-      imagePullSecrets: {{ include "network-operator.secondaryNetwork.ipamPlugin.imagePullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{ include "network-operator.secondaryNetwork.ipamPlugin.imagePullSecrets" . }}
     {{- end }}
   {{- end }}
   psp:
@@ -183,7 +183,7 @@ spec:
     image: {{ .Values.nvIpam.image }}
     repository: {{ .Values.nvIpam.repository }}
     version: {{ .Values.nvIpam.version }}
-    imagePullSecrets: {{ include "network-operator.nvIpam.imagePullSecrets" . | nindent 4 }}
+    imagePullSecrets: {{ include "network-operator.nvIpam.imagePullSecrets" . }}
     config: {{ .Values.nvIpam.config | quote }}
   {{- end }}
 {{ end }}

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -44,7 +44,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}
-      imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}
       containers:
         - name: {{ .Chart.Name }}
           # Replace this with the built image name

--- a/deployment/network-operator/templates/upgrade-crd.yaml
+++ b/deployment/network-operator/templates/upgrade-crd.yaml
@@ -63,7 +63,7 @@ spec:
         app.kubernetes.io/component: "network-operator"
     spec:
       serviceAccountName: {{ include "network-operator.fullname" . }}-hooks-sa
-      imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}
       containers:
         - name: upgrade-crd
           image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ .Values.operator.tag | default .Chart.AppVersion }}"

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -225,7 +225,7 @@ ibKubernetes:
   periodicUpdateSeconds: 5
   pKeyGUIDPoolRangeStart: "02:00:00:00:00:00:00:00"
   pKeyGUIDPoolRangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"
-  ufmSecret: # specify the secret name here
+  ufmSecret: '' # specify the secret name here
 
 nvIpam:
   deploy: false

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -225,7 +225,7 @@ ibKubernetes:
   periodicUpdateSeconds: 5
   pKeyGUIDPoolRangeStart: "02:00:00:00:00:00:00:00"
   pKeyGUIDPoolRangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"
-  ufmSecret: # specify the secret name here
+  ufmSecret: '' # specify the secret name here
 
 nvIpam:
   deploy: false


### PR DESCRIPTION
To be able to use server-side apply YAML spec
should not contain "null" values

Changes:
- quote strings without default to always include a empty string value
- use empty list for imagePullSecrets field if secrets are not configured

Fixes #452 

Example of generated NicClusterPolicy
```
apiVersion: mellanox.com/v1alpha1                                                                                                                                                                                                                                                                                                [101/7155]
kind: NicClusterPolicy                                                                                                                                                                                        
metadata:                                                                                                                                                                                                     
  name: nic-cluster-policy                                                                                                                                                                                    
spec:                                                                                                                                                                                                         
  ofedDriver:                                                                                                                                                                                                 
    image: mofed                                                                                                                                                                                              
    repository: nvcr.io/nvidia/mellanox                                                                                                                                                                       
    version: 5.9-0.5.6.0                                                                                                                                                                                      
    imagePullSecrets: []                                                                                                                                                                                      
    terminationGracePeriodSeconds: 300                                                                                                                                                                        
    startupProbe:                                                                                                                                                                                             
      initialDelaySeconds: 60                                                                                                                                                                                 
      periodSeconds: 60                                                                                                                                                                                       
    livenessProbe:                              
      initialDelaySeconds: 30                   
      periodSeconds: 30                                                                                
    readinessProbe:                                                                                    
      initialDelaySeconds: 10                                                                          
      periodSeconds: 30
    upgradePolicy:                                                                                     
      autoUpgrade: false                  
      maxParallelUpgrades: 1
      drain:               
        enable: true                                                                                   
        force: false                   
        podSelector: ""                  
        timeoutSeconds: 300                                                                            
        deleteEmptyDir: false
  rdmaSharedDevicePlugin:               
    # [map[name:rdma_shared_device_a vendors:[15b3]]]                                                  
    image: k8s-rdma-shared-dev-plugin
    repository: nvcr.io/nvidia/cloud-native
    version: v1.3.2                                                                                                                                                                                           
    imagePullSecrets: []                                                                               
    # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
    # Replace 'devices' with your (RDMA capable) netdevice name.
    config: |
      {
        "configList": [
          {
            "resourceName": "rdma_shared_device_a", 
            "rdmaHcaMax": 1000,
            "selectors": {
              "vendors": ["15b3"],
              "deviceIDs": [],
              "drivers": [],
              "ifNames": [],
              "linkTypes": []                              
            }                                              
          }                                                
        ]                                                           
      }                                                             
  psp:                                                              
    enabled: false 
```
With imagePullSecrets
```
apiVersion: mellanox.com/v1alpha1               
kind: NicClusterPolicy                      
metadata:                                   
  name: nic-cluster-policy                                         
spec:                                 
  ofedDriver:                                      
    image: mofed
    repository: nvcr.io/nvidia/mellanox
    version: 5.9-0.5.6.0
    imagePullSecrets: ["foo","bar"]     
    terminationGracePeriodSeconds: 300
    startupProbe:                                  
      initialDelaySeconds: 60                   
      periodSeconds: 60                              
    livenessProbe:                               
      initialDelaySeconds: 30             
      periodSeconds: 30                                
    readinessProbe:                                
      initialDelaySeconds: 10                                   
      periodSeconds: 30                  
    upgradePolicy:                                                 
      autoUpgrade: false    
      maxParallelUpgrades: 1                                                
      drain:                           
        enable: true                            
        force: false  
        podSelector: ""
        timeoutSeconds: 300
        deleteEmptyDir: false                         
  rdmaSharedDevicePlugin:            
    # [map[name:rdma_shared_device_a vendors:[15b3]]]
    image: k8s-rdma-shared-dev-plugin                                                                                                                                
    repository: nvcr.io/nvidia/cloud-native
    version: v1.3.2
    imagePullSecrets: ["foo","bar"]
    # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
    # Replace 'devices' with your (RDMA capable) netdevice name.
    config: |
      {
        "configList": [
          {
            "resourceName": "rdma_shared_device_a",
            "rdmaHcaMax": 1000,
            "selectors": {
              "vendors": ["15b3"],
              "deviceIDs": [],
              "drivers": [],
              "ifNames": [],
              "linkTypes": []
            }
          }
        ]
      }
  psp:
    enabled: false

```