### PR TITLE
fix: remove stale objects handling from *network CR states

### DIFF
--- a/pkg/state/state_hostdevice_network.go
+++ b/pkg/state/state_hostdevice_network.go
@@ -105,13 +105,6 @@ func (s *stateHostDeviceNetwork) Sync(
 	if err != nil {
 		return SyncStateNotReady, errors.Wrap(err, "failed to create/update objects")
 	}
-	waitForStaleObjectsRemoval, err := s.handleStaleStateObjects(ctx, objs)
-	if err != nil {
-		return SyncStateNotReady, errors.Wrap(err, "failed to handle state stale objects")
-	}
-	if waitForStaleObjectsRemoval {
-		return SyncStateNotReady, nil
-	}
 	// Check objects status
 	syncState, err := s.getSyncState(ctx, objs)
 	if err != nil {

--- a/pkg/state/state_ipoib_network.go
+++ b/pkg/state/state_ipoib_network.go
@@ -105,13 +105,6 @@ func (s *stateIPoIBNetwork) Sync(ctx context.Context, customResource interface{}
 	if err != nil {
 		return SyncStateNotReady, errors.Wrap(err, "failed to create/update objects")
 	}
-	waitForStaleObjectsRemoval, err := s.handleStaleStateObjects(ctx, objs)
-	if err != nil {
-		return SyncStateNotReady, errors.Wrap(err, "failed to handle state stale objects")
-	}
-	if waitForStaleObjectsRemoval {
-		return SyncStateNotReady, nil
-	}
 	// Check objects status
 	syncState, err := s.getSyncState(ctx, objs)
 	if err != nil {

--- a/pkg/state/state_macvlan_network.go
+++ b/pkg/state/state_macvlan_network.go
@@ -105,13 +105,6 @@ func (s *stateMacvlanNetwork) Sync(ctx context.Context, customResource interface
 	if err != nil {
 		return SyncStateNotReady, errors.Wrap(err, "failed to create/update objects")
 	}
-	waitForStaleObjectsRemoval, err := s.handleStaleStateObjects(ctx, objs)
-	if err != nil {
-		return SyncStateNotReady, errors.Wrap(err, "failed to handle state stale objects")
-	}
-	if waitForStaleObjectsRemoval {
-		return SyncStateNotReady, nil
-	}
 	// Check objects status
 	syncState, err := s.getSyncState(ctx, objs)
 	if err != nil {


### PR DESCRIPTION

All CR instances are sharing the same state name, but they handled by a separate Reconcile loop. 
Stale objects removal logic doesn't support this scenario.