### PR TITLE
feat: add support for safe driver loading feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,7 @@ release-build:
 	cd hack && $(GO) run release.go --templateDir ./templates/samples/ --outputDir ../config/samples/
 	cd hack && $(GO) run release.go --templateDir ./templates/crs/ --outputDir ../example/crs
 	cd hack && $(GO) run release.go --templateDir ./templates/values/ --outputDir ../deployment/network-operator/
+	cd hack && $(GO) run release.go --templateDir ./templates/config/manager --outputDir ../config/manager/
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool

--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -108,6 +108,10 @@ type DriverUpgradePolicySpec struct {
 	MaxParallelUpgrades int                    `json:"maxParallelUpgrades,omitempty"`
 	WaitForCompletion   *WaitForCompletionSpec `json:"waitForCompletion,omitempty"`
 	DrainSpec           *DrainSpec             `json:"drain,omitempty"`
+	// SafeLoad turn on safe driver loading (cordon and drain the node before loading the driver)
+	// +optional
+	// +kubebuilder:default:=false
+	SafeLoad bool `json:"safeLoad,omitempty"`
 }
 
 // WaitForCompletionSpec describes the configuration for waiting on job completions

--- a/api/v1alpha1/nicclusterpolicy_webhook_test.go
+++ b/api/v1alpha1/nicclusterpolicy_webhook_test.go
@@ -118,6 +118,47 @@ var _ = Describe("Validate", func() {
 			_, err := nicClusterPolicy.ValidateCreate()
 			Expect(err.Error()).To(ContainSubstring("invalid OFED version"))
 		})
