### PR TITLE
chore: Update SR-IOV Network Operator chart to consume new cert logic

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/templates/certificate.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/certificate.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.operator.admissionControllers.enabled }}
+{{- if and (.Values.operator.admissionControllers.certificates.certManager.enabled) (.Values.operator.admissionControllers.certificates.certManager.generateSelfSigned) }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - operator-webhook-service.{{ .Release.Namespace }}.svc
+  - operator-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: operator-webhook-selfsigned-issuer
+  secretName: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: operator-webhook-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.operator.admissionControllers.certificates.secretNames.injector }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - network-resources-injector-service.{{ .Release.Namespace }}.svc
+  - network-resources-injector-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: network-resources-injector-selfsigned-issuer
+  secretName: {{ .Values.operator.admissionControllers.certificates.secretNames.injector }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: network-resources-injector-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- else if and (not .Values.operator.admissionControllers.certificates.certManager.enabled) (.Values.operator.admissionControllers.certificates.custom.enabled) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  ca.crt: {{ .Values.operator.admissionControllers.certificates.custom.operator.caCrt | b64enc | b64enc | quote }}
+  tls.crt: {{ .Values.operator.admissionControllers.certificates.custom.operator.tlsCrt | b64enc | quote }}
+  tls.key: {{ .Values.operator.admissionControllers.certificates.custom.operator.tlsKey | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.operator.admissionControllers.certificates.secretNames.injector }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  ca.crt: {{ .Values.operator.admissionControllers.certificates.custom.injector.caCrt | b64enc | b64enc | quote }}
+  tls.crt: {{ .Values.operator.admissionControllers.certificates.custom.injector.tlsCrt | b64enc | quote }}
+  tls.key: {{ .Values.operator.admissionControllers.certificates.custom.injector.tlsKey | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
@@ -43,7 +43,6 @@ spec:
           image: {{ .Values.images.operator }}
           command:
             - sriov-network-operator
-          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 100m
@@ -69,8 +68,6 @@ spec:
               value: {{ .Values.images.webhook }}
             - name: RESOURCE_PREFIX
               value: {{ .Values.operator.resourcePrefix }}
-            - name: ENABLE_ADMISSION_CONTROLLER
-              value: {{ .Values.operator.enableAdmissionController | quote }}
             - name: IMAGE_PULL_SECRETS
               value: {{ join "," .Values.imagePullSecrets }}
             - name: NAMESPACE
@@ -91,3 +88,26 @@ spec:
               value: {{ .Values.operator.cniBinPath }}
             - name: CLUSTER_TYPE
               value: {{ .Values.operator.clusterType }}
+            - name: ADMISSION_CONTROLLERS_ENABLED
+              value: {{ .Values.operator.admissionControllers.enabled | quote }}
+        {{- if .Values.operator.admissionControllers.enabled }}
+            - name: ADMISSION_CONTROLLERS_CERTIFICATES_OPERATOR_SECRET_NAME
+              value: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}
+            - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME
+              value: {{ .Values.operator.admissionControllers.certificates.secretNames.injector }}
+        {{- if .Values.operator.admissionControllers.certificates.certManager.enabled }}
+            - name: ADMISSION_CONTROLLERS_CERTIFICATES_CERT_MANAGER_ENABLED
+              value: {{ .Values.operator.admissionControllers.certificates.certManager.enabled | quote }}
+        {{- else }}
+            - name: ADMISSION_CONTROLLERS_CERTIFICATES_OPERATOR_CA_CRT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}
+                  key: ca.crt
+            - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_CA_CRT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.operator.admissionControllers.certificates.secretNames.injector }}
+                  key: ca.crt
+        {{- end }}
+        {{- end }}

--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -25,9 +25,56 @@ operator:
   nameOverride: ""
   fullnameOverride: ""
   resourcePrefix: "openshift.io"
-  enableAdmissionController: false
   cniBinPath: "/opt/cni/bin"
   clusterType: "kubernetes"
+  admissionControllers:
+    enabled: false
+    certificates:
+      secretNames:
+        operator: "operator-webhook-cert"
+        injector: "network-resources-injector-cert"
+      certManager:
+        # When enabled, makes use of certificates managed by cert-manager.
+        enabled: false
+        # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
+        # defined above
+        generateSelfSigned: false
+      # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
+      # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
+      custom:
+        enabled: false
+    #   operator:
+    #     caCrt: |
+    #       -----BEGIN CERTIFICATE-----
+    #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+    #       ...
+    #       -----END CERTIFICATE-----
+    #     tlsCrt: |
+    #       -----BEGIN CERTIFICATE-----
+    #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+    #       ...
+    #       -----END CERTIFICATE-----
+    #     tlsKey: |
+    #       -----BEGIN EC PRIVATE KEY-----
+    #       MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+    #       ...
+    #      -----END EC PRIVATE KEY-----
+    #   injector:
+    #     caCrt: |
+    #       -----BEGIN CERTIFICATE-----
+    #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+    #       ...
+    #       -----END CERTIFICATE-----
+    #     tlsCrt: |
+    #       -----BEGIN CERTIFICATE-----
+    #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+    #       ...
+    #       -----END CERTIFICATE-----
+    #     tlsKey: |
+    #       -----BEGIN EC PRIVATE KEY-----
+    #       MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+    #       ...
+    #      -----END EC PRIVATE KEY-----
 
 # Image URIs for sriov-network-operator components
 images:

