### PR TITLE
feat: Adjust SR-IOV NetOp webhook image on release

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -149,7 +149,7 @@ sriov-network-operator:
     ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.0.3
     sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:2cc723dcbc712290055b763dc9d3c090ba41e929
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.4
-    webhook: ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook:v1.1.0
+    webhook: nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-24.1.0-beta.2
   # imagePullSecrest for SR-IOV Network Operator related images
   # imagePullSecrets: []
 

--- a/hack/release.go
+++ b/hack/release.go
@@ -36,6 +36,7 @@ type Release struct {
 	NetworkOperator              *mellanoxv1alpha1.ImageSpec
 	NetworkOperatorInitContainer *mellanoxv1alpha1.ImageSpec
 	SriovNetworkOperator         *mellanoxv1alpha1.ImageSpec
+	SriovNetworkOperatorWebhook  *mellanoxv1alpha1.ImageSpec
 	SriovConfigDaemon            *mellanoxv1alpha1.ImageSpec
 	SriovCni                     *mellanoxv1alpha1.ImageSpec
 	SriovIbCni                   *mellanoxv1alpha1.ImageSpec

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -9,6 +9,10 @@ SriovNetworkOperator:
   image: sriov-network-operator
   repository: nvcr.io/nvstaging/mellanox
   version: network-operator-24.1.0-beta.2
+SriovNetworkOperatorWebhook:
+  image: sriov-network-operator-webhook
+  repository: nvcr.io/nvstaging/mellanox
+  version: network-operator-24.1.0-beta.2
 SriovConfigDaemon:
   image: sriov-network-operator-config-daemon
   repository: nvcr.io/nvstaging/mellanox

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -149,7 +149,7 @@ sriov-network-operator:
     ibSriovCni: {{ .SriovIbCni.Repository }}/{{ .SriovIbCni.Image }}:{{ .SriovIbCni.Version }}
     sriovDevicePlugin: {{ .SriovDevicePlugin.Repository }}/{{ .SriovDevicePlugin.Image }}:{{ .SriovDevicePlugin.Version }}
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.4
-    webhook: ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook:v1.1.0
+    webhook: {{ .SriovNetworkOperatorWebhook.Repository }}/{{ .SriovNetworkOperatorWebhook.Image }}:{{ .SriovNetworkOperatorWebhook.Version }}
   # imagePullSecrest for SR-IOV Network Operator related images
   # imagePullSecrets: []
 


### PR DESCRIPTION
The goal of this PR is to adjust the SR-IOV NetOp webhook image on release to an image built via our release pipeline, similarly to what we do with most of the images related to SR-IOV when we make a new release.

Needed by https://github.com/Mellanox/network-operator/pull/710