### PR TITLE
feat: add controller revision to managed resources

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -38,4 +38,5 @@ const (
 	// that network-operator pod should be skipped during the drain operation which
 	// is executed by the upgrade controller.
 	OfedDriverSkipDrainLabelSelector = "nvidia.com/ofed-driver-upgrade-drain.skip!=true"
+	ControllerRevisionAnnotation     = "nvidia.network-operator.revision"
 )

--- a/pkg/revision/revision.go
+++ b/pkg/revision/revision.go
@@ -1,0 +1,69 @@
+/*
+ 2023 NVIDIA CORPORATION & AFFILIATES
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package revision
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Mellanox/network-operator/pkg/consts"
+)
+
+// ControllerRevision is the data to be stored as checkpoint
+type ControllerRevision uint32
+
+// CalculateRevision calculates controller revision for the object
+func CalculateRevision(o client.Object) (ControllerRevision, error) {
+	rev, err := getHash(o)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compute controller revision for the object: %v", err)
+	}
+	return ControllerRevision(rev), nil
+}
+
+// GetRevision returns controller revision which is saved in the object.
+// returns 0 if revision is not set for the object
+func GetRevision(o client.Object) ControllerRevision {
+	val := o.GetAnnotations()[consts.ControllerRevisionAnnotation]
+	rev, err := strconv.ParseUint(val, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return ControllerRevision(rev)
+}
+
+// SetRevision saves controller revision to the object.
+func SetRevision(o client.Object, rev ControllerRevision) {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[consts.ControllerRevisionAnnotation] = strconv.FormatUint(uint64(rev), 10)
+	o.SetAnnotations(annotations)
+}
+
+// Get returns calculated checksum for the object
+func getHash(o client.Object) (uint32, error) {
+	h := fnv.New32a()
+	data, err := json.Marshal(o)
+	if err != nil {
+		return 0, err
+	}
+	_, _ = h.Write(data)
+	return h.Sum32(), nil
+}

--- a/pkg/revision/revision_suite_test.go
+++ b/pkg/revision/revision_suite_test.go
@@ -1,0 +1,26 @@
+/*
+ 2023 NVIDIA CORPORATION & AFFILIATES
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package revision_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRevision(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Revision Suite")
+}

--- a/pkg/revision/revision_test.go
+++ b/pkg/revision/revision_test.go
@@ -1,0 +1,58 @@
+/*
+ 2023 NVIDIA CORPORATION & AFFILIATES
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package revision_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Mellanox/network-operator/pkg/revision"
+)
+
+var _ = Describe("Revision", func() {
+	Context("CalculateRevision", func() {
+		It("Should be equal for same objects", func() {
+			o := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj1", Namespace: "ns1"}}
+			rev1, err := revision.CalculateRevision(o)
+			Expect(err).NotTo(HaveOccurred())
+			rev2, err := revision.CalculateRevision(o)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rev1).To(Equal(rev2))
+		})
+		It("Should not be equal for different objects", func() {
+			o1 := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj1", Namespace: "ns1"}}
+			o2 := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj2", Namespace: "ns2"}}
+			rev1, err := revision.CalculateRevision(o1)
+			Expect(err).NotTo(HaveOccurred())
+			rev2, err := revision.CalculateRevision(o2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rev1).NotTo(Equal(rev2))
+		})
+	})
+	Context("Set/Get Revision", func() {
+		It("Should get revision set by setter", func() {
+			o := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj1", Namespace: "ns1"}}
+			testRev := revision.ControllerRevision(1000)
+			revision.SetRevision(o, testRev)
+			Expect(revision.GetRevision(o)).To(Equal(testRev))
+		})
+		It("Should return zero if revision not set", func() {
+			o := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj1", Namespace: "ns1"}}
+			Expect(revision.GetRevision(o)).To(Equal(revision.ControllerRevision(0)))
+		})
+	})
+})


### PR DESCRIPTION
Inject controller generated revision to all managed objects as annotation. 
The revision is later used to check if object update is required. 
This change should help to reduce amount of API calls to Kubernetes.

fixes #614 