### PR TITLE
fix: ensure default resources are rendered in all states

### DIFF
--- a/manifests/state-container-networking-plugins/0010-container-networking-plugins-ds.yml
+++ b/manifests/state-container-networking-plugins/0010-container-networking-plugins-ds.yml
@@ -55,7 +55,8 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-          {{- with index .RuntimeSpec.ContainerResources "cni-plugins" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "cni-plugins" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -65,6 +66,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- else }}
           resources:
             requests:

--- a/manifests/state-ib-kubernetes/0070-deployment.yaml
+++ b/manifests/state-ib-kubernetes/0070-deployment.yaml
@@ -71,7 +71,8 @@ spec:
           image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
           imagePullPolicy: IfNotPresent
           command: ["/usr/bin/ib-kubernetes"]
-          {{- with index .RuntimeSpec.ContainerResources "ib-kubernetes" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "ib-kubernetes" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -81,6 +82,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- else }}
           resources:
             requests:

--- a/manifests/state-ipoib-cni/0050-ipoib-cni-ds.yml
+++ b/manifests/state-ipoib-cni/0050-ipoib-cni-ds.yml
@@ -59,7 +59,8 @@ spec:
       containers:
         - name: ipoib-cni
           image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
-          {{- with index .RuntimeSpec.ContainerResources "ipoib-cni" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "ipoib-cni" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -69,6 +70,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- else }}
           resources:
             requests:

--- a/manifests/state-nic-feature-discovery/030-nic-feature-discovery-ds.yaml
+++ b/manifests/state-nic-feature-discovery/030-nic-feature-discovery-ds.yaml
@@ -63,7 +63,8 @@ spec:
           args:
             - --v=0
             - --logging-format=json
-          {{- with index .RuntimeSpec.ContainerResources "nic-feature-discovery" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "nic-feature-discovery" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -73,6 +74,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- else }}
           resources:
             requests:

--- a/manifests/state-nv-ipam-cni/040-nv-ipam-controller.yaml
+++ b/manifests/state-nv-ipam-cni/040-nv-ipam-controller.yaml
@@ -119,7 +119,8 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          {{- with index .RuntimeSpec.ContainerResources "nv-ipam-controller" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "nv-ipam-controller" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -129,6 +130,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- else }}
           resources:
             requests:

--- a/manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
+++ b/manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
@@ -81,7 +81,8 @@ spec:
           - --cni-log-file=/var/log/nv-ipam-cni.log
           - --cni-log-level=info # log level for shim CNI
           - --ippools-namespace=$(IPPOOLS_NAMESPACE)
-        {{- with index .RuntimeSpec.ContainerResources "nv-ipam-node" }}
+        {{- with .RuntimeSpec.ContainerResources }}
+        {{- with index . "nv-ipam-node" }}
         resources:
           {{- if .Requests }}
           requests:
@@ -91,6 +92,7 @@ spec:
           limits:
             {{ .Limits | yaml | nindent 12}}
           {{- end }}
+        {{- end }}
         {{- else }}
         resources:
           requests:

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -124,7 +124,8 @@ spec:
             - name: shared-doca-driver-toolkit
               mountPath: /mnt/shared-doca-driver-toolkit
             {{- end}}
-          {{- with index .RuntimeSpec.ContainerResources "mofed-container" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "mofed-container" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -134,6 +135,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- end }}
           startupProbe:
             exec:

--- a/manifests/state-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/state-rdma-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -78,7 +78,8 @@ spec:
           - name: host-config-volume
             mountPath: /host/etc/pcidp/
           {{- end }}
-        {{- with index .RuntimeSpec.ContainerResources "rdma-shared-dp" }}
+        {{- with .RuntimeSpec.ContainerResources }}
+        {{- with index . "rdma-shared-dp" }}
         resources:
           {{- if .Requests }}
           requests:
@@ -88,6 +89,7 @@ spec:
           limits:
             {{ .Limits | yaml | nindent 12}}
           {{- end }}
+        {{- end }}
         {{- end }}
       volumes:
         - name: device-plugin

--- a/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yml
+++ b/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yml
@@ -93,7 +93,8 @@ spec:
             - name: host-config-volume
               mountPath: /host/etc/pcidp/
             {{- end}}
-          {{- with index .RuntimeSpec.ContainerResources "kube-sriovdp" }}
+          {{- with .RuntimeSpec.ContainerResources }}
+          {{- with index . "kube-sriovdp" }}
           resources:
             {{- if .Requests }}
             requests:
@@ -103,6 +104,7 @@ spec:
             limits:
               {{ .Limits | yaml | nindent 14}}
             {{- end }}
+          {{- end }}
           {{- end }}
       volumes:
         - name: devicesock

--- a/manifests/state-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/state-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -60,7 +60,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- with index .RuntimeSpec.ContainerResources "whereabouts" }}
+        {{- with .RuntimeSpec.ContainerResources }}
+        {{- with index . "whereabouts" }}
         resources:
           {{- if .Requests }}
           requests:
@@ -70,6 +71,7 @@ spec:
           limits:
             {{ .Limits | yaml | nindent 12}}
           {{- end }}
+        {{- end }}
         {{- else }}
         resources:
           requests:


### PR DESCRIPTION
Issue identified in https://github.com/Mellanox/network-operator/pull/769 and in particular https://github.com/Mellanox/network-operator/commit/bae3edd6cb0ecf83b7d2dd5c7530ec8e86e19248.

Before this change, always the branch under `{{- with index .RuntimeSpec.ContainerResources <REPLACE_WITH_CONTAINER_NAME> }}` would be executed and not the branch under `{{- else }}`.  This means that the default resources will never render.

This is because the `.RuntimeSpec.ContainerResources` would be empty and we try to check for a key in an empty map using index that [will always return something](https://cs.opensource.google/go/go/+/master:src/text/template/funcs.go;l=234). According to the [docs](https://pkg.go.dev/text/template@go1.21.6#hdr-Functions:~:text=%7B%7Bwith%20pipeline%7D%7D%20T1%20%7B%7Belse%7D%7D%20T0%20%7B%7Bend%7D%7D), only if the condition is empty, which is not, then the second branch will run.
```
{{with pipeline}} T1 {{else}} T0 {{end}}
	If the value of the pipeline is empty, dot is unaffected and T0
	is executed; otherwise, dot is set to the value of the pipeline
	and T1 is executed.
```

There is still an edge case when we use a wrong container, but this is ultimately caught on the webhook level, validated in that test case: https://github.com/Mellanox/network-operator/blob/5e566cdfc897cfa153b8d702b2247e8bced8f393/api/v1alpha1/validator/nicclusterpolicy_webhook_test.go#L748-L772. That edge case is reflected in this test. Resources should not be nil but default here: https://github.com/Mellanox/network-operator/blob/5e566cdfc897cfa153b8d702b2247e8bced8f393/pkg/state/state_ib_kubernetes_test.go#L154-L199. 
