### PR TITLE
Watch ConfigMap changes for related states

### DIFF
--- a/pkg/state/state_multus_cni.go
+++ b/pkg/state/state_multus_cni.go
@@ -112,6 +112,7 @@ func (s *stateMultusCNI) Sync(ctx context.Context, customResource interface{}, _
 func (s *stateMultusCNI) GetWatchSources() map[string]*source.Kind {
 	wr := make(map[string]*source.Kind)
 	wr["DaemonSet"] = &source.Kind{Type: &appsv1.DaemonSet{}}
+	wr["ConfigMap"] = &source.Kind{Type: &v1.ConfigMap{}}
 	return wr
 }
 

--- a/pkg/state/state_nv_ipam_cni.go
+++ b/pkg/state/state_nv_ipam_cni.go
@@ -113,6 +113,7 @@ func (s *stateNVIPAMCNI) GetWatchSources() map[string]*source.Kind {
 	wr := make(map[string]*source.Kind)
 	wr["DaemonSet"] = &source.Kind{Type: &appsv1.DaemonSet{}}
 	wr["Deployment"] = &source.Kind{Type: &appsv1.Deployment{}}
+	wr["ConfigMap"] = &source.Kind{Type: &v1.ConfigMap{}}
 	return wr
 }
 

--- a/pkg/state/state_shared_dp.go
+++ b/pkg/state/state_shared_dp.go
@@ -124,6 +124,7 @@ func (s *stateSharedDp) Sync(
 func (s *stateSharedDp) GetWatchSources() map[string]*source.Kind {
 	wr := make(map[string]*source.Kind)
 	wr["DaemonSet"] = &source.Kind{Type: &appsv1.DaemonSet{}}
+	wr["ConfigMap"] = &source.Kind{Type: &v1.ConfigMap{}}
 	return wr
 }
 

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -125,6 +125,7 @@ func (s *stateSriovDp) Sync(
 func (s *stateSriovDp) GetWatchSources() map[string]*source.Kind {
 	wr := make(map[string]*source.Kind)
 	wr["DaemonSet"] = &source.Kind{Type: &appsv1.DaemonSet{}}
+	wr["ConfigMap"] = &source.Kind{Type: &v1.ConfigMap{}}
 	return wr
 }
 


### PR DESCRIPTION
Currently config map changes will not trigger reconcile. Add ConfigMap as watched resource for nicclusterpolicy controller using nv-ipam state.