### PR TITLE
fix: Allow to enable SR-IOV Network Operator Webhook

### DIFF
--- a/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
+++ b/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
@@ -21,8 +21,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   # Add fields here
-  enableInjector: false
-  enableOperatorWebhook: false
+  {{- with (index .Values "sriov-network-operator" "operator") }}
+  enableInjector: {{ .enableAdmissionController }}
+  enableOperatorWebhook: {{ .enableAdmissionController }}
+  {{- end }}
   configDaemonNodeSelector:
     {{- $defaults := dict "beta.kubernetes.io/os" "linux" "network.nvidia.com/operator.mofed.wait" "false" }}
     {{- $selectors := merge $defaults (.Values.sriovNetworkOperator.configDaemonNodeSelectorExtra | default dict  ) }}


### PR DESCRIPTION
We need to take into account SR-IOV Network Operator help values during SriovOperatorConfig deployment.

Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>
(cherry picked from commit 6f74cebbe57d1f0bcd4d430a4144a85bd389389f)