### PR TITLE
fix: Re-enable multi-arch docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir crds && \
     cp -r chart/charts/node-feature-discovery/crds /workspace/crds/node-feature-discovery/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -gcflags="${GO_BUILD_GC_ARGS}" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GO_BUILD_GC_ARGS}" -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8-micro:8.8
 


### PR DESCRIPTION
Fix an issue introduced in #733 which breaks multi-arch docker builds.

This fix will re-enable building multi-arch images.