### PR TITLE
devtools: Add skaffold config for network-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ARG ARCH ?= $(shell go env GOARCH)
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 ARG LDFLAGS
+ARG GO_BUILD_GC_ARGS
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -48,7 +49,7 @@ RUN mkdir crds && \
     cp -r chart/charts/node-feature-discovery/crds /workspace/crds/node-feature-discovery/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -gcflags="${GO_BUILD_GC_ARGS}" -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8-micro:8.8
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -30,6 +30,9 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
+# Add default program arguments and resource requests and limits to the manager container.
+- manager_args_and_resource_limits.yaml
+
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml

--- a/config/default/manager_args_and_resource_limits.yaml
+++ b/config/default/manager_args_and_resource_limits.yaml
@@ -1,0 +1,22 @@
+# Add command args and resource limits to the manager container.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          args:
+            - "--health-probe-bind-address=:8081"
+            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--leader-elect"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64M

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -26,15 +26,3 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64M

--- a/config/dev/drop_manager_args_and_resources.yaml
+++ b/config/dev/drop_manager_args_and_resources.yaml
@@ -1,0 +1,4 @@
+- op: remove
+  path: /spec/template/spec/containers/0/args
+- op: remove
+  path: /spec/template/spec/containers/0/resources

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,0 +1,21 @@
+## This folder is strictly for local development work.
+
+# Adds namespace to all resources.
+namespace: nvidia-network-operator
+
+# Adds a prefix to all resource names.
+namePrefix: nvidia-network-operator-
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+
+patches:
+  - path: ./drop_manager_args_and_resources.yaml
+    target:
+      group: apps
+      kind: Deployment
+      name: controller-manager
+      namespace: system
+      version: v1

--- a/docs/skaffold.md
+++ b/docs/skaffold.md
@@ -1,0 +1,39 @@
+## Development with skaffold
+
+The network operator includes a `skaffold.yaml` for iterative development with `skaffold`.
+
+For more information on `skaffold` [see the official docs](https://skaffold.dev/).
+
+### Prerequisites
+NOTE: This list does not include dependencies of the `network-operator` e.g. Node Feature Discovery or cert-manager. These must be installed on the cluster independently where required.
+
+- Skaffold CLI - https://skaffold.dev/docs/install/#standalone-binary
+- An image registry to push images to.
+- kustomize
+- kubectl
+- Docker
+- A running Kubernetes cluster.
+
+### Deploying with Skaffold
+
+Export a registry to push images to:
+
+`export REGISTRY="localhost:5000`
+
+From the root directory of the `network-operator` repository run:
+
+`skaffold dev --default-repo $REGISTRY --trigger manual`
+
+### Remote debugging with Skaffold
+
+Export a registry to push images to:
+
+`export REGISTRY="localhost:5000`
+
+From the root directory of the `network-operator` repository run:
+
+`skaffold debug --default-repo $REGISTRY`
+
+This config runs the go debugger `delve` and exposes port `8080` on the remote host that runs the pod.
+
+You can attach to this debugger using your IDE [following the instructions on the `skaffold` documentation.](https://skaffold.dev/docs/workflows/debug/#detailed-debugger-configuration-and-setup). 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,28 @@
+apiVersion: skaffold/v4beta8
+kind: Config
+metadata:
+  name: network-operator
+build:
+  artifacts:
+    - image: mellanox/network-operator
+      runtimeType: go
+      docker:
+       buildArgs:
+         ## Used for debugging. Disable inlining and optimizations in the go compiler. Passed to go build using `-gcflags`
+         GO_BUILD_GC_ARGS: "all=-N -l"
+       dockerfile: Dockerfile
+manifests:
+  ## Deploy the manager.
+  kustomize:
+    paths:
+      - config/dev
+  ## Deploy the network attachment definition CRD.
+  rawYaml:
+  - hack/crds/*
+portForward:
+      - resourceType: deployment
+        resourceName: nvidia-network-operator-controller-manager
+        namespace: nvidia-network-operator
+        port: 56268
+        localPort: 8080
+        address: 0.0.0.0


### PR DESCRIPTION
Adds a skaffold config that can be used to deploy and debug the network operator.

Related to https://github.com/Mellanox/network-operator/issues/576