### PR TITLE
fix: remove default value for nv-ipam spec in NicClusterPolicy

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -237,7 +237,6 @@ type IBKubernetesSpec struct {
 // 2. Configuration for nv-ipam
 type NVIPAMSpec struct {
 	// Enable deployment of the validation webhook
-	// +kubebuilder:default:=false
 	EnableWebhook bool `json:"enableWebhook,omitempty"`
 	ImageSpec     `json:""`
 }

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -409,7 +409,6 @@ spec:
                       type: object
                     type: array
                   enableWebhook:
-                    default: false
                     description: Enable deployment of the validation webhook
                     type: boolean
                   image:

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -409,7 +409,6 @@ spec:
                       type: object
                     type: array
                   enableWebhook:
-                    default: false
                     description: Enable deployment of the validation webhook
                     type: boolean
                   image:


### PR DESCRIPTION

This is required to prevent the rendering
of this field in the OLM examples for Openshift.

![nv-ipam-OLM-problem](https://github.com/Mellanox/network-operator/assets/60463629/e2926157-d841-4dd1-8854-d9097194f822)
