### PR TITLE
Enable NodeFeatureApi in NFD

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ __Example NFD worker configurations:__
 
 >\* Required for GPUDirect driver container deployment
 
-If NFD is already deployed in the cluster, make sure to pass `--set nfd.enabled=false` to the helm install command to avoid conflicts.
+>__NOTE__: If NFD is already deployed in the cluster, make sure to pass `--set nfd.enabled=false` to the helm install command to avoid conflicts,
+and if NFD is deployed from this repo the `enableNodeFeatureApi` flag is enabled by default to have the ability to create NodeFeatureRules.
 
 ## Resource Definitions
 The Operator Acts on the following CRDs:

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -32,7 +32,7 @@ sriovNetworkOperator:
 
 # Node Feature discovery chart related values
 node-feature-discovery:
-  enableNodeFeatureApi: false
+  enableNodeFeatureApi: true
   worker:
     serviceAccount:
       name: node-feature-discovery
@@ -60,7 +60,6 @@ node-feature-discovery:
           deviceLabelFields:
           - vendor
   master:
-    instance: "nvidia.networking"
     serviceAccount:
       name: node-feature-discovery
       create: true

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -32,7 +32,7 @@ sriovNetworkOperator:
 
 # Node Feature discovery chart related values
 node-feature-discovery:
-  enableNodeFeatureApi: false
+  enableNodeFeatureApi: true
   worker:
     serviceAccount:
       name: node-feature-discovery
@@ -60,7 +60,6 @@ node-feature-discovery:
           deviceLabelFields:
           - vendor
   master:
-    instance: "nvidia.networking"
     serviceAccount:
       name: node-feature-discovery
       create: true


### PR DESCRIPTION
…namespace

This patch does the following:
 - Set enableNodeFeatureApi to true by default
 - Run the NFD with default annotation namespace
 - Enhance READE NFD documentation