### PR TITLE
chore: remove driver-pod label

### DIFF
--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -175,8 +175,7 @@ func (r *NicClusterPolicyReconciler) handleMOFEDWaitLabels(
 		return r.handleMOFEDWaitLabelsNoConfig(ctx)
 	}
 	pods := &corev1.PodList{}
-	podLabel := "mofed-" + cr.Spec.OFEDDriver.Version
-	_ = r.Client.List(ctx, pods, client.MatchingLabels{"driver-pod": podLabel})
+	_ = r.Client.List(ctx, pods, client.MatchingLabels{"nvidia.com/ofed-driver": ""})
 	for i := range pods.Items {
 		pod := pods.Items[i]
 		labelValue := "true"

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -29,7 +29,6 @@ spec:
     metadata:
       labels:
         app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}
-        driver-pod: mofed-{{ .CrSpec.Version }}
         nvidia.com/ofed-driver: ""
     spec:
       priorityClassName: system-node-critical


### PR DESCRIPTION
We already have a label which marks a pod as a driver pod which does not rely on the version of the driver. use it instead
