### PR TITLE
chore: Speed up image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ VCS_BRANCH := $(strip $(shell git rev-parse --abbrev-ref HEAD))
 VCS_REF := $(strip $(shell [ -d .git ] && git rev-parse --short HEAD))
 
 # Docker
-IMAGE_BUILDER?=@docker
+IMAGE_BUILDER?=docker
 IMAGEDIR=$(CURDIR)/images
 DOCKERFILE?=$(CURDIR)/Dockerfile
 TAG?=mellanox/network-operator
@@ -214,7 +214,7 @@ test-coverage: setup-envtest test-coverage-tools ; $(info  running coverage test
 # Container image
 .PHONY: image
 image: ; $(info Building Docker image...)  @ ## Build container image
-	$(IMAGE_BUILDER) build --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
+	$Q DOCKER_BUILDKIT=1 $(IMAGE_BUILDER) build --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
 		--build-arg VERSION="$(BUILD_VERSION)" \
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -3,6 +3,8 @@ kind: Config
 metadata:
   name: network-operator
 build:
+  local:
+    useBuildkit: true
   artifacts:
     - image: mellanox/network-operator
       runtimeType: go
@@ -16,9 +18,6 @@ manifests:
   kustomize:
     paths:
       - config/dev
-  ## Deploy the network attachment definition CRD.
-  rawYaml:
-  - hack/crds/*
 portForward:
       - resourceType: deployment
         resourceName: nvidia-network-operator-controller-manager


### PR DESCRIPTION
Make some changes to the dockerfile to speed up builds.

Main changes:
- Use the go cache to avoid full recompilation every time
- Remove the `-a` arg from `go build` to allow using precompiled packages from the cache

Time comparison versus master:
 15s v 59s


<details>

## Master build log
```
Building Docker image...
[+] Building 58.8s (27/27) FINISHED                                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                0.0s
 => => transferring dockerfile: 2.87kB                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8-micro:8.8                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/golang:1.20                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                   0.0s
 => => transferring context: 26.65kB                                                                                                                                                                                0.0s
 => CACHED [stage-1 1/7] FROM registry.access.redhat.com/ubi8-micro:8.8                                                                                                                                             0.0s
 => [builder  1/15] FROM docker.io/library/golang:1.20                                                                                                                                                              0.0s
 => CACHED [builder  2/15] WORKDIR /workspace                                                                                                                                                                       0.0s
 => CACHED [builder  3/15] COPY go.mod go.mod                                                                                                                                                                       0.0s
 => CACHED [builder  4/15] COPY go.sum go.sum                                                                                                                                                                       0.0s
 => [builder  5/15] RUN go mod download                                                                                                                                                                            12.5s
 => [builder  6/15] COPY main.go main.go                                                                                                                                                                            0.0s
 => [builder  7/15] COPY api/ api/                                                                                                                                                                                  0.0s
 => [builder  8/15] COPY controllers/ controllers/                                                                                                                                                                  0.0s
 => [builder  9/15] COPY pkg/ pkg/                                                                                                                                                                                  0.0s
 => [builder 10/15] COPY version/ version/                                                                                                                                                                          0.0s
 => [builder 11/15] RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"                                                                             3.2s
 => [builder 12/15] RUN chmod +x ./kubectl                                                                                                                                                                          0.6s
 => [builder 13/15] COPY deployment/network-operator chart                                                                                                                                                          0.1s 
 => [builder 14/15] RUN mkdir crds &&     cp -r chart/crds /workspace/crds/network-operator/ &&     cp -r chart/charts/sriov-network-operator/crds /workspace/crds/sriov-network-operator/ &&     cp -r chart/char  0.4s 
 => [builder 15/15] RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="-X github.com/Mellanox/network-operator/version.Version=v1.9.3-9-g501ce9c-dirty -X github.com/Mellanox/network-operator/versio  39.9s 
 => [stage-1 2/7] COPY --from=builder /workspace/manager .                                                                                                                                                          0.3s
 => [stage-1 3/7] COPY --from=builder /workspace/kubectl /usr/local/bin                                                                                                                                             0.3s
 => [stage-1 4/7] COPY --from=builder /workspace/crds /crds                                                                                                                                                         0.1s
 => [stage-1 5/7] COPY /webhook-schemas /webhook-schemas                                                                                                                                                            0.0s
 => [stage-1 6/7] COPY manifests/ manifests/                                                                                                                                                                        0.1s
 => exporting to image                                                                                                                                                                                              0.6s
 => => exporting layers                                                                                                                                                                                             0.6s
 => => writing image sha256:00faaa4d930ee05d60253b67303bc6be5344a594f03265a7a72ab4afaa3500a5                                                                                                                        0.0s
 => => naming to docker.io/mellanox/network-operator                                                                                                                                                                0.0s

```
## This PR build log
  ```
Building Docker image...
[+] Building 14.9s (21/21) FINISHED                                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                0.0s
 => => transferring dockerfile: 2.71kB                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8-micro:8.8                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/golang:1.20                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                   0.1s
 => => transferring context: 101.81kB                                                                                                                                                                               0.1s
 => CACHED [stage-1 1/8] FROM registry.access.redhat.com/ubi8-micro:8.8                                                                                                                                             0.0s
 => [builder 1/8] FROM docker.io/library/golang:1.20                                                                                                                                                                0.0s
 => CACHED [builder 2/8] WORKDIR /workspace                                                                                                                                                                         0.0s
 => CACHED [builder 3/8] COPY go.mod go.mod                                                                                                                                                                         0.0s
 => CACHED [builder 4/8] COPY go.sum go.sum                                                                                                                                                                         0.0s
 => CACHED [builder 5/8] RUN --mount=type=cache,target=/go/pkg/mod     go mod download -x                                                                                                                           0.0s
 => [builder 6/8] COPY ./ ./                                                                                                                                                                                        1.2s
 => [builder 7/8] RUN mkdir crds &&     cp -r deployment/network-operator/crds /workspace/crds/network-operator/ &&     cp -r deployment/network-operator/charts/sriov-network-operator/crds /workspace/crds/sriov  0.3s
 => [builder 8/8] RUN --mount=type=cache,target=/root/.cache/go-build         --mount=type=cache,target=/go/pkg/mod       GO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="-X github.com/Mellanox/networ  10.4s
 => [stage-1 2/8] COPY --from=builder /workspace/manager .                                                                                                                                                          0.4s
 => [stage-1 3/8] COPY --from=builder /workspace/crds /crds                                                                                                                                                         0.0s
 => [stage-1 4/8] COPY ./bin/kubectl-for-image /usr/local/bin/kubectl                                                                                                                                               0.2s
 => [stage-1 5/8] RUN chmod +x /usr/local/bin/kubectl                                                                                                                                                               0.5s
 => [stage-1 6/8] COPY /webhook-schemas /webhook-schemas                                                                                                                                                            0.0s
 => [stage-1 7/8] COPY manifests/ manifests/                                                                                                                                                                        0.1s
 => exporting to image                                                                                                                                                                                              0.8s
 => => exporting layers                                                                                                                                                                                             0.8s
 => => writing image sha256:6d17a4c742d65c40dff25c6c17dce71ba698523b7fc8dd513ab15447d960a421                                                                                                                        0.0s
 => => naming to docker.io/mellanox/network-operator                                                                                                                                                                0.0s
   ```

</details>