### PR TITLE
chore:  update base image to ubi8-micro 8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir crds && \
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi8-micro:8.5
+FROM registry.access.redhat.com/ubi8-micro:8.8
 
 ARG BUILD_DATE
 ARG VERSION


### PR DESCRIPTION
update base image to receive latest security fixes
