### PR TITLE
chore: Update envtest version and install process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ deployment/network-operator/charts/*.tgz
 # Folders
 bin
 testbin
+test
 build

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,0 @@
-// +build tools
-
-// Place any runtime dependencies as imports in this file.
-// Go modules will be forced to download and install them.
-package tools


### PR DESCRIPTION
Update the `setup-envtest` version and Kubernetes version for envtest used in the Makefile.

A couple of other small cleanups - removing broken `test-xml` make target and unused `tools.go` file.