### PR TITLE
fix: add missing roles in chart

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
@@ -108,6 +108,13 @@ rules:
       - 'leases'
     verbs:
       - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
sriov network operator config daemon
requires access to events.