### PR TITLE
Add tolerations, nodeSelector and affinity rules to upgrade CRD job

### DIFF
--- a/deployment/network-operator/templates/upgrade-crd.yaml
+++ b/deployment/network-operator/templates/upgrade-crd.yaml
@@ -62,6 +62,18 @@ spec:
         {{- include "network-operator.labels" . | nindent 8 }}
         app.kubernetes.io/component: "network-operator"
     spec:
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity}}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}-hooks-sa
       imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}
       containers:


### PR DESCRIPTION
Align tolerations, nodeSelector and affinity rules  with the network-operator Pod