### PR TITLE
Add update permission for nicclusterpolicies/finalizers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -266,6 +266,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - mellanox.com
+  resources:
+  - nicclusterpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -57,6 +57,7 @@ type NicClusterPolicyReconciler struct {
 
 //nolint:lll
 // +kubebuilder:rbac:groups=mellanox.com,resources=nicclusterpolicies;nicclusterpolicies/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mellanox.com,resources=nicclusterpolicies/finalizers,verbs=update
 // +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Without this permission we will got `is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on` error