### PR TITLE
refactor: remove redundant Scheme from state

### DIFF
--- a/api/v1alpha1/validator/nicclusterpolicy_webhook.go
+++ b/api/v1alpha1/validator/nicclusterpolicy_webhook.go
@@ -493,7 +493,7 @@ type containerResourcesProvider interface {
 
 // newStateFunc is a common alias for all functions that create states deployed by nicClusterPolicy
 type newStateFunc func(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (state.State, state.ManifestRenderer, error)
+	k8sAPIClient client.Client, manifestDir string) (state.State, state.ManifestRenderer, error)
 
 // stateRenderData is a helper struct that consolidates everything required to render a state
 type stateRenderData struct {
@@ -594,7 +594,7 @@ func validateContainerResourcesIfNotNil(
 		return allErrs
 	}
 
-	_, renderer, err := resource.newState(nil, nil, resource.manifestDir)
+	_, renderer, err := resource.newState(nil, resource.manifestDir)
 	if err != nil {
 		nicClusterPolicyLog.Error(err, "failed to created state renderer")
 		return allErrs

--- a/controllers/hostdevicenetwork_controller.go
+++ b/controllers/hostdevicenetwork_controller.go
@@ -141,7 +141,7 @@ NextResult:
 //nolint:dupl
 func (r *HostDeviceNetworkReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Logger) error {
 	// Create state manager
-	stateManager, err := state.NewManager(mellanoxcomv1alpha1.HostDeviceNetworkCRDName, mgr.GetClient(), mgr.GetScheme(),
+	stateManager, err := state.NewManager(mellanoxcomv1alpha1.HostDeviceNetworkCRDName, mgr.GetClient(),
 		setupLog.WithName("StateManager"))
 	if err != nil {
 		// Error creating stateManager

--- a/controllers/ipoibnetwork_controller.go
+++ b/controllers/ipoibnetwork_controller.go
@@ -132,7 +132,7 @@ func (r *IPoIBNetworkReconciler) updateCrStatus(
 //nolint:dupl
 func (r *IPoIBNetworkReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Logger) error {
 	// Create state manager
-	stateManager, err := state.NewManager(mellanoxcomv1alpha1.IPoIBNetworkCRDName, mgr.GetClient(), mgr.GetScheme(),
+	stateManager, err := state.NewManager(mellanoxcomv1alpha1.IPoIBNetworkCRDName, mgr.GetClient(),
 		setupLog.WithName("StateManager"))
 	if err != nil {
 		// Error creating stateManager

--- a/controllers/macvlannetwork_controller.go
+++ b/controllers/macvlannetwork_controller.go
@@ -127,7 +127,7 @@ func (r *MacvlanNetworkReconciler) updateCrStatus(
 //nolint:dupl
 func (r *MacvlanNetworkReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Logger) error {
 	// Create state manager
-	stateManager, err := state.NewManager(mellanoxcomv1alpha1.MacvlanNetworkCRDName, mgr.GetClient(), mgr.GetScheme(),
+	stateManager, err := state.NewManager(mellanoxcomv1alpha1.MacvlanNetworkCRDName, mgr.GetClient(),
 		setupLog.WithName("StateManager"))
 	if err != nil {
 		// Error creating stateManager

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -324,7 +324,7 @@ func (r *NicClusterPolicyReconciler) handleUnsupportedInstance(
 //nolint:dupl
 func (r *NicClusterPolicyReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Logger) error {
 	// Create state manager
-	stateManager, err := state.NewManager(mellanoxv1alpha1.NicClusterPolicyCRDName, mgr.GetClient(), mgr.GetScheme(),
+	stateManager, err := state.NewManager(mellanoxv1alpha1.NicClusterPolicyCRDName, mgr.GetClient(),
 		setupLog.WithName("StateManager"))
 	if err != nil {
 		setupLog.V(consts.LogLevelError).Error(err, "Error creating state manager.")

--- a/pkg/state/continuity_check_test.go
+++ b/pkg/state/continuity_check_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Continuity check", func() {
 
 			manifestsBaseDir := filepath.Join("..", "..", "manifests")
 			envConfig = &config.OperatorConfig{State: config.StateConfig{ManifestBaseDir: manifestsBaseDir}}
-			states, err := newNicClusterPolicyStates(nil, nil)
+			states, err := newNicClusterPolicyStates(nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, state := range states {

--- a/pkg/state/state_cni_plugins.go
+++ b/pkg/state/state_cni_plugins.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,7 +40,7 @@ const stateCNIPluginsDescription = "Container Networking CNI Plugins deployed in
 
 // NewStateCNIPlugins creates a new state for secondary container networking CNI plugins
 func NewStateCNIPlugins(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -53,7 +52,6 @@ func NewStateCNIPlugins(
 			name:        stateCNIPluginsName,
 			description: stateCNIPluginsDescription,
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 
@@ -104,7 +102,7 @@ func (s *stateCNIPlugins) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_cni_plugins_test.go
+++ b/pkg/state/state_cni_plugins_test.go
@@ -51,7 +51,7 @@ var _ = Describe("CNI plugins state", func() {
 		Expect(appsv1.AddToScheme(scheme)).NotTo(HaveOccurred())
 		client = fake.NewClientBuilder().WithScheme(scheme).Build()
 		manifestDir := "../../manifests/state-container-networking-plugins"
-		s, _, err := state.NewStateCNIPlugins(client, scheme, manifestDir)
+		s, _, err := state.NewStateCNIPlugins(client, manifestDir)
 		Expect(err).NotTo(HaveOccurred())
 		cniPluginsState = s
 		catalog = getTestCatalog()

--- a/pkg/state/state_hostdevice_network.go
+++ b/pkg/state/state_hostdevice_network.go
@@ -24,7 +24,6 @@ import (
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,7 +42,7 @@ const (
 )
 
 // NewStateHostDeviceNetwork creates a new state for HostDeviceNetwork CR
-func NewStateHostDeviceNetwork(k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, error) {
+func NewStateHostDeviceNetwork(k8sAPIClient client.Client, manifestDir string) (State, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -55,7 +54,6 @@ func NewStateHostDeviceNetwork(k8sAPIClient client.Client, scheme *runtime.Schem
 			name:        stateHostDeviceNetworkName,
 			description: stateHostDeviceNetworkDescription,
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}, nil
 }
@@ -96,7 +94,7 @@ func (s *stateHostDeviceNetwork) Sync(
 	}
 
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_hostdevice_network_test.go
+++ b/pkg/state/state_hostdevice_network_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/pkg/render"
@@ -45,7 +44,6 @@ var _ = Describe("HostDevice Network State rendering tests", func() {
 		It("Should Render NetworkAttachmentDefinition", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-hostdevice-network"
-			scheme := runtime.NewScheme()
 
 			files, err := utils.GetFilesWithSuffix(manifestBaseDir, render.ManifestFileSuffix...)
 			Expect(err).NotTo(HaveOccurred())
@@ -57,7 +55,6 @@ var _ = Describe("HostDevice Network State rendering tests", func() {
 					name:        stateName,
 					description: "Host Device net-attach-def CR deployed in cluster",
 					client:      &client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}

--- a/pkg/state/state_ib_kubernetes.go
+++ b/pkg/state/state_ib_kubernetes.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,7 +35,7 @@ import (
 
 // NewStateIBKubernetes creates a new ib-kubernetes state
 func NewStateIBKubernetes(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -48,7 +47,6 @@ func NewStateIBKubernetes(
 			name:        "state-ib-kubernetes",
 			description: "ib-kubernetes deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -108,7 +106,7 @@ func (s *stateIBKubernetes) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_ib_kubernetes_test.go
+++ b/pkg/state/state_ib_kubernetes_test.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +38,6 @@ var _ = Describe("IB Kubernetes state rendering tests", func() {
 		It("Should Render NetworkAttachmentDefinition", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-ib-kubernetes"
-			scheme := runtime.NewScheme()
 
 			files, err := utils.GetFilesWithSuffix(manifestBaseDir, render.ManifestFileSuffix...)
 			Expect(err).NotTo(HaveOccurred())
@@ -51,7 +49,6 @@ var _ = Describe("IB Kubernetes state rendering tests", func() {
 					name:        stateName,
 					description: "ib-kubernetes deployed in the cluster",
 					client:      &client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}

--- a/pkg/state/state_ipoib_cni.go
+++ b/pkg/state/state_ipoib_cni.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateIPoIBCNI creates a new state for IPoIB NI
 func NewStateIPoIBCNI(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateIPoIBCNI(
 			name:        "state-ipoib-cni",
 			description: "IPoIB CNI deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -105,7 +103,7 @@ func (s *stateIPoIBCNI) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_ipoib_cni_test.go
+++ b/pkg/state/state_ipoib_cni_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,7 +37,6 @@ var _ = Describe("IPoIB CNI State tests", func() {
 		It("Should Apply", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-ipoib-cni"
-			scheme := runtime.NewScheme()
 
 			files, err := utils.GetFilesWithSuffix(manifestBaseDir, render.ManifestFileSuffix...)
 			Expect(err).NotTo(HaveOccurred())
@@ -50,7 +48,6 @@ var _ = Describe("IPoIB CNI State tests", func() {
 					name:        stateName,
 					description: "IPoIB CNI deployed in the cluster",
 					client:      &client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}

--- a/pkg/state/state_ipoib_network.go
+++ b/pkg/state/state_ipoib_network.go
@@ -26,7 +26,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -44,7 +43,7 @@ const (
 )
 
 // NewStateIPoIBNetwork creates a new state for IPoIBNetwork CR
-func NewStateIPoIBNetwork(k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, error) {
+func NewStateIPoIBNetwork(k8sAPIClient client.Client, manifestDir string) (State, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -56,7 +55,6 @@ func NewStateIPoIBNetwork(k8sAPIClient client.Client, scheme *runtime.Scheme, ma
 			name:        stateIPoIBNetworkName,
 			description: stateIPoIBNetworkDescription,
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}, nil
 }
@@ -95,7 +93,7 @@ func (s *stateIPoIBNetwork) Sync(ctx context.Context, customResource interface{}
 	}
 
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_ipoib_network_test.go
+++ b/pkg/state/state_ipoib_network_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package state
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -34,7 +32,6 @@ var _ = Describe("IPoIBNetwork Network state rendering tests", func() {
 		It("Should Render NetworkAttachmentDefinition", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-ipoib-network"
-			scheme := runtime.NewScheme()
 
 			files, err := utils.GetFilesWithSuffix(manifestBaseDir, render.ManifestFileSuffix...)
 			Expect(err).NotTo(HaveOccurred())
@@ -46,7 +43,6 @@ var _ = Describe("IPoIBNetwork Network state rendering tests", func() {
 					name:        stateName,
 					description: "IPoIBNetwork net-attach-def CR deployed in cluster",
 					client:      &client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}

--- a/pkg/state/state_macvlan_network.go
+++ b/pkg/state/state_macvlan_network.go
@@ -26,7 +26,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -44,7 +43,7 @@ const (
 )
 
 // NewStateMacvlanNetwork creates a new state for MacvlanNetwork CR
-func NewStateMacvlanNetwork(k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, error) {
+func NewStateMacvlanNetwork(k8sAPIClient client.Client, manifestDir string) (State, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -56,7 +55,6 @@ func NewStateMacvlanNetwork(k8sAPIClient client.Client, scheme *runtime.Scheme, 
 			name:        stateMacvlanNetworkName,
 			description: stateMacvlanNetworkDescription,
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}, nil
 }
@@ -95,7 +93,7 @@ func (s *stateMacvlanNetwork) Sync(ctx context.Context, customResource interface
 	}
 
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_multus_cni.go
+++ b/pkg/state/state_multus_cni.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateMultusCNI creates a new state for Multus
 func NewStateMultusCNI(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateMultusCNI(
 			name:        "state-multus-cni",
 			description: "multus CNI deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -100,7 +98,7 @@ func (s *stateMultusCNI) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_multus_cni_test.go
+++ b/pkg/state/state_multus_cni_test.go
@@ -46,14 +46,12 @@ var _ = Describe("Multus CNI state", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		client := mocks.ControllerRuntimeClient{}
-		scheme := runtime.NewScheme()
 		renderer := render.NewRenderer(files)
 		state = stateMultusCNI{
 			stateSkel: stateSkel{
 				name:        "state-multus-cni",
 				description: "multus CNI deployed in the cluster",
 				client:      &client,
-				scheme:      scheme,
 				renderer:    renderer,
 			}}
 		catalog = NewInfoCatalog()

--- a/pkg/state/state_nic_feature_discovery.go
+++ b/pkg/state/state_nic_feature_discovery.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateNICFeatureDiscovery creates a new state for NICFeatureDiscovery
 func NewStateNICFeatureDiscovery(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateNICFeatureDiscovery(
 			name:        "state-nic-feature-discovery",
 			description: "nic-feature-discovery deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -108,7 +106,7 @@ func (s *stateNICFeatureDiscovery) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_nv_ipam_cni.go
+++ b/pkg/state/state_nv_ipam_cni.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateNVIPAMCNI creates a new state for Multus
 func NewStateNVIPAMCNI(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateNVIPAMCNI(
 			name:        "state-nv-ipam-cni",
 			description: "nv-ipam IPAM CNI deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -106,7 +104,7 @@ func (s *stateNVIPAMCNI) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -230,7 +230,6 @@ var _ = Describe("MOFED state test", func() {
 		It("Should Render Mofed DaemonSet", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-ofed-driver"
-			scheme := runtime.NewScheme()
 
 			files, err := utils.GetFilesWithSuffix(manifestBaseDir, render.ManifestFileSuffix...)
 			Expect(err).NotTo(HaveOccurred())
@@ -241,7 +240,6 @@ var _ = Describe("MOFED state test", func() {
 					name:        stateOFEDName,
 					description: stateOFEDDescription,
 					client:      &client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}
@@ -316,7 +314,6 @@ var _ = Describe("MOFED state test", func() {
 					name:        stateOFEDName,
 					description: stateOFEDDescription,
 					client:      client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}

--- a/pkg/state/state_shared_dp.go
+++ b/pkg/state/state_shared_dp.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateSharedDp creates a new shared device plugin state
 func NewStateSharedDp(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateSharedDp(
 			name:        "state-RDMA-device-plugin",
 			description: "RDMA shared device plugin deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -106,7 +104,7 @@ func (s *stateSharedDp) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -27,7 +27,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +56,6 @@ type stateSkel struct {
 	description string
 
 	client   client.Client
-	scheme   *runtime.Scheme
 	renderer render.Renderer
 }
 

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateSriovDp creates a new shared device plugin state
 func NewStateSriovDp(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateSriovDp(
 			name:        "state-SRIOV-device-plugin",
 			description: "SR-IOV device plugin deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -108,7 +106,7 @@ func (s *stateSriovDp) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil

--- a/pkg/state/state_sriov_dp_test.go
+++ b/pkg/state/state_sriov_dp_test.go
@@ -26,7 +26,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/pkg/config"
@@ -67,7 +66,6 @@ var _ = Describe("SR-IOV Device Plugin State tests", func() {
 		It("Should Apply", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-sriov-device-plugin"
-			scheme := runtime.NewScheme()
 
 			files, err := utils.GetFilesWithSuffix(manifestBaseDir, render.ManifestFileSuffix...)
 			Expect(err).NotTo(HaveOccurred())
@@ -79,7 +77,6 @@ var _ = Describe("SR-IOV Device Plugin State tests", func() {
 					name:        stateName,
 					description: "SR-IOV device plugin deployed in the cluster",
 					client:      &client,
-					scheme:      scheme,
 					renderer:    renderer,
 				},
 			}

--- a/pkg/state/state_whereabouts_cni.go
+++ b/pkg/state/state_whereabouts_cni.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +37,7 @@ import (
 
 // NewStateWhereaboutsCNI creates a new state for Whereabouts
 func NewStateWhereaboutsCNI(
-	k8sAPIClient client.Client, scheme *runtime.Scheme, manifestDir string) (State, ManifestRenderer, error) {
+	k8sAPIClient client.Client, manifestDir string) (State, ManifestRenderer, error) {
 	files, err := utils.GetFilesWithSuffix(manifestDir, render.ManifestFileSuffix...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get files from manifest dir")
@@ -50,7 +49,6 @@ func NewStateWhereaboutsCNI(
 			name:        "state-whereabouts-cni",
 			description: "whereabouts IPAM CNI deployed in the cluster",
 			client:      k8sAPIClient,
-			scheme:      scheme,
 			renderer:    renderer,
 		}}
 	return state, state, nil
@@ -100,7 +98,7 @@ func (s *stateWhereaboutsCNI) Sync(
 
 	// Create objects if they dont exist, Update objects if they do exist
 	err = s.createOrUpdateObjs(ctx, func(obj *unstructured.Unstructured) error {
-		if err := controllerutil.SetControllerReference(cr, obj, s.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cr, obj, s.client.Scheme()); err != nil {
 			return errors.Wrap(err, "failed to set controller reference for object")
 		}
 		return nil


### PR DESCRIPTION
k8s client already has a method to get scheme.
