### PR TITLE
fix: Add check for go modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,16 @@ jobs:
         uses: actions/checkout@v3
       - name: check manifests
         run: make check-manifests
+  diff-modules:
+    name: check go modules
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: check go modules
+        run: make check-go-modules
   diff-release-build:
     name: check release-build
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,14 @@ check-manifests: generate manifests
 	$(info checking for git diff after running 'make manifests')
 	git diff --quiet ; if [ $$? -eq 1 ] ; then echo "Please, commit manifests after running 'make manifests' command"; exit 1 ; fi
 
+.PHONY: check-go-modules
+check-go-modules: generate-go-modules
+	git diff --quiet HEAD go.sum; if [ $$? -eq 1 ] ; then echo "go.sum is out of date. Please commit after running 'make generate-go-modules' command"; exit 1; fi
+
+.PHONY: generate-go-modules
+generate-go-modules:
+	go mod tidy
+
 .PHONY: check-release-build
 check-release-build: release-build
 	$(info checking for git diff after running 'make release-build')


### PR DESCRIPTION
Add a check in the CI to ensure that go modules are up to date.

This will catch issues like #718 from recurring.