### PR TITLE
feat: Allow to configure persistent driver inventory for the OFED driver to avoid recompilation between runs

### DIFF
--- a/docs/mofed-container-env-vars.md
+++ b/docs/mofed-container-env-vars.md
@@ -23,6 +23,7 @@ In most deployments its expected to not require setting those.
 | UNLOAD_STORAGE_MODULES |N|`"false"`| unload host storage modules prior to loading mofed modules  |
 | ENABLE_NFSRDMA |N|`"false"`| enable loading of nfs relates storage modules from mofed container|
 | RESTORE_DRIVER_ON_POD_TERMINATION |N|`"true"`| restore host drivers when container is gracefully stopped |
+| NVIDIA_NIC_DRIVERS_INVENTORY_PATH | N | `"/mnt/drivers-inventory"` | enable use of a persistent directory to store drivers' build artifacts to avoid recompilation between runs. Keep the default value or set to "" to disable. |
 
 In addition, the user can specify essentially any environment variables to be exposed to the MOFED container such as
 the standard `"HTTP_PROXY"`, `"HTTPS_PROXY"`, `"NO_PROXY"`

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -112,6 +112,8 @@ spec:
               readOnly: true
             - name: host-lib-modules
               mountPath: /host/lib/modules
+            - name: drivers-inventory
+              mountPath: /mnt/drivers-inventory
             {{- if.AdditionalVolumeMounts.VolumeMounts }}
             {{- range .AdditionalVolumeMounts.VolumeMounts }}
             - name: {{ .Name }}
@@ -219,6 +221,10 @@ spec:
         - name: host-lib-modules
           hostPath:
             path: /lib/modules
+        - name: drivers-inventory
+          hostPath:
+            path: /var/opt/mofed-container/inventory
+            type: DirectoryOrCreate
         {{- range .AdditionalVolumeMounts.Volumes }}
         - name: {{ .Name }}
           configMap:

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -80,9 +80,12 @@ const (
 
 // names of environment variables which used for OFED proxy configuration
 const (
-	envVarNameHTTPProxy  = "HTTP_PROXY"
-	envVarNameHTTPSProxy = "HTTPS_PROXY"
-	envVarNameNoProxy    = "NO_PROXY"
+	envVarNameHTTPProxy         = "HTTP_PROXY"
+	envVarNameHTTPSProxy        = "HTTPS_PROXY"
+	envVarNameNoProxy           = "NO_PROXY"
+	envVarCreateIfNamesUdev     = "CREATE_IFNAMES_UDEV"
+	envVarDriversInventoryPath  = "NVIDIA_NIC_DRIVERS_INVENTORY_PATH"
+	defaultDriversInventoryPath = "/mnt/drivers-inventory"
 )
 
 // CertConfigPathMap indicates standard OS specific paths for ssl keys/certificates.
@@ -647,13 +650,18 @@ func (s *stateOFED) setEnvFromClusterWideProxy(cr *mellanoxv1alpha1.NicClusterPo
 // mergeWithDefaultEnvs returns env variables provided in currentEnvs merged with default
 // env variables for MOFED container.
 func (s *stateOFED) mergeWithDefaultEnvs(currentEnvs []v1.EnvVar) []v1.EnvVar {
-	if envVarsWithGet(currentEnvs).Get("CREATE_IFNAMES_UDEV") != nil {
-		// already exists dont overwrite
-		return currentEnvs
-	}
+	envs := currentEnvs
 
 	// CREATE_IFNAMES_UDEV: should be set to true if not provided.
-	return append(currentEnvs, v1.EnvVar{Name: "CREATE_IFNAMES_UDEV", Value: "true"})
+	if envVarsWithGet(currentEnvs).Get(envVarCreateIfNamesUdev) == nil {
+		envs = append(envs, v1.EnvVar{Name: envVarCreateIfNamesUdev, Value: "true"})
+	}
+	// NVIDIA_NIC_DRIVERS_INVENTORY_PATH: should be set to true if not provided.
+	if envVarsWithGet(currentEnvs).Get(envVarDriversInventoryPath) == nil {
+		envs = append(envs, v1.EnvVar{Name: envVarDriversInventoryPath, Value: defaultDriversInventoryPath})
+	}
+
+	return envs
 }
 
 // envVarsWithGet is a wrapper type for []EnvVar to extend with additional functionality

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -214,16 +214,31 @@ var _ = Describe("MOFED state test", func() {
 			Expect(mergedEnvs).To(BeEquivalentTo(expectedEnvs))
 		},
 		Entry("add defaults when no env vars",
-			[]v1.EnvVar{}, []v1.EnvVar{{Name: "CREATE_IFNAMES_UDEV", Value: "true"}}),
+			[]v1.EnvVar{}, []v1.EnvVar{
+				{Name: envVarCreateIfNamesUdev, Value: "true"},
+				{Name: envVarDriversInventoryPath, Value: defaultDriversInventoryPath}}),
 		Entry("add defaults when env vars provided",
 			[]v1.EnvVar{{Name: "Foo", Value: "Bar"}},
-			[]v1.EnvVar{{Name: "Foo", Value: "Bar"}, {Name: "CREATE_IFNAMES_UDEV", Value: "true"}}),
+			[]v1.EnvVar{
+				{Name: "Foo", Value: "Bar"},
+				{Name: envVarCreateIfNamesUdev, Value: "true"},
+				{Name: envVarDriversInventoryPath, Value: defaultDriversInventoryPath}}),
 		Entry("override defaults by user",
-			[]v1.EnvVar{{Name: "CREATE_IFNAMES_UDEV", Value: "false"}},
-			[]v1.EnvVar{{Name: "CREATE_IFNAMES_UDEV", Value: "false"}}),
+			[]v1.EnvVar{
+				{Name: envVarCreateIfNamesUdev, Value: "false"},
+				{Name: envVarDriversInventoryPath, Value: ""}},
+			[]v1.EnvVar{
+				{Name: envVarCreateIfNamesUdev, Value: "false"},
+				{Name: envVarDriversInventoryPath, Value: ""}}),
 		Entry("override defaults by user with additional env vars",
-			[]v1.EnvVar{{Name: "Foo", Value: "Bar"}, {Name: "CREATE_IFNAMES_UDEV", Value: "false"}},
-			[]v1.EnvVar{{Name: "Foo", Value: "Bar"}, {Name: "CREATE_IFNAMES_UDEV", Value: "false"}}),
+			[]v1.EnvVar{
+				{Name: "Foo", Value: "Bar"},
+				{Name: envVarCreateIfNamesUdev, Value: "false"},
+				{Name: envVarDriversInventoryPath, Value: ""}},
+			[]v1.EnvVar{
+				{Name: "Foo", Value: "Bar"},
+				{Name: envVarCreateIfNamesUdev, Value: "false"},
+				{Name: envVarDriversInventoryPath, Value: ""}}),
 	)
 
 	Context("Render Manifests", func() {


### PR DESCRIPTION
Introduce DriverInventoryPath to the OFED spec.

It represents a path to a persistent writable folder where OFED container can store its build artifacts. If the artifacts for the correct version and arch exist in this folder when the OFED container is started, they will be reused without driver being recompiled.