### PR TITLE
chore: Bump commit check github action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore:"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
+    ignore:
+      # Ignore k8s-operator-libs, controller-runtime, and Kubernetes major and minor updates. These should be done manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "github.com/NVIDIA/k8s-operator-libs"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    commit-message:
+      prefix: "chore:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   lint-code:
     name: golangci-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -18,7 +18,7 @@ jobs:
         run: make lint
   lint-docker:
     name: hadolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -28,7 +28,7 @@ jobs:
         run: make lint-dockerfile
   lint-helm:
     name: helm lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -38,7 +38,7 @@ jobs:
         run: make lint-helm
   diff-manifests:
     name: check manifests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -48,7 +48,7 @@ jobs:
         run: make check-manifests
   diff-modules:
     name: check go modules
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -58,7 +58,7 @@ jobs:
         run: make check-go-modules
   diff-release-build:
     name: check release-build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -68,7 +68,7 @@ jobs:
         run: make check-release-build
   unit-tests:
     name: Unit-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/commit-msg-chk.yaml
+++ b/.github/workflows/commit-msg-chk.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - name: check-for-cc
         id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+        uses: agenthunt/conventional-commit-checker-action@v2.0.0


### PR DESCRIPTION
Bump conventional commit github action. This action was giving a security warning because of outdated dependencies.

Release: https://github.com/agenthunt/conventional-commit-checker-action/releases/tag/v2.0.0 