### PR TITLE
add cniSpec to HostDeviceRenderData and prettyPrint CNI JSON

### DIFF
--- a/manifests/state-hostdevice-network/0010-hostdevice-net-cr.yml
+++ b/manifests/state-hostdevice-network/0010-hostdevice-net-cr.yml
@@ -6,9 +6,5 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/resourceName: {{.ResourceName}}
 spec:
-  config: '{
-  "cniVersion":"0.3.1",
-  "name":"{{.HostDeviceNetworkName}}",
-  "type":"host-device",
-  "ipam": {{.CrSpec.IPAM}}
-}'
+  config:
+    '{{.CNISpec | json}}'

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -26,6 +26,7 @@ package render
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -113,6 +114,10 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 	// Create a new template
 	tmpl := template.New(path.Base(filePath)).Option("missingkey=error")
 	tmpl.Funcs(template.FuncMap{
+		"json": func(obj interface{}) (string, error) {
+			jsonBytes, err := json.Marshal(obj)
+			return string(jsonBytes), err
+		},
 		"yaml": func(obj interface{}) (string, error) {
 			yamlBytes, err := yamlConverter.Marshal(obj)
 			return string(yamlBytes), err

--- a/pkg/state/state_hostdevice_network.go
+++ b/pkg/state/state_hostdevice_network.go
@@ -38,6 +38,8 @@ import (
 )
 
 const (
+	stateHostDeviceCNIVersion         = "0.3.1"
+	stateHostDeviceCNIType            = "host-device"
 	stateHostDeviceNetworkName        = "state-host-device-network"
 	stateHostDeviceNetworkDescription = "Host Device net-attach-def CR deployed in cluster"
 	resourceNamePrefix                = "nvidia.com/"
@@ -70,6 +72,7 @@ type HostDeviceManifestRenderData struct {
 	CrSpec                mellanoxv1alpha1.HostDeviceNetworkSpec
 	RuntimeSpec           *runtimeSpec
 	ResourceName          string
+	CNISpec               *cniSpec
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -135,9 +138,17 @@ func (s *stateHostDeviceNetwork) getManifestObjects(
 		resourceName = resourceNamePrefix + resourceName
 	}
 
+	cniSpec := &cniSpec{
+		CNIVersion: stateHostDeviceCNIVersion,
+		Name:       cr.Name,
+		Type:       stateHostDeviceCNIType,
+		IPAM:       cr.Spec.IPAM,
+	}
+
 	renderData := &HostDeviceManifestRenderData{
 		HostDeviceNetworkName: cr.Name,
 		CrSpec:                cr.Spec,
+		CNISpec:               cniSpec,
 		RuntimeSpec: &runtimeSpec{
 			Namespace: config.FromEnv().State.NetworkOperatorResourceNamespace,
 		},

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -38,6 +38,13 @@ import (
 	"github.com/Mellanox/network-operator/pkg/render"
 )
 
+type cniSpec struct {
+	CNIVersion string `json:"cniVersion,omitempty"`
+	Name       string `json:"name,omitempty"`
+	IPAM       string `json:"ipam,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
 type runtimeSpec struct {
 	Namespace string
 }


### PR DESCRIPTION
Add cniSpec as a renderable object to `HostDeviceRenderData` and use go template to prettyPrint the cniSpec json


If this change looks okay, I can make this apply to all the other Net-Attach-Def renderers and update test cases

@adrianchiris @e0ne 