### PR TITLE
fix: Update both chart and app version when bulding helm chart with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,11 @@ image-push:
 
 .PHONY: chart-build
 chart-build: $(HELM) ; $(info Building Helm image...)  @ ## Build Helm Chart
-	$Q $(HELM) package deployment/network-operator/ --version $(VERSION)
+	@if [ -z "$(APP_VERSION)" ]; then \
+		echo "APP_VERSION is not set, skipping a part of the command."; \
+		$(HELM) package deployment/network-operator/ --version $(VERSION); \
+	else $(HELM) package deployment/network-operator/ --version $(VERSION) --app-version $(APP_VERSION); \
+	fi
 
 .PHONY: chart-push
 chart-push: $(HELM) ; $(info Pushing Helm image...)  @ ## Push Helm Chart


### PR DESCRIPTION
When deploying network-operator helm chart, the templates rely on chart.AppVersion when constructing the image url. To allow to automate chart publishing, consistent AppVersions need to be provided when chart is built.
Add a flag to helm package command in the make chart-build target