### PR TITLE
devtools: Enable webhooks in dev-skaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ bin
 testbin
 test
 build
+hack/manifests

--- a/config/dev/cainjection_in_hostdevicenetworks.yaml
+++ b/config/dev/cainjection_in_hostdevicenetworks.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: hostdevicenetworks.mellanox.com

--- a/config/dev/cainjection_in_nicclusterpolicies.yaml
+++ b/config/dev/cainjection_in_nicclusterpolicies.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: nicclusterpolicies.mellanox.com

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,21 +1,93 @@
 ## This folder is strictly for local development work.
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # Adds namespace to all resources.
 namespace: nvidia-network-operator
 
 # Adds a prefix to all resource names.
 namePrefix: nvidia-network-operator-
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../certmanager
+- ../webhook
 
 patches:
-  - path: ./drop_manager_args_and_resources.yaml
-    target:
-      group: apps
-      kind: Deployment
-      name: controller-manager
-      namespace: system
-      version: v1
+# Drop args and resources to enable debugging.
+- path: ./drop_manager_args_and_resources.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+    version: v1
+# Enable webhook.
+- path: ./manager_webhook_patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+    version: v1
+# Inject certificates in the webhook definition.
+- path: webhookcainjection_patch.yaml
+  target:
+    group: admissionregistration.k8s.io
+    kind: ValidatingWebhookConfiguration
+    version: v1
+# Inject certificates in the nicclusterpolicy webhook definition.
+- path: cainjection_in_nicclusterpolicies.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    version: v1
+# Enable the webhook in the nicclusterpolicy CRD.
+- path: webhook_in_nicclusterpolicies.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    version: v1
+# Inject certificates in the hostdevicenetwork webhook definition.
+- path: cainjection_in_hostdevicenetworks.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    version: v1
+# Enable the webhook in the hostdevicenetwork CRD.
+- path: webhook_in_hostdevicenetworks.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    version: v1
+
+vars:
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/dev/manager_webhook_patch.yaml
+++ b/config/dev/manager_webhook_patch.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: "ENABLE_WEBHOOKS"
+          value: "true"
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/dev/webhook_in_hostdevicenetworks.yaml
+++ b/config/dev/webhook_in_hostdevicenetworks.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostdevicenetworks.mellanox.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/dev/webhook_in_nicclusterpolicies.yaml
+++ b/config/dev/webhook_in_nicclusterpolicies.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nicclusterpolicies.mellanox.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/dev/webhookcainjection_patch.yaml
+++ b/config/dev/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: validatingwebhookconfiguration
+    app.kubernetes.io/instance: validating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: nvidia-network-operator
+    app.kubernetes.io/part-of: nvidia-network-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/hack/scripts/minikube-install.sh
+++ b/hack/scripts/minikube-install.sh
@@ -82,7 +82,7 @@ if [[ $($MINIKUBE_BIN status -p $CLUSTER_NAME  -f '{{.Name}}') == $CLUSTER_NAME 
   exit 0
 fi
 
-$MINIKUBE_BIN start --profile $CLUSTER_NAME $MINIKUBE_ARGS
+$MINIKUBE_BIN start --profile $CLUSTER_NAME $MINIKUBE_ARGS $MINIKUBE_EXTRA_ARGS
 
 ## Set environment variables to use the Minikube VM docker build for
 if [[ "$USE_MINIKUBE_DOCKER" == "true" ]]; then


### PR DESCRIPTION
This change enables the nicclusterpolicy and hostnetwork webhooks under the `dev-skaffold` make target.

This change means that users of the `dev/skaffold` kustomize target - used by default with the `skaffold.yaml` - will have to install cert manager.

