### PR TITLE
Remove wildcard permissions from controllers' roles

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,5 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:7005fa24a1ae52d927e76d50d90fddf6b6c7b08885a2dad3c7e5e2c2ac21c834
-  name: controller
-  newName: nvcr.io/nvidia/cloud-native/network-operator
+- name: controller
+  newName: mellanox/network-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -158,13 +158,7 @@ rules:
 - apiGroups:
   - k8s.cni.cncf.io
   resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - mellanox.com
-  resources:
-  - '*'
+  - network-attachment-definitions
   verbs:
   - create
   - delete
@@ -233,6 +227,19 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - mellanox.com
+  resources:
+  - nicclusterpolicies
+  - nicclusterpolicies/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/controllers/hostdevicenetwork_controller.go
+++ b/controllers/hostdevicenetwork_controller.go
@@ -48,9 +48,10 @@ type HostDeviceNetworkReconciler struct {
 	stateManager state.Manager
 }
 
+//nolint:lll
 // +kubebuilder:rbac:groups=mellanox.com,resources=hostdevicenetworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=mellanox.com,resources=hostdevicenetworks/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=*,verbs=*
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/ipoibnetwork_controller.go
+++ b/controllers/ipoibnetwork_controller.go
@@ -48,10 +48,10 @@ type IPoIBNetworkReconciler struct {
 	stateManager state.Manager
 }
 
+//nolint:lll
 // +kubebuilder:rbac:groups=mellanox.com,resources=ipoibnetworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=mellanox.com,resources=ipoibnetworks/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=mellanox.com,resources=*,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=*,verbs=*
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/macvlannetwork_controller.go
+++ b/controllers/macvlannetwork_controller.go
@@ -50,10 +50,10 @@ type MacvlanNetworkReconciler struct {
 	stateManager state.Manager
 }
 
+//nolint:lll
 // +kubebuilder:rbac:groups=mellanox.com,resources=macvlannetworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=mellanox.com,resources=macvlannetworks/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=mellanox.com,resources=*,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=*,verbs=*
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -54,8 +54,9 @@ type NicClusterPolicyReconciler struct {
 }
 
 // In case of adding support for additional types, also update in getSupportedGVKs func in pkg/state/state_skel.go
-//nolint
-// +kubebuilder:rbac:groups=mellanox.com,resources=*,verbs=get;list;watch;create;update;patch;delete
+
+//nolint:lll
+// +kubebuilder:rbac:groups=mellanox.com,resources=nicclusterpolicies;nicclusterpolicies/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/upgrade_controller.go
+++ b/controllers/upgrade_controller.go
@@ -59,8 +59,8 @@ const plannedRequeueInterval = time.Minute * 2
 // UpgradeStateAnnotation is kept for backwards cleanup TODO: drop in 2 releases
 const UpgradeStateAnnotation = "nvidia.com/ofed-upgrade-state"
 
-//nolint
-// +kubebuilder:rbac:groups=mellanox.com,resources=*,verbs=get;list;watch;create;update;patch;delete
+//nolint:lll
+// +kubebuilder:rbac:groups=mellanox.com,resources=nicclusterpolicies;nicclusterpolicies/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=list
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets;controllerrevisions,verbs=get;list;watch;create;update;patch;delete

--- a/manifests/state-multus-cni/0010-cluter_role.yml
+++ b/manifests/state-multus-cni/0010-cluter_role.yml
@@ -18,9 +18,15 @@ metadata:
 rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources:
-      - '*'
+      - network-attachment-definitions
     verbs:
-      - '*'
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
This brings back the changes from https://github.com/Mellanox/network-operator/pull/596

Previously, the CI failed because apart from `mellanox/nicclusterpolicies` resource, `mellanox/nicclusterpolicies/status` also needs to be explicitely mentiones.
Other than that, multus cluster role also required wildcard permissions for k8s.cni.cncf.io group. Limited them to `network-attachment-definition`
