### PR TITLE
fix: Toleration indentation problem

### DIFF
--- a/manifests/state-nic-feature-discovery/030-nic-feature-discovery-ds.yaml
+++ b/manifests/state-nic-feature-discovery/030-nic-feature-discovery-ds.yaml
@@ -39,9 +39,9 @@ spec:
       serviceAccountName: nic-feature-discovery
       {{- end }}
       tolerations:
-      {{- if .Tolerations }}
-        {{- .Tolerations | yaml | nindent 8 }}
-      {{- end }}
+        {{- if .Tolerations }}
+          {{- .Tolerations | yaml | nindent 8 }}
+        {{- end }}
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
+++ b/manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
@@ -37,12 +37,12 @@ spec:
       serviceAccountName: nv-ipam-node
       terminationGracePeriodSeconds: 10
       tolerations:
-      {{- if .Tolerations }}
-      {{- .Tolerations | yaml | nindent 8 }}
-      {{- end }}
-      - key: nvidia.com/gpu
-        operator: Exists
-        effect: NoSchedule
+        {{- if .Tolerations }}
+        {{- .Tolerations | yaml | nindent 8 }}
+        {{- end }}
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
       {{- if .NodeAffinity }}
       affinity:
         nodeAffinity:


### PR DESCRIPTION
If you try to add a toleration, it fails with the exception below. It is failing because the Toleration block is in a different level of indentation as `nvidia.com/gpu:NoSchedule`.

```
error converting YAML to JSON: yaml: line 28: did not find expected key
failed to unmarshal manifest /manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
github.com/Mellanox/network-operator/pkg/render.(*textTemplateRenderer).renderFile
	/workspace/pkg/render/render.go:155
github.com/Mellanox/network-operator/pkg/render.(*textTemplateRenderer).RenderObjects
	/workspace/pkg/render/render.go:81
github.com/Mellanox/network-operator/pkg/state.(*stateNVIPAMCNI).getManifestObjects
	/workspace/pkg/state/state_nv_ipam_cni.go:157
github.com/Mellanox/network-operator/pkg/state.(*stateNVIPAMCNI).Sync
	/workspace/pkg/state/state_nv_ipam_cni.go:99
github.com/Mellanox/network-operator/pkg/state.(*stateManager).SyncState
	/workspace/pkg/state/manager.go:92
github.com/Mellanox/network-operator/controllers.(*NicClusterPolicyReconciler).Reconcile
	/workspace/controllers/nicclusterpolicy_controller.go:144
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1598
failed to render objects
github.com/Mellanox/network-operator/pkg/state.(*stateNVIPAMCNI).getManifestObjects
	/workspace/pkg/state/state_nv_ipam_cni.go:160
github.com/Mellanox/network-operator/pkg/state.(*stateNVIPAMCNI).Sync
	/workspace/pkg/state/state_nv_ipam_cni.go:99
github.com/Mellanox/network-operator/pkg/state.(*stateManager).SyncState
	/workspace/pkg/state/manager.go:92
github.com/Mellanox/network-operator/controllers.(*NicClusterPolicyReconciler).Reconcile
	/workspace/controllers/nicclusterpolicy_controller.go:144
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1598
failed to create k8s objects from manifest
github.com/Mellanox/network-operator/pkg/state.(*stateNVIPAMCNI).Sync
	/workspace/pkg/state/state_nv_ipam_cni.go:101
github.com/Mellanox/network-operator/pkg/state.(*stateManager).SyncState
	/workspace/pkg/state/manager.go:92
github.com/Mellanox/network-operator/controllers.(*NicClusterPolicyReconciler).Reconcile
	/workspace/controllers/nicclusterpolicy_controller.go:144
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1598
```