### PR TITLE
devtools: Add minikube dev environment

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,102 @@
+## Development with minikube and skaffold
+
+The network operator includes tooling to develop locally using `minikube` and `skaffold`.
+
+For more information on `skaffold` [see the official docs](https://skaffold.dev/).
+For more information on `minikube` [see the official docs](https://minikube.sigs.k8s.io/docs/).
+
+This development environment is designed to work on Linux amd64 and MacOS on Mac Silicon. It should be extensible for other platforms with some changes to the `minikube` installation.
+
+### Prerequisites:
+- `kubectl` CLI
+- `docker` CLI - but not necessarily the `docker` engine. This dev setup configures the CLI to use `minikube` as its `docker` engine.
+- `docker buildx` CLI plugin. [Installation instructions](https://github.com/docker/buildx?tab=readme-ov-file#manual-download)
+- A virtualization driver for minikube. This will be `qemu` for MacOS and `kvm2` for Linux. If this is not installed `minikube` will fail with an error pointing to install instructions.
+
+The `make` targets and scripts will install `minikube` and `skaffold` when running targets.
+
+### Local development with `skaffold`
+
+To spin up a cluster and deploy the network operator run:
+
+`make dev-skaffold`
+
+This will install `skaffold` and `minikube` if needed, spin up a `minikube` cluster called `net-op-dev`, and deploy the network operator in debug mode on the cluster. If there is an error ensure the [prerequisites](#prerequisites), including the virtualization driver, are met.
+
+Other useful `make` targets include `make dev-minikube` to setup the development cluster without skaffold and `make clean-minikube` to tear down the development cluster.
+
+NOTE: If `minikube` with the `kvm` provider is failing with permission errors changing the value of `MINIKUBE_HOME` to a different location could solve the issue. This issue can occur when the user has a network drive for their `$HOME` directory. For example: `MINIKUBE_HOME=/local/path make dev-skaffold`.
+
+### Debugging
+This config runs the go debugger `delve` and exposes port `8080` on the remote host that runs the pod.
+
+You can attach to this debugger using your IDE [following the instructions on the `skaffold` documentation.](https://skaffold.dev/docs/workflows/debug/#detailed-debugger-configuration-and-setup).
+
+### Using minikube as a Docker environment
+
+The `skaffold` development setup uses the `minikube` deployment to build docker images and to store them in a registry. This may cause some confusion when running this setup on an installation with multiple docker environments. By design the `minikube` `docker` server is only used by the `dev-skaffold` make target. 
+
+To use the same environment in any shell run:
+```bash
+eval $(/bin/minikube-XXX -p net-op-dev docker-env)
+```
+Where XXX is the version of minikube `installed`. Running `docker info | grep net-op-dev` should show the server is running on the minikube VM.
+
+For more information see [the official docs](https://minikube.sigs.k8s.io/docs/tutorials/docker_desktop_replacement/)
+
+## Running skaffold against an existing Kubernetes cluster
+
+`skaffold` can be used independently of `minikube` to deploy the `network-operator` against an existing Kubernetes cluster. This is useful for testing scenarios that require real hardware.
+
+### Prerequisites
+NOTE: This list does not include dependencies of the `network-operator` e.g. Node Feature Discovery or cert-manager. These must be installed on the cluster independently where required.
+
+- `skaffold` CLI - https://skaffold.dev/docs/install/#standalone-binary
+- An image registry to push images to.
+- `kustomize`
+- `kubectl`
+- Docker
+- A running Kubernetes cluster.
+
+### Deploying with Skaffold
+
+Export a registry to push images to:
+
+`export REGISTRY="localhost:5000`
+
+From the root directory of the `network-operator` repository run:
+
+`skaffold dev --default-repo $REGISTRY --trigger manual`
+
+### Remote debugging with Skaffold
+
+Export a registry to push images to:
+
+`export REGISTRY="localhost:5000`
+
+From the root directory of the `network-operator` repository run:
+
+`skaffold debug --default-repo $REGISTRY`
+
+This config runs the go debugger `delve` and exposes port `8080` on the remote host that runs the pod.
+
+You can attach to this debugger using your IDE [following the instructions on the `skaffold` documentation.](https://skaffold.dev/docs/workflows/debug/#detailed-debugger-configuration-and-setup). 
+
+With VSCode your launch.json should look similar to the below. Note that `remotePath` is set to `""` which is different from the config in the documentation linked above.
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Skaffold Debug",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "host": "X.X.X.X", // ENTER your hostname here.
+      "port": 8080,
+      "cwd": "${workspaceFolder}",
+      "remotePath": ""
+    }
+  ]
+}
+```

--- a/hack/scripts/minikube-install.sh
+++ b/hack/scripts/minikube-install.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+#  2024 NVIDIA CORPORATION & AFFILIATES
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an AS IS BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+CLUSTER_NAME="${CLUSTER_NAME:-"net-op-dev"}"
+MINIKUBE_BIN="${MINIKUBE_BIN:-"unknown"}"
+MINIKUBE_DRIVER="${MINIKUBE_DRIVER:-"unknown"}"
+USE_MINIKUBE_DOCKER="${USE_MINIKUBE_DOCKER:-"true"}"
+NUM_NODES="${NUM_NODES:-"1"}"
+NODE_MEMORY="${NODE_MEMORY:-"4g"}"
+NODE_CPUS="${NODE_CPUS:-"2"}"
+NODE_DISK="${NODE_DISK:-"20g"}"
+
+## Detect the OS.
+OS="unknown"
+if [[ "${OSTYPE}" == "linux"* ]]; then
+  OS="linux"
+elif [[ "${OSTYPE}" == "darwin"* ]]; then
+  OS="darwin"
+fi
+
+# Exit if the OS is not supported.
+if [[ "$OS" == "unknown" ]]; then
+  echo "os '$OSTYPE' not supported. Aborting." >&2
+  exit 1
+fi
+
+## Set the driver used for minikube machines. By default this script will select the preferred VM driver for each OS.
+## Users can override this using the MINIKUBE_DRIVER env variable.
+if [[ "$MINIKUBE_DRIVER" == "unknown" ]]; then
+  if [[ "${OSTYPE}" == "linux"* ]]; then
+    MINIKUBE_DRIVER="kvm2"
+  elif [[ "${OSTYPE}" == "darwin"* ]]; then
+    MINIKUBE_DRIVER="qemu"
+  fi
+fi
+
+MINIKUBE_ARGS="${MINIKUBE_ARGS:-"\
+  --driver $MINIKUBE_DRIVER \
+  --cpus=$NODE_CPUS \
+  --memory=$NODE_MEMORY \
+  --disk-size=$NODE_DISK \
+  --nodes=$NUM_NODES \
+  --preload=true \
+  --cni calico \
+  --container-runtime=docker\
+  --install-addons \
+  --addons registry"}"
+
+MINIKUBE_EXTRA_ARGS="${MINIKUBE_EXTRA_ARGS:-""}"
+
+echo "Setting up Minikube cluster..."
+
+## Exit early if the cluster already exists.
+if [[ $($MINIKUBE_BIN status -p $CLUSTER_NAME  -f '{{.Name}}') == $CLUSTER_NAME ]]; then
+  echo "Minikube cluster '$CLUSTER_NAME' found. Skipping cluster set-up"
+  ## Set environment variables to use the Minikube VM docker build for
+  if [[ "$USE_MINIKUBE_DOCKER" == "true" ]]; then
+    echo "Setting environment variables to use $CLUSTER_NAME as docker build environment."
+    eval $($MINIKUBE_BIN -p $CLUSTER_NAME docker-env)
+  fi
+  exit 0
+fi
+
+$MINIKUBE_BIN start --profile $CLUSTER_NAME $MINIKUBE_ARGS
+
+## Set environment variables to use the Minikube VM docker build for
+if [[ "$USE_MINIKUBE_DOCKER" == "true" ]]; then
+  echo "Setting environment variables to use $CLUSTER_NAME as docker build environment."
+  eval $($MINIKUBE_BIN -p $CLUSTER_NAME docker-env)
+fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -3,6 +3,8 @@ kind: Config
 metadata:
   name: network-operator
 build:
+  local:
+    useBuildkit: true
   artifacts:
     - image: mellanox/network-operator
       runtimeType: go
@@ -16,9 +18,6 @@ manifests:
   kustomize:
     paths:
       - config/dev
-  ## Deploy the network attachment definition CRD.
-  rawYaml:
-  - hack/crds/*
 portForward:
       - resourceType: deployment
         resourceName: nvidia-network-operator-controller-manager


### PR DESCRIPTION
Add a minikube development environment for the network operator. 

This development environment spins up a minikube cluster and runs the network operator using skaffold.

