### PR TITLE
fix: add label changed predicate for node obj in upgrade controller

### DIFF
--- a/controllers/upgrade_controller.go
+++ b/controllers/upgrade_controller.go
@@ -222,8 +222,10 @@ func (r *UpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return ok
 	}))
 
-	// Watch for spec and annotation changes
-	nodePredicates := builder.WithPredicates(predicate.AnnotationChangedPredicate{})
+	// react only on label and annotation changes
+	nodePredicates := builder.WithPredicates(
+		predicate.Or(predicate.AnnotationChangedPredicate{},
+			predicate.LabelChangedPredicate{}))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mellanoxv1alpha1.NicClusterPolicy{}).


### PR DESCRIPTION
This change is needed because common upgrade lib is using both labels and annotations to store upgrade state. 
This change increase performance of the upgrade controller.