### PR TITLE
feat: Support SR-IOV Network Operator Admission Controllers

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -100,10 +100,10 @@ sriov-network-operator:
           injector: "network-resources-injector-cert"
         certManager:
           # When enabled, makes use of certificates managed by cert-manager.
-          enabled: false
+          enabled: true
           # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
           # defined above
-          generateSelfSigned: false
+          generateSelfSigned: true
         # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
         # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
         custom:

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -100,10 +100,10 @@ sriov-network-operator:
           injector: "network-resources-injector-cert"
         certManager:
           # When enabled, makes use of certificates managed by cert-manager.
-          enabled: false
+          enabled: true
           # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
           # defined above
-          generateSelfSigned: false
+          generateSelfSigned: true
         # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
         # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
         custom:


### PR DESCRIPTION
Requires and is based on: https://github.com/Mellanox/network-operator/pull/709

This PR adds support for auto generated cert-manager certificates when user enables the SR-IOV Network Operator Admission Controllers via the Helm value `sriov-network-operator.operator.admissionControllers.enabled`.

This PR won't work until:
* a new image of SR-IOV Network Operator is published and the following value is updated https://github.com/vasrem/network-operator/blob/f125b8a67772fc31af6ced0b24c9249531e5e542/deployment/network-operator/values.yaml#L146
* a new image of SR-IOV Network Operator Webhook is published and the following value is updated https://github.com/vasrem/network-operator/blob/f125b8a67772fc31af6ced0b24c9249531e5e542/deployment/network-operator/values.yaml#L152
  * This is needed to ensure smooth `helm uninstall` operation. Depends on https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/566.