### PR TITLE
feat: Support multiple MOFED DS

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -106,21 +106,27 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	migrationCompletionChan := make(chan struct{})
+	close(migrationCompletionChan)
+
 	err = (&HostDeviceNetworkReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:      k8sManager.GetClient(),
+		Scheme:      k8sManager.GetScheme(),
+		MigrationCh: migrationCompletionChan,
 	}).SetupWithManager(k8sManager, testSetupLog)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&IPoIBNetworkReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:      k8sManager.GetClient(),
+		Scheme:      k8sManager.GetScheme(),
+		MigrationCh: migrationCompletionChan,
 	}).SetupWithManager(k8sManager, testSetupLog)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&MacvlanNetworkReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:      k8sManager.GetClient(),
+		Scheme:      k8sManager.GetScheme(),
+		MigrationCh: migrationCompletionChan,
 	}).SetupWithManager(k8sManager, testSetupLog)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -133,6 +139,7 @@ var _ = BeforeSuite(func() {
 		Scheme:               k8sManager.GetScheme(),
 		ClusterTypeProvider:  clusterTypeProvider,
 		StaticConfigProvider: staticConfigProvider,
+		MigrationCh:          migrationCompletionChan,
 	}).SetupWithManager(k8sManager, testSetupLog)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/upgrade_controller_test.go
+++ b/controllers/upgrade_controller_test.go
@@ -55,9 +55,12 @@ var _ = Describe("Upgrade Controller", func() {
 	})
 	Context("When NicClusterPolicy CR is created", func() {
 		It("Upgrade policy is disabled", func() {
+			migrationCompletionChan := make(chan struct{})
+			close(migrationCompletionChan)
 			upgradeReconciler := &UpgradeReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				MigrationCh: migrationCompletionChan,
 			}
 
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: consts.NicClusterPolicyResourceName}}
@@ -76,10 +79,13 @@ var _ = Describe("Upgrade Controller", func() {
 				err := k8sClient.Create(goctx.TODO(), node)
 				Expect(err).NotTo(HaveOccurred())
 			}
+			migrationCompletionChan := make(chan struct{})
+			close(migrationCompletionChan)
 
 			upgradeReconciler := &UpgradeReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				MigrationCh: migrationCompletionChan,
 			}
 			// Call removeNodeUpgradeStateLabels function
 			err := upgradeReconciler.removeNodeUpgradeStateLabels(goctx.TODO())

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -15,20 +15,22 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+    app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}
     nvidia.com/ofed-driver: ""
-  name: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-ds
+    mofed-ds-format-version: "1"
+  name: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}-ds
   namespace: {{ .RuntimeSpec.Namespace }}
 spec:
   updateStrategy:
     type: OnDelete
   selector:
     matchLabels:
-      app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+      app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}
   template:
     metadata:
       labels:
-        app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
+        app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}
+        kernel: {{ .RuntimeSpec.Kernel }}
         nvidia.com/ofed-driver: ""
     spec:
       priorityClassName: system-node-critical
@@ -250,6 +252,10 @@ spec:
         feature.node.kubernetes.io/pci-15b3.present: "true"
         feature.node.kubernetes.io/system-os_release.ID: {{ .RuntimeSpec.OSName }}
         feature.node.kubernetes.io/system-os_release.VERSION_ID: "{{ .RuntimeSpec.OSVer }}"
+        feature.node.kubernetes.io/kernel-version.full: "{{ .RuntimeSpec.Kernel }}"
+        {{- if .RuntimeSpec.UseDtk }}
+        feature.node.kubernetes.io/system-os_release.OSTREE_VERSION: "{{ .RuntimeSpec.RhcosVersion }}"
+        {{- end }}
       {{- if .NodeAffinity }}
       affinity:
         nodeAffinity:

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,7 +32,35 @@ import (
 
 	"github.com/Mellanox/network-operator/pkg/config"
 	"github.com/Mellanox/network-operator/pkg/consts"
+
+	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
+
+	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 )
+
+// Migrator migrates from previous versions
+type Migrator struct {
+	K8sClient      client.Client
+	MigrationCh    chan struct{}
+	LeaderElection bool
+	Logger         logr.Logger
+}
+
+// NeedLeaderElection implements manager.NeedLeaderElection
+func (m *Migrator) NeedLeaderElection() bool {
+	return m.LeaderElection
+}
+
+// Start implements manager.Runnable
+func (m *Migrator) Start(ctx context.Context) error {
+	err := Migrate(ctx, m.Logger, m.K8sClient)
+	if err != nil {
+		m.Logger.Error(err, "failed to migrate Network Operator")
+		return err
+	}
+	close(m.MigrationCh)
+	return nil
+}
 
 // Migrate contains logic which should run once during controller start.
 // The main use case for this handler is network-operator upgrade
