### PR TITLE
Update device plugins volumes mounts

### DIFF
--- a/manifests/state-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/state-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -59,7 +59,11 @@ spec:
           privileged: true
         volumeMounts:
           - name: device-plugin
-            mountPath: /var/lib/kubelet/
+            mountPath: /var/lib/kubelet/device-plugins
+            readOnly: false
+          - name: plugins-registry
+            mountPath: /var/lib/kubelet/plugins_registry
+            readOnly: false
           - name: config
             mountPath: /k8s-rdma-shared-dev-plugin
           - name: devs
@@ -67,7 +71,10 @@ spec:
       volumes:
         - name: device-plugin
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: config
           configMap:
             name: rdma-devices

--- a/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yml
+++ b/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yml
@@ -73,7 +73,10 @@ spec:
             privileged: true
           volumeMounts:
             - name: devicesock
-              mountPath: /var/lib/kubelet/
+              mountPath: /var/lib/kubelet/device-plugins
+              readOnly: false
+            - name: plugins-registry
+              mountPath: /var/lib/kubelet/plugins_registry
               readOnly: false
             - name: log
               mountPath: /var/log
@@ -84,7 +87,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
             path: /var/log


### PR DESCRIPTION
There is no need to mount the whole '/var/lib/kubelet/' directory into a pod. It's enough to mount only '/var/lib/kubelet/device-plugins' and '/var/lib/kubelet/plugins_registry' directories.