### PR TITLE
chore: Bump helm, hadolint, and golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck
@@ -95,6 +94,11 @@ issues:
 
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
+    - path: _test\.go
+      linters:
+      - revive
+      - stylecheck
+      text: "should not use dot imports"
     - path: _test\.go
       linters:
         - gomnd

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ GO = go
 # golangci-lint is used to lint go code.
 GOLANGCI_LINT_PKG=github.com/golangci/golangci-lint/cmd/golangci-lint
 GOLANGCI_LINT_BIN= golangci-lint
-GOLANGCI_LINT_VER = v1.52.2
+GOLANGCI_LINT_VER = v1.55.2
 GOLANGCI_LINT = $(TOOLSDIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT_PKG),$(GOLANGCI_LINT_BIN),$(GOLANGCI_LINT_VER))

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ $(HADOLINT): | $(TOOLSDIR)
 
 # helm is used to manage helm deployments and artifacts.
 GET_HELM = $(TOOLSDIR)/get_helm.sh
-HELM_VER = v3.5.3
+HELM_VER = v3.13.3
 HELM_BIN = helm
 HELM = $(abspath $(TOOLSDIR)/$(HELM_BIN)-$(HELM_VER))
 $(HELM): | $(TOOLSDIR)

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ $(SETUP_ENVTEST):
 
 # hadolint is used to lint docker files.
 HADOLINT_BIN = hadolint
-HADOLINT_VER = v1.23.0
+HADOLINT_VER = v2.12.0
 HADOLINT = $(abspath $(TOOLSDIR)/$(HADOLINT_BIN)-$(HADOLINT_VER))
 $(HADOLINT): | $(TOOLSDIR)
 	$Q echo "Installing hadolint-$(HADOLINT_VER) to $(TOOLSDIR)"
@@ -182,9 +182,7 @@ lint: | $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run golangci-l
 
 .PHONY: lint-dockerfile
 lint-dockerfile: $(HADOLINT) ; $(info  running Dockerfile lint with hadolint...) @ ## Run hadolint
-# DL3018 - allow installing apks without explicit version
-# DL3006 - Always tag the version of an image explicitly (until https://github.com/hadolint/hadolint/issues/339 is fixed)
-	$Q $(HADOLINT) --ignore DL3018 --ignore DL3006 Dockerfile
+	$Q $(HADOLINT) Dockerfile
 
 .PHONY: lint-helm
 lint-helm: $(HELM) ; $(info  running lint for helm charts...) @ ## Run helm lint

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,7 +78,6 @@ func GetCniBinDirectory(staticInfo staticconfig.Provider,
 	} else if clusterInfo != nil && clusterInfo.IsOpenshift() {
 		// /opt/cni/bin directory is read-only on OCP, so we need to use another one
 		return consts.OcpCniBinDirectory
-	} else {
-		return consts.DefaultCniBinDirectory
 	}
+	return consts.DefaultCniBinDirectory
 }


### PR DESCRIPTION
Bumps to some tooling in the Makefile. None of them bring major changes.

`helm v3.5.3` -> `helm v3.13.3`
`hadolint v1.23.0` -> `hadolint v2.12.0`
`golangci-lint v1.52.2` -> `golangci-lint v1.55.2`
