### PR TITLE
fix: Description of Makefile go-install-tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ dev-skaffold: $(SKAFFOLD) dev-minikube ## Create a development minikube cluster 
 	$Q eval $$($(MINIKUBE) -p $(MINIKUBE_CLUSTER_NAME) docker-env); \
 	$(SKAFFOLD) debug --default-repo=$(SKAFFOLD_REGISTRY) --detect-minikube=false
 
-# go-install-tool will 'go install' any package $2 and install it to $1.
+# go-install-tool will 'go install' a go module $1 with version $3 and install it with the name $2-$3 to $TOOLSDIR.
 define go-install-tool
 	$Q echo "Installing $(2)-$(3) to $(TOOLSDIR)"
 	$Q GOBIN=$(TOOLSDIR) go install $(1)@$(3)


### PR DESCRIPTION
Fix-up a comment on the `go-install-tool` function inside the Makefile to reflect what it's actually doing.

This function was changed in https://github.com/Mellanox/network-operator/pull/755 but the comment was not updated.