--- a/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
+++ b/deployment/network-operator/templates/sriovnetwork.openshift.io_sriovoperatorconfig.yaml
@@ -22,8 +22,8 @@ metadata:
 spec:
   # Add fields here
   {{- with (index .Values "sriov-network-operator" "operator") }}
-  enableInjector: {{ .enableAdmissionController }}
-  enableOperatorWebhook: {{ .enableAdmissionController }}
+  enableInjector: {{ .admissionControllers.enabled }}
+  enableOperatorWebhook: {{ .admissionControllers.enabled }}
   {{- end }}
   configDaemonNodeSelector:
     {{- $defaults := dict "beta.kubernetes.io/os" "linux" "network.nvidia.com/operator.mofed.wait" "false" }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -90,16 +90,63 @@ sriov-network-operator:
     nameOverride: ""
     fullnameOverride: ""
     resourcePrefix: "nvidia.com"
-    enableAdmissionController: false
     cniBinPath: "/opt/cni/bin"
     clusterType: "kubernetes"
+    admissionControllers:
+      enabled: false
+      certificates:
+        secretNames:
+          operator: "operator-webhook-cert"
+          injector: "network-resources-injector-cert"
+        certManager:
+          # When enabled, makes use of certificates managed by cert-manager.
+          enabled: false
+          # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
+          # defined above
+          generateSelfSigned: false
+        # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
+        # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
+        custom:
+          enabled: false
+      #   operator:
+      #     caCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsKey: |
+      #       -----BEGIN EC PRIVATE KEY-----
+      #       MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      #       ...
+      #      -----END EC PRIVATE KEY-----
+      #   injector:
+      #     caCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsKey: |
+      #       -----BEGIN EC PRIVATE KEY-----
+      #       MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      #       ...
+      #      -----END EC PRIVATE KEY-----
 
   # Image URIs for sriov-network-operator components
   images:
     operator: nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.1.0-beta.1
     sriovConfigDaemon: nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.1.0-beta.1
     sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.7.0
-    ibSriovCni:  ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.0.3
+    ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.0.3
     sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:2cc723dcbc712290055b763dc9d3c090ba41e929
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.4
     webhook: ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook:v1.1.0

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -90,16 +90,63 @@ sriov-network-operator:
     nameOverride: ""
     fullnameOverride: ""
     resourcePrefix: "nvidia.com"
-    enableAdmissionController: false
     cniBinPath: "/opt/cni/bin"
     clusterType: "kubernetes"
+    admissionControllers:
+      enabled: false
+      certificates:
+        secretNames:
+          operator: "operator-webhook-cert"
+          injector: "network-resources-injector-cert"
+        certManager:
+          # When enabled, makes use of certificates managed by cert-manager.
+          enabled: false
+          # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
+          # defined above
+          generateSelfSigned: false
+        # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
+        # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
+        custom:
+          enabled: false
+      #   operator:
+      #     caCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsKey: |
+      #       -----BEGIN EC PRIVATE KEY-----
+      #       MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      #       ...
+      #      -----END EC PRIVATE KEY-----
+      #   injector:
+      #     caCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsCrt: |
+      #       -----BEGIN CERTIFICATE-----
+      #       MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #       ...
+      #       -----END CERTIFICATE-----
+      #     tlsKey: |
+      #       -----BEGIN EC PRIVATE KEY-----
+      #       MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      #       ...
+      #      -----END EC PRIVATE KEY-----
 
   # Image URIs for sriov-network-operator components
   images:
     operator: {{ .SriovNetworkOperator.Repository }}/{{ .SriovNetworkOperator.Image }}:{{ .SriovNetworkOperator.Version }}
     sriovConfigDaemon: {{ .SriovConfigDaemon.Repository }}/{{ .SriovConfigDaemon.Image }}:{{ .SriovConfigDaemon.Version }}
     sriovCni: {{ .SriovCni.Repository }}/{{ .SriovCni.Image }}:{{ .SriovCni.Version }}
-    ibSriovCni:  {{ .SriovIbCni.Repository }}/{{ .SriovIbCni.Image }}:{{ .SriovIbCni.Version }}
+    ibSriovCni: {{ .SriovIbCni.Repository }}/{{ .SriovIbCni.Image }}:{{ .SriovIbCni.Version }}
     sriovDevicePlugin: {{ .SriovDevicePlugin.Repository }}/{{ .SriovDevicePlugin.Image }}:{{ .SriovDevicePlugin.Version }}
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.4
     webhook: ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook:v1.1.0


### PR DESCRIPTION
Today it's cumbersome to enable admission controllers for SRIOV Network Operator because the user needs to create a secret manually. With this PR https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/561, it's possible to generate a self signed certificate so the user doesn't need to do manual steps to enable those admission controllers.

This PR just updates the chart to the latest chart found in the `master` branch of https://github.com/k8snetworkplumbingwg/sriov-network-operator which at the time was https://github.com/k8snetworkplumbingwg/sriov-network-operator/commit/233b99abed2645f626dea43b02179fcec0d661b4.

Another PR will enable proper support for admission controllers.