### PR TITLE
chore: Update Node Selector for node policy

### DIFF
--- a/example/sriov-network/sriov-network-node-policy-legacy.yaml
+++ b/example/sriov-network/sriov-network-node-policy-legacy.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   resourceName: sriovlegacy
   nodeSelector:
-    feature.node.kubernetes.io/network-sriov.capable: "true"
+    feature.node.kubernetes.io/pci-15b3.present: "true"
   numVfs: 1
   nicSelector:
     vendor: "15b3"

--- a/example/sriov-network/sriov-network-node-policy-switchdev.yaml
+++ b/example/sriov-network/sriov-network-node-policy-switchdev.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   resourceName: sriovswitchdev
   nodeSelector:
-    feature.node.kubernetes.io/network-sriov.capable: "true"
+    feature.node.kubernetes.io/pci-15b3.present: "true"
   numVfs: 1
   nicSelector:
     vendor: "15b3"


### PR DESCRIPTION
It is recommended to use the following node selector in SRIOV network policy:
`feature.node.kubernetes.io/pci-15b3.present`

