### PR TITLE
fix: remove extra selector from network-operator Deployment

### DIFF
--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -25,7 +25,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: {{ .Release.Name }}-controller
       {{- include "network-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:


### PR DESCRIPTION
Remove `control-plane: {{ .Release.Name }}-controller` selector from the network-operator object in the helm chart
to fix helm upgrade behaviour.

With the current selector we will have the following error when trying to upgrade from the latest GA version (23.7)

```
helm upgrade -n nvidia-network-operator network-operator ./network-operator -f myvalues.yaml 
Error: UPGRADE FAILED: cannot patch "network-operator" with kind Deployment: Deployment.apps "network-operator" is i
nvalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"n
etwork-operator", "app.kubernetes.io/name":"network-operator", "control-plane":"network-operator-controller"}, Match
Expressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable       

```

The extra selector was added as a part of https://github.com/Mellanox/network-operator/pull/645