@@ -53,6 +82,11 @@ func migrate(ctx context.Context, log logr.Logger, c client.Client) error {
 	if err := removeStateLabelFromNVIpamConfigMap(ctx, log, c); err != nil {
 		// critical for the operator operation, will fail NVIPAM migration
 		log.V(consts.LogLevelError).Error(err, "error trying to remove state label on NV IPAM configmap")
+		return err
+	}
+	if err := handleSingleMofedDS(ctx, log, c); err != nil {
+		// critical for the operator operation, will fail Mofed migration
+		log.V(consts.LogLevelError).Error(err, "error trying to handle single MOFED DS")
 		return err
 	}
 	return nil
@@ -114,4 +148,97 @@ func removeStateLabelFromNVIpamConfigMap(ctx context.Context, log logr.Logger, c
 		log.V(consts.LogLevelDebug).Info("state label not set on NVIPAM configmap")
 	}
 	return nil
+}
+
+func handleSingleMofedDS(ctx context.Context, log logr.Logger, c client.Client) error {
+	ncp := &mellanoxv1alpha1.NicClusterPolicy{}
+	key := types.NamespacedName{
+		Name: consts.NicClusterPolicyResourceName,
+	}
+	err := c.Get(ctx, key, ncp)
+	if apiErrors.IsNotFound(err) {
+		log.V(consts.LogLevelDebug).Info("NIC ClusterPolicy not found, skip handling single MOFED DS")
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if ncp.Spec.OFEDDriver == nil {
+		return nil
+	}
+	log.V(consts.LogLevelDebug).Info("Searching for single MOFED DS")
+	dsList := &appsv1.DaemonSetList{}
+	err = c.List(ctx, dsList, client.MatchingLabels{"nvidia.com/ofed-driver": ""})
+	if err != nil {
+		log.V(consts.LogLevelError).Error(err, "fail to list MOFED DS")
+		return err
+	}
+	var ds *appsv1.DaemonSet
+	for i := range dsList.Items {
+		mofedDs := &dsList.Items[i]
+		// The single MOFED DS does not contain the label "mofed-ds-format-version"
+		_, ok := mofedDs.Labels["mofed-ds-format-version"]
+		if ok {
+			continue
+		}
+		log.V(consts.LogLevelDebug).Info("Found single MOFED DS", "name", mofedDs.Name)
+		ds = mofedDs
+		break
+	}
+	if ds != nil {
+		err = markNodesAsUpgradeRequested(ctx, log, c, ds)
+		if err != nil {
+			return err
+		}
+		policy := metav1.DeletePropagationOrphan
+		err = c.Delete(ctx, ds, &client.DeleteOptions{PropagationPolicy: &policy})
+		if err != nil {
+			return err
+		}
+		log.V(consts.LogLevelDebug).Info("Deleted single MOFED DS with orphaned", "name", ds.Name)
+		return nil
+	}
+	log.V(consts.LogLevelDebug).Info("Single MOFED DS not found")
+	return nil
+}
+
+func markNodesAsUpgradeRequested(ctx context.Context, log logr.Logger, c client.Client, ds *appsv1.DaemonSet) error {
+	nodes, err := getDaemonSetNodes(ctx, c, ds)
+	if err != nil {
+		return err
+	}
+	for _, nodeName := range nodes {
+		node := &corev1.Node{}
+		nodeKey := client.ObjectKey{
+			Name: nodeName,
+		}
+		if err := c.Get(context.Background(), nodeKey, node); err != nil {
+			return err
+		}
+		patchString := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: "true"}}}`,
+			upgrade.GetUpgradeRequestedAnnotationKey()))
+		patch := client.RawPatch(types.MergePatchType, patchString)
+		err = c.Patch(ctx, node, patch)
+		if err != nil {
+			return err
+		}
+		log.V(consts.LogLevelDebug).Info("Node annotated with upgrade-requested", "name", nodeName)
+	}
+
+	return nil
+}
+
+func getDaemonSetNodes(ctx context.Context, c client.Client, ds *appsv1.DaemonSet) ([]string, error) {
+	nodeNames := make([]string, 0)
+	pods := &corev1.PodList{}
+	err := c.List(ctx, pods, client.MatchingLabels(ds.Spec.Selector.MatchLabels))
+	if err != nil {
+		return nil, err
+	}
+	for i := range pods.Items {
+		nodeName := pods.Items[i].Spec.NodeName
+		if nodeName != "" {
+			nodeNames = append(nodeNames, nodeName)
+		}
+	}
+	return nodeNames, nil
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -19,7 +19,9 @@ package migrate
 import (
 	goctx "context"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -27,6 +29,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Mellanox/network-operator/pkg/consts"
+
+	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
+
+	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 )
 
 //nolint:dupl
@@ -34,6 +40,8 @@ var _ = Describe("Migrate", func() {
 	AfterEach(func() {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName, Name: nvIPAMcmName}}
 		_ = k8sClient.Delete(goctx.Background(), cm)
+		_ = k8sClient.DeleteAllOf(goctx.Background(), &corev1.Node{})
+		_ = k8sClient.DeleteAllOf(goctx.Background(), &corev1.Pod{})
 	})
 	It("should remove annotation on NVIPAM CM", func() {
 		createConfigMap(true)
@@ -55,6 +63,32 @@ var _ = Describe("Migrate", func() {
 		err := Migrate(goctx.Background(), testLog, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
+	It("should delete MOFED DS", func() {
+		upgrade.SetDriverName("ofed")
+		createNCP()
+		createMofedDS()
+		createNodes()
+		createPods()
+		By("Verify Single DS is deleted")
+		err := Migrate(goctx.Background(), testLog, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() bool {
+			ds := &appsv1.DaemonSet{}
+			err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "test-ds"}, ds)
+			return errors.IsNotFound(err)
+		})
+		By("Verify Nodes have upgrade-requested annotation")
+		Eventually(func() bool {
+			node1 := &corev1.Node{}
+			err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "test-node1"}, node1)
+			Expect(err).NotTo(HaveOccurred())
+			node2 := &corev1.Node{}
+			err = k8sClient.Get(goctx.TODO(), types.NamespacedName{Namespace: namespaceName, Name: "test-node2"}, node2)
+			Expect(err).NotTo(HaveOccurred())
+			return node1.Annotations[upgrade.GetUpgradeRequestedAnnotationKey()] == "true" &&
+				node2.Annotations[upgrade.GetUpgradeRequestedAnnotationKey()] == "true"
+		})
+	})
 })
 
 func createConfigMap(addLabel bool) {
@@ -64,5 +98,112 @@ func createConfigMap(addLabel bool) {
 		cm.Labels[consts.StateLabel] = "state-nv-ipam-cni"
 	}
 	err := k8sClient.Create(goctx.Background(), cm)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createMofedDS() {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaceName,
+			Name:      "test-ds",
+			Labels:    map[string]string{"nvidia.com/ofed-driver": ""},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "mofed-ubuntu22.04"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "mofed-ubuntu22.04"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "mofed-container",
+							Image: "github/mofed",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(goctx.Background(), ds)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createNodes() {
+	By("Create Nodes")
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node1",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+	}
+	err := k8sClient.Create(goctx.TODO(), node)
+	Expect(err).NotTo(HaveOccurred())
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node2",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+	}
+	err = k8sClient.Create(goctx.TODO(), node2)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createPods() {
+	By("Create Pods")
+	gracePeriodSeconds := int64(0)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: namespaceName,
+			Labels:    map[string]string{"app": "mofed-ubuntu22.04"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:                      "test-node1",
+			TerminationGracePeriodSeconds: &gracePeriodSeconds,
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(goctx.TODO(), pod)
+	Expect(err).NotTo(HaveOccurred())
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod2",
+			Namespace: namespaceName,
+			Labels:    map[string]string{"app": "mofed-ubuntu22.04"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:                      "test-node2",
+			TerminationGracePeriodSeconds: &gracePeriodSeconds,
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+	err = k8sClient.Create(goctx.TODO(), pod2)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createNCP() {
+	ncp := &mellanoxv1alpha1.NicClusterPolicy{ObjectMeta: metav1.ObjectMeta{Name: consts.NicClusterPolicyResourceName}}
+	ncp.Spec.OFEDDriver = &mellanoxv1alpha1.OFEDDriverSpec{
+		ImageSpec: mellanoxv1alpha1.ImageSpec{
+			Image:            "mofed",
+			Repository:       "nvcr.io/nvidia/mellanox",
+			Version:          "5.9-0.5.6.0",
+			ImagePullSecrets: []string{},
+		},
+	}
+	err := k8sClient.Create(goctx.Background(), ncp)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/pkg/migrate/suite_test.go
+++ b/pkg/migrate/suite_test.go
@@ -18,6 +18,7 @@ package migrate
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -29,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	mellanoxcomv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,9 +61,21 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	testLog = logf.Log.WithName("test-log").WithName("setup")
 
-	By("bootstrapping test environment")
+	err := mellanoxcomv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
-	testEnv = &envtest.Environment{}
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	// Go to project root directory
+	err = os.Chdir("../..")
+	Expect(err).NotTo(HaveOccurred())
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{"config/crd/bases"},
+		CRDInstallOptions:     envtest.CRDInstallOptions{ErrorIfPathMissing: true},
+		ErrorIfCRDPathMissing: true,
+	}
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/nodeinfo/node_info_test.go
+++ b/pkg/nodeinfo/node_info_test.go
@@ -23,6 +23,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	testArch       = "amd64"
+	testOsUbuntu   = "ubuntu"
+	testOsRhcos    = "rhcos"
+	testOsVer      = "22.04"
+	testKernelFull = "5.15.0-78-generic"
+)
+
 // A Filter applies a filter on a list of Nodes
 type dummyFilter struct {
 	called   bool
@@ -103,4 +111,135 @@ var _ = Describe("nodeinfo Provider tests", func() {
 			Expect(len(attrs)).To(Equal(0))
 		})
 	})
+
+	Context("GetNodePools with filter", func() {
+		It("Should return an empty list of pools", func() {
+			filter := &dummyFilter{filtered: []*corev1.Node{}}
+			provider := NewProvider([]*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsUbuntu, testOsVer, testKernelFull, testArch),
+			})
+			pools := provider.GetNodePools(filter)
+			Expect(len(pools)).To(Equal(0))
+		})
+		It("Should return an empty list of pools, filter by label", func() {
+			node := getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch)
+			delete(node.Labels, NodeLabelMlnxNIC)
+			provider := NewProvider([]*corev1.Node{node})
+			pools := provider.GetNodePools(NewNodeLabelFilterBuilder().WithLabel(NodeLabelMlnxNIC, "true").Build())
+			Expect(len(pools)).To(Equal(0))
+		})
+	})
+
+	Context("GetNodePools without filter", func() {
+		It("Should return pool", func() {
+			provider := NewProvider([]*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsUbuntu, testOsVer, testKernelFull, testArch),
+			})
+			pools := provider.GetNodePools()
+			Expect(len(pools)).To(Equal(1))
+			Expect(pools[0].Arch).To(Equal(testArch))
+			Expect(pools[0].OsName).To(Equal(testOsUbuntu))
+			Expect(pools[0].OsVersion).To(Equal(testOsVer))
+			Expect(pools[0].Kernel).To(Equal(testKernelFull))
+		})
+		DescribeTable("GetNodePools",
+			func(nodeList []*corev1.Node, expectedPools int) {
+				provider := NewProvider(nodeList)
+				pools := provider.GetNodePools()
+				Expect(len(pools)).To(Equal(expectedPools))
+			},
+			Entry("single pool, multiple nodes same NFD labels", []*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-3", testOsUbuntu, testOsVer, testKernelFull, testArch),
+			}, 1),
+			Entry("2 pools, multiple nodes different OS NFD labels", []*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsRhcos, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-3", testOsRhcos, testOsVer, testKernelFull, testArch),
+			}, 2),
+			Entry("2 pools, multiple nodes different OSVer NFD labels", []*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsUbuntu, "20.04", testKernelFull, testArch),
+			}, 2),
+			Entry("2 pools, multiple nodes different KernelFull NFD labels", []*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsUbuntu, testOsVer, "6", testArch),
+			}, 2),
+			Entry("1 pool, multiple nodes different arch NFD labels", []*corev1.Node{
+				getNodeWithNfdLabels("Node-1", testOsUbuntu, testOsVer, testKernelFull, testArch),
+				getNodeWithNfdLabels("Node-2", testOsUbuntu, testOsVer, testKernelFull, "arm"),
+			}, 1),
+			Entry("no pool, node without NFD labels", []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "Node-1"},
+				},
+			}, 0),
+			Entry("no pool, node with missing osName NFD label", []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node-1",
+						Labels: map[string]string{
+							NodeLabelMlnxNIC:       "true",
+							NodeLabelOSVer:         testOsVer,
+							NodeLabelKernelVerFull: testKernelFull,
+							NodeLabelCPUArch:       testArch,
+						}},
+				},
+			}, 0),
+			Entry("no pool, node with missing osVer NFD label", []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node-1",
+						Labels: map[string]string{
+							NodeLabelMlnxNIC:       "true",
+							NodeLabelOSName:        testOsUbuntu,
+							NodeLabelKernelVerFull: testKernelFull,
+							NodeLabelCPUArch:       testArch,
+						}},
+				},
+			}, 0),
+			Entry("no pool, node with missing arch NFD label", []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node-1",
+						Labels: map[string]string{
+							NodeLabelMlnxNIC:       "true",
+							NodeLabelOSName:        testOsUbuntu,
+							NodeLabelOSVer:         testOsVer,
+							NodeLabelKernelVerFull: testKernelFull,
+						}},
+				},
+			}, 0),
+			Entry("no pool, node with missing Kernel full NFD label", []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node-1",
+						Labels: map[string]string{
+							NodeLabelMlnxNIC: "true",
+							NodeLabelOSName:  testOsUbuntu,
+							NodeLabelOSVer:   testOsVer,
+							NodeLabelCPUArch: testArch,
+						}},
+				},
+			}, 0),
+		)
+	})
 })
+
+func getNodeWithNfdLabels(name, osName, osVer, kernelFull, arch string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				NodeLabelMlnxNIC:       "true",
+				NodeLabelOSName:        osName,
+				NodeLabelOSVer:         osVer,
+				NodeLabelKernelVerFull: kernelFull,
+				NodeLabelCPUArch:       arch,
+			},
+		},
+	}
+}

--- a/pkg/state/dummy_provider.go
+++ b/pkg/state/dummy_provider.go
@@ -50,6 +50,17 @@ func (d *dummyProvider) GetNodesAttributes(...nodeinfo.Filter) []nodeinfo.NodeAt
 	return []nodeinfo.NodeAttributes{{Attributes: nodeAttr}}
 }
 
+func (d *dummyProvider) GetNodePools(...nodeinfo.Filter) []nodeinfo.NodePool {
+	return []nodeinfo.NodePool{
+		{
+			Name:      "ubuntu20.04-5.15",
+			OsName:    "ubuntu",
+			OsVersion: "20.04",
+			Kernel:    "5.15.0-78-generic",
+		},
+	}
+}
+
 func getDummyCatalog() InfoCatalog {
 	catalog := NewInfoCatalog()
 	catalog.Add(InfoTypeNodeInfo, &dummyProvider{})

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -19,7 +19,6 @@ package state
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -33,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Mellanox/network-operator/pkg/consts"
-	"github.com/Mellanox/network-operator/pkg/nodeinfo"
 	"github.com/Mellanox/network-operator/pkg/render"
 	"github.com/Mellanox/network-operator/pkg/revision"
 )
@@ -462,16 +460,6 @@ func (s *stateSkel) isDaemonSetReady(uds *unstructured.Unstructured, reqLogger l
 		return true, nil
 	}
 	return false, nil
-}
-
-// Check if provided attrTypes are present in NodeAttributes.Attributes
-func (s *stateSkel) checkAttributesExist(attrs nodeinfo.NodeAttributes, attrTypes ...nodeinfo.AttributeType) error {
-	for _, t := range attrTypes {
-		if _, ok := attrs.Attributes[t]; !ok {
-			return fmt.Errorf("mandatory node attribute does not exist for node %s", attrs.Name)
-		}
-	}
-	return nil
 }
 
 func (s *stateSkel) SetRenderer(renderer render.Renderer) {


### PR DESCRIPTION
Mofed driver precompiled container images
are compiled using a specific Kernel.

As a result, the Mofed Driver DaemonSet should
have the Kernel as part of the Node Selector.

In addition, since there can be Nodes with different Kernel versions, a DaemonSet for each existing Kernel in the cluster is created.