+		It("MOFED SafeLoad requires AutoUpgrade to be enabled", func() {
+			nicClusterPolicy := NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: NicClusterPolicySpec{
+					OFEDDriver: &OFEDDriverSpec{
+						ImageSpec: ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "23.10-0.2.2.0",
+							ImagePullSecrets: []string{},
+						},
+						OfedUpgradePolicy: &DriverUpgradePolicySpec{
+							SafeLoad: true,
+						},
+					},
+				},
+			}
+			_, err := nicClusterPolicy.ValidateCreate()
+			Expect(err.Error()).To(ContainSubstring("autoUpgrade"))
+		})
+		It("MOFED valid SafeLoad config", func() {
+			nicClusterPolicy := NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: NicClusterPolicySpec{
+					OFEDDriver: &OFEDDriverSpec{
+						ImageSpec: ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "23.10-0.2.2.0",
+							ImagePullSecrets: []string{},
+						},
+						OfedUpgradePolicy: &DriverUpgradePolicySpec{
+							SafeLoad:    true,
+							AutoUpgrade: true,
+						},
+					},
+				},
+			}
+			_, err := nicClusterPolicy.ValidateCreate()
+			Expect(err).To(BeNil())
+		})
 		It("Valid RDMA config JSON", func() {
 			rdmaConfig := `{
 				"configList": [{

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -555,6 +555,11 @@ spec:
                           will be upgraded in parallel
                         minimum: 0
                         type: integer
+                      safeLoad:
+                        default: false
+                        description: SafeLoad turn on safe driver loading (cordon
+                          and drain the node before loading the driver)
+                        type: boolean
                       waitForCompletion:
                         description: WaitForCompletionSpec describes the configuration
                           for waiting on job completions

--- a/config/manager/init_container_image_name_patch.yaml
+++ b/config/manager/init_container_image_name_patch.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: "/spec/template/spec/containers/0/env/-"
+  value:
+    name: OFED_INIT_CONTAINER_IMAGE
+    value: "ghcr.io/mellanox/network-operator-init-container:v0.0.2"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,6 +7,15 @@ commonLabels:
 generatorOptions:
   disableNameSuffixHash: true
 
+patches:
+- path: init_container_image_name_patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+    version: v1
+
 kind: Kustomization
 images:
 - name: controller

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -128,7 +128,7 @@ $ helm install --set nfd.enabled=false -n network-operator --create-namespace --
 > __Note:__ The labels which Network Operator depends on may change between releases.
 
 > __Note:__ By default the operator is deployed without an instance of `NicClusterPolicy` and `MacvlanNetwork`
-custom resources. The user is required to create it later with configuration matching the cluster or use chart parameters to deploy it together with the operator.
+> custom resources. The user is required to create it later with configuration matching the cluster or use chart parameters to deploy it together with the operator.
 
 #### Deploy development version of Network Operator
 
@@ -398,23 +398,37 @@ imagePullSecrets:
 
 #### Mellanox OFED driver
 
-| Name | Type | Default | Description                                                                                                                                                               |
-| ---- | ---- | ------- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ofedDriver.deploy` | bool | `false` | deploy Mellanox OFED driver container                                                                                                                                     |
-| `ofedDriver.repository` | string | `mellanox` | Mellanox OFED driver image repository                                                                                                                                     |
-| `ofedDriver.image` | string | `mofed` | Mellanox OFED driver image name                                                                                                                                           |
-| `ofedDriver.version` | string | `5.9-0.5.6.0` | Mellanox OFED driver version                                                                                                                                              |
-| `ofedDriver.imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling any of the Mellanox OFED driver image                                                                        |
-| `ofedDriver.env` | list | `[]` | An optional list of [environment variables](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) passed to the Mellanox OFED driver image |
-| `ofedDriver.repoConfig.name` | string | `` | Private mirror repository configuration configMap name |
-| `ofedDriver.certConfig.name` | string | `` | Custom TLS key/certificate configuration configMap name |
-| `ofedDriver.terminationGracePeriodSeconds` | int | 300 | Mellanox OFED termination grace periods in seconds|
-| `ofedDriver.startupProbe.initialDelaySeconds` | int | 10 | Mellanox OFED startup probe initial delay                                                                                                                                 |
-| `ofedDriver.startupProbe.periodSeconds` | int | 20 | Mellanox OFED startup probe interval                                                                                                                                      |
-| `ofedDriver.livenessProbe.initialDelaySeconds` | int | 30 | Mellanox OFED liveness probe initial delay                                                                                                                                |
-| `ofedDriver.livenessProbe.periodSeconds` | int | 30 | Mellanox OFED liveness probe interval                                                                                                                                     |
-| `ofedDriver.readinessProbe.initialDelaySeconds` | int | 10 | Mellanox OFED readiness probe initial delay                                                                                                                               |
-| `ofedDriver.readinessProbe.periodSeconds` | int | 30 | Mellanox OFED readiness probe interval                                                                                                                                    |
+| Name                                                        | Type   | Default                           | Description                                                                                                                                                                   |
+|-------------------------------------------------------------|--------|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ofedDriver.deploy`                                         | bool   | `false`                           | deploy Mellanox OFED driver container                                                                                                                                         |
+| `ofedDriver.repository`                                     | string | `mellanox`                        | Mellanox OFED driver image repository                                                                                                                                         |
+| `ofedDriver.image`                                          | string | `mofed`                           | Mellanox OFED driver image name                                                                                                                                               |
+| `ofedDriver.version`                                        | string | `5.9-0.5.6.0`                     | Mellanox OFED driver version                                                                                                                                                  |
+| `ofedDriver.initContainer.enable`                           | bool   | `true`                            | deploy init container                                                                                                                                                         |
+| `ofedDriver.initContainer.repository`                       | string | `ghcr.io/mellanox`                | init container image repository                                                                                                                                               |
+| `ofedDriver.initContainer.image`                            | string | `network-operator-init-container` | init container image name                                                                                                                                                     |
+| `ofedDriver.initContainer.version`                          | string | `v0.0.2`                          | init container image version                                                                                                                                                  |
+| `ofedDriver.imagePullSecrets`                               | list   | `[]`                              | An optional list of references to secrets to use for pulling any of the Mellanox OFED driver image                                                                            |
+| `ofedDriver.env`                                            | list   | `[]`                              | An optional list of [environment variables](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) passed to the Mellanox OFED driver image     |
+| `ofedDriver.repoConfig.name`                                | string | ``                                | Private mirror repository configuration configMap name                                                                                                                        |
+| `ofedDriver.certConfig.name`                                | string | ``                                | Custom TLS key/certificate configuration configMap name                                                                                                                       |
+| `ofedDriver.terminationGracePeriodSeconds`                  | int    | 300                               | Mellanox OFED termination grace periods in seconds                                                                                                                            |
+| `ofedDriver.startupProbe.initialDelaySeconds`               | int    | 10                                | Mellanox OFED startup probe initial delay                                                                                                                                     |
+| `ofedDriver.startupProbe.periodSeconds`                     | int    | 20                                | Mellanox OFED startup probe interval                                                                                                                                          |
+| `ofedDriver.livenessProbe.initialDelaySeconds`              | int    | 30                                | Mellanox OFED liveness probe initial delay                                                                                                                                    |
+| `ofedDriver.livenessProbe.periodSeconds`                    | int    | 30                                | Mellanox OFED liveness probe interval                                                                                                                                         |
+| `ofedDriver.readinessProbe.initialDelaySeconds`             | int    | 10                                | Mellanox OFED readiness probe initial delay                                                                                                                                   |
+| `ofedDriver.readinessProbe.periodSeconds`                   | int    | 30                                | Mellanox OFED readiness probe interval                                                                                                                                        |
+| `ofedDriver.upgradePolicy.autoUpgrade`                      | bool   | `false`                           | global switch for automatic upgrade feature                                                                                                                                   |
+| `ofedDriver.upgradePolicy.maxParallelUpgrades`              | int    | 1                                 | how many nodes can be upgraded in parallel, 0 means no limit, all nodes will be upgraded in parallel                                                                          |
+| `ofedDriver.upgradePolicy.safeLoad`                         | bool   | `false`                           | cordon and drain (if enabled) a node before loading the driver on it, requires `ofedDriver.initContainer` to be enabled and `ofedDriver.upgradePolicy.autoUpgrade` to be true |
+| `ofedDriver.upgradePolicy.drain.enable`                     | bool   | `true`                            | drain a node before the driver restart                                                                                                                                        |
+| `ofedDriver.upgradePolicy.drain.force`                      | bool   | `false`                           | use force drain (check `kubectl drain` doc for details)                                                                                                                       |
+| `ofedDriver.upgradePolicy.drain.podSelector`                | string | ""                                | drain only pods matching this selector                                                                                                                                        |
+| `ofedDriver.upgradePolicy.drain.timeoutSeconds`             | int    | 300                               | timeout for drain operation                                                                                                                                                   |
+| `ofedDriver.upgradePolicy.drain.deleteEmptyDir`             | bool   | `false`                           | continue even if there are pods using emptyDir                                                                                                                                |
+| `ofedDriver.upgradePolicy.waitForCompletion.podSelector`    | string | not set                           | specifies a label selector for the pods to wait for completion before starting the driver upgrade                                                                             |
+| `ofedDriver.upgradePolicy.waitForCompletion.timeoutSeconds` | int    | not set                           | specify the length of time in seconds to wait before giving up for workload to finish, zero means infinite                                                                    |
 
 #### RDMA Device Plugin
 
@@ -592,7 +606,7 @@ optionally deployed components:
 | `nvIpam.enableWebhook`    | bool   | `false`            | Enable deployment of the validataion webhook for IPPool CRD                         |
 
 > __Note__: Supported X.509 certificate management system should be available in the cluster to enable the validation webhook.
-Currently supported systems are [certmanager](https://cert-manager.io/) and
+> Currently supported systems are [certmanager](https://cert-manager.io/) and
 [Openshift certificate management](https://docs.openshift.com/container-platform/4.13/security/certificates/service-serving-certificate.html)
 
 

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -555,6 +555,11 @@ spec:
                           will be upgraded in parallel
                         minimum: 0
                         type: integer
+                      safeLoad:
+                        default: false
+                        description: SafeLoad turn on safe driver loading (cordon
+                          and drain the node before loading the driver)
+                        type: boolean
                       waitForCompletion:
                         description: WaitForCompletionSpec describes the configuration
                           for waiting on job completions

--- a/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/deployment/network-operator/templates/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -59,12 +59,20 @@ spec:
     upgradePolicy:
       autoUpgrade: {{ .Values.ofedDriver.upgradePolicy.autoUpgrade | default false }}
       maxParallelUpgrades: {{ .Values.ofedDriver.upgradePolicy.maxParallelUpgrades | default 0 }}
+      safeLoad: {{ .Values.ofedDriver.upgradePolicy.safeLoad | default false }}
+      {{- if .Values.ofedDriver.upgradePolicy.drain }}
       drain:
         enable: {{ .Values.ofedDriver.upgradePolicy.drain.enable | default true }}
         force: {{ .Values.ofedDriver.upgradePolicy.drain.force | default false }}
         podSelector: {{ .Values.ofedDriver.upgradePolicy.drain.podSelector | quote }}
         timeoutSeconds: {{ .Values.ofedDriver.upgradePolicy.drain.timeoutSeconds }}
         deleteEmptyDir: {{ .Values.ofedDriver.upgradePolicy.drain.deleteEmptyDir | default false}}
+      {{- end }}
+      {{- if .Values.ofedDriver.upgradePolicy.waitForCompletion }}
+      waitForCompletion:
+        podSelector: {{ .Values.ofedDriver.upgradePolicy.waitForCompletion.podSelector | default ""}}
+        timeoutSeconds: {{ .Values.ofedDriver.upgradePolicy.waitForCompletion.timeoutSeconds | default 0 }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- if .Values.rdmaSharedDevicePlugin.deploy }}

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -82,6 +82,12 @@ spec:
             - name: CNI_BIN_DIR
               value: "{{ .Values.operator.cniBinDirectory }}"
             {{- end }}
+            {{- if and .Values.ofedDriver.initContainer .Values.ofedDriver.initContainer.enable }}
+            - name: OFED_INIT_CONTAINER_IMAGE
+              {{- with .Values.ofedDriver.initContainer }}
+              value: "{{ .repository }}/{{ .image }}:{{ .version }}"
+              {{- end }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
           livenessProbe:

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -169,6 +169,11 @@ ofedDriver:
   image: mofed
   repository: nvcr.io/nvstaging/mellanox
   version: 23.10-0.5.5.0
+  initContainer:
+    enable: true
+    repository: ghcr.io/mellanox
+    image: network-operator-init-container
+    version: v0.0.2
   # imagePullSecrets: []
   # env, if defined will pass environment variables to the OFED container
   # env:
@@ -181,7 +186,6 @@ ofedDriver:
   # Custom ssl key/certificate configuration
   certConfig:
     name: ""
-
   startupProbe:
     initialDelaySeconds: 10
     periodSeconds: 20
@@ -198,6 +202,8 @@ ofedDriver:
     # how many nodes can be upgraded in parallel (default: 1)
     # 0 means no limit, all nodes will be upgraded in parallel
     maxParallelUpgrades: 1
+    # cordon and drain (if enabled) a node before loading the driver on it
+    safeLoad: false
     # options for node drain (`kubectl drain`) before the driver reload
     # if auto upgrade is enabled but drain.enable is false,
     # then driver POD will be reloaded immediately without
@@ -209,6 +215,11 @@ ofedDriver:
       # It's recommended to set a timeout to avoid infinite drain in case non-fatal error keeps happening on retries
       timeoutSeconds: 300
       deleteEmptyDir: false
+    waitForCompletion:
+      # specifies a label selector for the pods to wait for completion
+      # podSelector: "app=myapp"
+      # specify the length of time in seconds to wait before giving up for workload to finish, zero means infinite
+      # timeoutSeconds: 300
 
 rdmaSharedDevicePlugin:
   deploy: true

--- a/hack/release.go
+++ b/hack/release.go
@@ -31,21 +31,22 @@ import (
 )
 
 type Release struct {
-	NetworkOperator        *mellanoxv1alpha1.ImageSpec
-	SriovNetworkOperator   *mellanoxv1alpha1.ImageSpec
-	SriovConfigDaemon      *mellanoxv1alpha1.ImageSpec
-	SriovCni               *mellanoxv1alpha1.ImageSpec
-	SriovIbCni             *mellanoxv1alpha1.ImageSpec
-	Mofed                  *mellanoxv1alpha1.ImageSpec
-	RdmaSharedDevicePlugin *mellanoxv1alpha1.ImageSpec
-	SriovDevicePlugin      *mellanoxv1alpha1.ImageSpec
-	IbKubernetes           *mellanoxv1alpha1.ImageSpec
-	CniPlugins             *mellanoxv1alpha1.ImageSpec
-	Multus                 *mellanoxv1alpha1.ImageSpec
-	Ipoib                  *mellanoxv1alpha1.ImageSpec
-	IpamPlugin             *mellanoxv1alpha1.ImageSpec
-	NvIPAM                 *mellanoxv1alpha1.ImageSpec
-	NicFeatureDiscovery    *mellanoxv1alpha1.ImageSpec
+	NetworkOperator              *mellanoxv1alpha1.ImageSpec
+	NetworkOperatorInitContainer *mellanoxv1alpha1.ImageSpec
+	SriovNetworkOperator         *mellanoxv1alpha1.ImageSpec
+	SriovConfigDaemon            *mellanoxv1alpha1.ImageSpec
+	SriovCni                     *mellanoxv1alpha1.ImageSpec
+	SriovIbCni                   *mellanoxv1alpha1.ImageSpec
+	Mofed                        *mellanoxv1alpha1.ImageSpec
+	RdmaSharedDevicePlugin       *mellanoxv1alpha1.ImageSpec
+	SriovDevicePlugin            *mellanoxv1alpha1.ImageSpec
+	IbKubernetes                 *mellanoxv1alpha1.ImageSpec
+	CniPlugins                   *mellanoxv1alpha1.ImageSpec
+	Multus                       *mellanoxv1alpha1.ImageSpec
+	Ipoib                        *mellanoxv1alpha1.ImageSpec
+	IpamPlugin                   *mellanoxv1alpha1.ImageSpec
+	NvIPAM                       *mellanoxv1alpha1.ImageSpec
+	NicFeatureDiscovery          *mellanoxv1alpha1.ImageSpec
 }
 
 func readDefaults(releaseDefaults string) Release {
@@ -80,6 +81,7 @@ func initWithEnvVariale(name string, image *mellanoxv1alpha1.ImageSpec) {
 
 func readEnvironmentVariables(release *Release) {
 	initWithEnvVariale("NETWORK_OPERATOR", release.NetworkOperator)
+	initWithEnvVariale("NETWORK_OPERATOR_INIT_CONTAINER", release.NetworkOperatorInitContainer)
 	initWithEnvVariale("MOFED", release.Mofed)
 	initWithEnvVariale("RDMA_SHARED_DEVICE_PLUGIN", release.RdmaSharedDevicePlugin)
 	initWithEnvVariale("SRIOV_DEVICE_PLUGIN", release.SriovDevicePlugin)

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -1,6 +1,10 @@
 NetworkOperator:
   image: network-operator
   repository: nvcr.io/nvstaging/mellanox
+NetworkOperatorInitContainer:
+  image: network-operator-init-container
+  repository: ghcr.io/mellanox
+  version: v0.0.2
 SriovNetworkOperator:
   image: sriov-network-operator
   repository: nvcr.io/nvstaging/mellanox

--- a/hack/templates/config/manager/init_container_image_name_patch.template
+++ b/hack/templates/config/manager/init_container_image_name_patch.template
@@ -1,0 +1,5 @@
+- op: add
+  path: "/spec/template/spec/containers/0/env/-"
+  value:
+    name: OFED_INIT_CONTAINER_IMAGE
+    value: "{{ .NetworkOperatorInitContainer.Repository }}/{{ .NetworkOperatorInitContainer.Image }}:{{ .NetworkOperatorInitContainer.Version }}"

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -169,6 +169,11 @@ ofedDriver:
   image: {{ .Mofed.Image }}
   repository: {{ .Mofed.Repository }}
   version: {{ .Mofed.Version }}
+  initContainer:
+    enable: true
+    repository: {{ .NetworkOperatorInitContainer.Repository }}
+    image: {{ .NetworkOperatorInitContainer.Image }}
+    version: {{ .NetworkOperatorInitContainer.Version }}
   # imagePullSecrets: []
   # env, if defined will pass environment variables to the OFED container
   # env:
@@ -181,7 +186,6 @@ ofedDriver:
   # Custom ssl key/certificate configuration
   certConfig:
     name: ""
-
   startupProbe:
     initialDelaySeconds: 10
     periodSeconds: 20
@@ -198,6 +202,8 @@ ofedDriver:
     # how many nodes can be upgraded in parallel (default: 1)
     # 0 means no limit, all nodes will be upgraded in parallel
     maxParallelUpgrades: 1
+    # cordon and drain (if enabled) a node before loading the driver on it
+    safeLoad: false
     # options for node drain (`kubectl drain`) before the driver reload
     # if auto upgrade is enabled but drain.enable is false,
     # then driver POD will be reloaded immediately without
@@ -209,6 +215,11 @@ ofedDriver:
       # It's recommended to set a timeout to avoid infinite drain in case non-fatal error keeps happening on retries
       timeoutSeconds: 300
       deleteEmptyDir: false
+    waitForCompletion:
+      # specifies a label selector for the pods to wait for completion
+      # podSelector: "app=myapp"
+      # specify the length of time in seconds to wait before giving up for workload to finish, zero means infinite
+      # timeoutSeconds: 300
 
 rdmaSharedDevicePlugin:
   deploy: true

--- a/manifests/state-ofed-driver/0010_service-account.openshift.yaml
+++ b/manifests/state-ofed-driver/0010_service-account.openshift.yaml
@@ -1,7 +1,0 @@
-{{ if .RuntimeSpec.IsOpenshift }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ofed-driver
-  namespace: {{ .RuntimeSpec.Namespace }}
-{{end}}

--- a/manifests/state-ofed-driver/0010_service-account.yaml
+++ b/manifests/state-ofed-driver/0010_service-account.yaml
@@ -1,0 +1,18 @@
+# 2023 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ofed-driver
+  namespace: {{ .RuntimeSpec.Namespace }}

--- a/manifests/state-ofed-driver/0020_cluster_role.yaml
+++ b/manifests/state-ofed-driver/0020_cluster_role.yaml
@@ -1,0 +1,24 @@
+# 2023 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ofed-driver
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "patch", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]

--- a/manifests/state-ofed-driver/0030_cluster_role_binding.yaml
+++ b/manifests/state-ofed-driver/0030_cluster_role_binding.yaml
@@ -1,0 +1,25 @@
+# 2023 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ofed-driver
+subjects:
+  - kind: ServiceAccount
+    name: ofed-driver
+    namespace: {{ .RuntimeSpec.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: ofed-driver
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/state-ofed-driver/0040_ofed_init_container_config-configmap.yaml
+++ b/manifests/state-ofed-driver/0040_ofed_init_container_config-configmap.yaml
@@ -1,0 +1,28 @@
+# 2023 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .RuntimeSpec.InitContainerConfig.InitContainerEnable  }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ofed-init-container-config
+  namespace: {{ .RuntimeSpec.Namespace }}
+data:
+  config.json: |-
+    {
+      "safeDriverLoad": {
+        "enable": {{ .RuntimeSpec.InitContainerConfig.SafeLoadEnable }},
+        "annotation": "{{ .RuntimeSpec.InitContainerConfig.SafeLoadAnnotation }}"
+      }
+    }
+{{end}}

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 NVIDIA
+# Copyright 2023 NVIDIA
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,15 +40,33 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
-{{ if .RuntimeSpec.IsOpenshift }}
       serviceAccountName: ofed-driver
-{{end}}
       hostNetwork: true
       {{- if .CrSpec.ImagePullSecrets }}
       imagePullSecrets:
       {{- range .CrSpec.ImagePullSecrets }}
         - name: {{ . }}
       {{- end }}
+      {{- end }}
+      {{- if .RuntimeSpec.InitContainerConfig.InitContainerEnable  }}
+      initContainers:
+        - name: network-operator-init-container
+          imagePullPolicy: IfNotPresent
+          image: {{ .RuntimeSpec.InitContainerConfig.InitContainerImageName }}
+          args:
+            - --node-name
+            - $(NODE_NAME)
+            - --configmap-name
+            - ofed-init-container-config
+            - --configmap-namespace
+            - {{ .RuntimeSpec.Namespace }}
+            - --configmap-key
+            - config.json
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
       {{- end }}
       containers:
         - image: {{ .RuntimeSpec.MOFEDImageName }}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type OperatorConfig struct {
 type StateConfig struct {
 	NetworkOperatorResourceNamespace string `env:"POD_NAMESPACE" envDefault:"nvidia-network-operator"`
 	ManifestBaseDir                  string `env:"STATE_MANIFEST_BASE_DIR" envDefault:"./manifests"`
+	OFEDState                        OFEDStateConfig
 }
 
 // Controller related configurations
@@ -44,6 +45,14 @@ type ControllerConfig struct {
 	//nolint:stylecheck
 	// Request requeue time(seconds) in case the system still needs to be reconciled
 	RequeueTimeSeconds uint `env:"CONTROLLER_REQUEST_REQUEUE_SECONDS" envDefault:"5"`
+}
+
+// OFEDStateConfig contains extra configuration options for the OFED state which
+// can't be configured via CRD
+type OFEDStateConfig struct {
+	// InitContainerImage is a full image name (registry, image name, tag) for the OFED init container.
+	// The init container will not be deployed if this variable is empty/not set.
+	InitContainerImage string `env:"OFED_INIT_CONTAINER_IMAGE"`
 }
 
 func FromEnv() *OperatorConfig {

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -78,6 +78,55 @@ var _ = Describe("MOFED state test", func() {
 		})
 	})
 
+	Context("Init container", func() {
+		It("getInitContainerConfig", func() {
+			cr := &v1alpha1.NicClusterPolicy{
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						OfedUpgradePolicy: &v1alpha1.DriverUpgradePolicySpec{
+							AutoUpgrade: true,
+							SafeLoad:    true,
+						},
+					},
+				},
+			}
+			cfg := stateOfed.getInitContainerConfig(cr, testLogger, "repository/image:version")
+			Expect(cfg.SafeLoadAnnotation).NotTo(BeEmpty())
+			Expect(cfg.SafeLoadEnable).To(BeTrue())
+			Expect(cfg.InitContainerEnable).To(BeTrue())
+			Expect(cfg.InitContainerImageName).To(Equal("repository/image:version"))
+		})
+		It("getInitContainerConfig - no image", func() {
+			cr := &v1alpha1.NicClusterPolicy{
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						OfedUpgradePolicy: &v1alpha1.DriverUpgradePolicySpec{
+							AutoUpgrade: true,
+							SafeLoad:    true,
+						},
+					},
+				},
+			}
+			cfg := stateOfed.getInitContainerConfig(cr, testLogger, "")
+			Expect(cfg.SafeLoadEnable).To(BeFalse())
+			Expect(cfg.InitContainerEnable).To(BeFalse())
+		})
+		It("getInitContainerConfig - SafeLoad disabled if AutoUpgrade is false ", func() {
+			cr := &v1alpha1.NicClusterPolicy{
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						OfedUpgradePolicy: &v1alpha1.DriverUpgradePolicySpec{
+							AutoUpgrade: false,
+							SafeLoad:    true,
+						},
+					},
+				},
+			}
+			cfg := stateOfed.getInitContainerConfig(cr, testLogger, "repository/image:version")
+			Expect(cfg.SafeLoadEnable).To(BeFalse())
+			Expect(cfg.InitContainerEnable).To(BeTrue())
+		})
+	})
 	Context("Proxy config", func() {
 		It("Set Proxy from Cluster Wide Proxy", func() {
 			cr := &v1alpha1.NicClusterPolicy{


### PR DESCRIPTION
On Node startup, the OFED container takes some time to compile and load the driver. 
During that time, workloads might get scheduled on that Node.
When OFED is loaded, all existing PODs that use NVIDIA NICs will lose their network interfaces.
Some such PODs might silently fail or hang.
To avoid such a situation, before the OFED container is loaded, 
the Node should get Cordoned and Drained to ensure all workloads are rescheduled.
The Node should be un-cordoned when the driver is ready on it.

The safe driver loading feature is implemented as a part of the upgrade flow,
meaning safe driver loading is a special scenario of the upgrade procedure,
where we upgrade from the inbox driver to the containerized OFED.

depends on: #685 