### PR TITLE
chore: Update MOFED to 23.10-0.5.5.0

### DIFF
--- a/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
+++ b/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: mofed
     repository: nvcr.io/nvstaging/mellanox
-    version: 23.10-0.5.4.0
+    version: 23.10-0.5.5.0
     livenessProbe:
       initialDelaySeconds: 30
       periodSeconds: 30

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -167,7 +167,7 @@ ofedDriver:
   deploy: false
   image: mofed
   repository: nvcr.io/nvstaging/mellanox
-  version: 23.10-0.5.4.0
+  version: 23.10-0.5.5.0
   # imagePullSecrets: []
   # env, if defined will pass environment variables to the OFED container
   # env:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: mofed
     repository: nvcr.io/nvstaging/mellanox
-    version: 23.10-0.5.4.0
+    version: 23.10-0.5.5.0
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: mofed
     repository: nvcr.io/nvstaging/mellanox
-    version: 23.10-0.5.4.0
+    version: 23.10-0.5.5.0
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: mofed
     repository: nvcr.io/nvstaging/mellanox
-    version: 23.10-0.5.4.0
+    version: 23.10-0.5.5.0
     upgradePolicy:
       autoUpgrade: false
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: mofed
     repository: nvcr.io/nvstaging/mellanox
-    version: 23.10-0.5.4.0
+    version: 23.10-0.5.5.0
     upgradePolicy:
       autoUpgrade: false
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: mofed
     repository: nvcr.io/nvstaging/mellanox
-    version: 23.10-0.5.4.0
+    version: 23.10-0.5.5.0
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -20,7 +20,7 @@ SriovIbCni:
 Mofed:
   image: mofed
   repository: nvcr.io/nvstaging/mellanox
-  version: 23.10-0.5.4.0
+  version: 23.10-0.5.5.0
 RdmaSharedDevicePlugin:
   image: k8s-rdma-shared-dev-plugin
   repository: ghcr.io/mellanox


### PR DESCRIPTION
MOFED v23.10-0.5.5.0 is a GA version
