### PR TITLE
docs: add deprecation notice

### DIFF
--- a/deployment/network-operator/templates/NOTES.txt
+++ b/deployment/network-operator/templates/NOTES.txt
@@ -1,3 +1,11 @@
 Get Network Operator deployed resources by running the following commands:
 
 $ kubectl -n {{ .Release.Namespace }} get pods
+
+{{ if .Values.deployCR }}
+IMPORTANT:
+  * Deploying NicClusterPolicy Custom Resource through helm is deprecated,
+  * support will be removed in future release.
+  * Please set deployCR=false in your helm values and create/update NicClusterPolicy
+  * Custom Resource directly, post helm install/update. 
+{{- end}}


### PR DESCRIPTION
Add deprecation notice to helm notes in case
user deployed CR via helm.

This mode of operation is intended to be deprecated Users should transition to deploying CR independently post helm install/update