### PR TITLE
Limit maximum number of RDMA resources for Shared Device Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["1017"],
@@ -198,7 +198,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
+++ b/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
@@ -50,7 +50,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"]
             }

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -415,10 +415,12 @@ resources:
       vendors: [15b3]
       deviceIDs: [1017]
       ifNames: [enp5s0f0]
+      rdmaHcaMax: 63
     - name: rdma_shared_device_b
       vendors: [15b3]
       deviceIDs: [1017]
       ifNames: [ib0, ib1]
+      rdmaHcaMax: 63
 ```
 
 #### SR-IOV Network Device plugin

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -83,7 +83,7 @@ spec:
           {{- range $index, $element := .Values.rdmaSharedDevicePlugin.resources }}
           {
             "resourceName": {{ $element.name | quote }},
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": {{ $element.rdmaHcaMax | default 63 }},
             "selectors": {
               "vendors": {{ $element.vendors | default list | toJson }},
               "deviceIDs": {{ $element.deviceIDs | default list | toJson }},

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -208,6 +208,7 @@ rdmaSharedDevicePlugin:
   resources:
     - name: rdma_shared_device_a
       vendors: [15b3]
+      rdmaHcaMax: 63
 
 sriovDevicePlugin:
   deploy: false

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -40,7 +40,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -40,7 +40,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -39,7 +39,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"]
             }

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -40,7 +40,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.template
@@ -40,7 +40,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.template
@@ -40,7 +40,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.template
@@ -39,7 +39,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"]
             }

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.template
@@ -40,7 +40,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"],
               "deviceIDs": ["101b"]

--- a/hack/templates/samples/mellanox.com_v1alpha1_nicclusterpolicy.template
+++ b/hack/templates/samples/mellanox.com_v1alpha1_nicclusterpolicy.template
@@ -50,7 +50,7 @@ spec:
         "configList": [
           {
             "resourceName": "rdma_shared_device_a",
-            "rdmaHcaMax": 1000,
+            "rdmaHcaMax": 63,
             "selectors": {
               "vendors": ["15b3"]
             }

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -208,6 +208,7 @@ rdmaSharedDevicePlugin:
   resources:
     - name: rdma_shared_device_a
       vendors: [15b3]
+      rdmaHcaMax: 63
 
 sriovDevicePlugin:
   deploy: false


### PR DESCRIPTION
There us hardware limitation of 128 GIDs per port in RocE mode. Since RocE v1 and v2 are enabled by default we have to limit to 63 devices per port to be allocated to workloads.

There is no such limitation for IPoIB mode, so user should update default value if needed.

This commit also makes rdmaHcaMax configurable via helm values.