### PR TITLE
feat: modify OFED version validation to support new scheme

### DIFF
--- a/api/v1alpha1/validator/nicclusterpolicy_webhook.go
+++ b/api/v1alpha1/validator/nicclusterpolicy_webhook.go
@@ -659,7 +659,7 @@ func validateResources(resources map[v1.ResourceName]apiresource.Quantity, allEr
 
 // isValidOFEDVersion is a custom function to validate OFED version
 func isValidOFEDVersion(version string) bool {
-	versionPattern := `^(\d+\.\d+-\d+(\.\d+)*)$`
+	versionPattern := `^(\d+\.\d+-\d+(\.\d+)*(-\d+)?)$`
 	versionRegex := regexp.MustCompile(versionPattern)
 	return versionRegex.MatchString(version)
 }

--- a/api/v1alpha1/validator/nicclusterpolicy_webhook_test.go
+++ b/api/v1alpha1/validator/nicclusterpolicy_webhook_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Validate", func() {
 				ContainSubstring("pKeyGUIDPoolRangeStart must be a valid GUID format"),
 				ContainSubstring("pKeyGUIDPoolRangeEnd must be a valid GUID format")))
 		})
-		It("Valid MOFED version", func() {
+		It("Valid MOFED version (old scheme)", func() {
 			validator := nicClusterPolicyValidator{}
 			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
@@ -110,6 +110,42 @@ var _ = Describe("Validate", func() {
 							Image:            "mofed",
 							Repository:       "ghcr.io/mellanox",
 							Version:          "23.10-0.2.2.0",
+							ImagePullSecrets: []string{},
+						},
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(context.TODO(), nicClusterPolicy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Valid MOFED version (old scheme with container version suffix)", func() {
+			validator := nicClusterPolicyValidator{}
+			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						ImageSpec: v1alpha1.ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "23.10-0.2.2.0.1",
+							ImagePullSecrets: []string{},
+						},
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(context.TODO(), nicClusterPolicy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Valid MOFED version", func() {
+			validator := nicClusterPolicyValidator{}
+			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						ImageSpec: v1alpha1.ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "24.01-0.3.3.1-0",
 							ImagePullSecrets: []string{},
 						},
 					},


### PR DESCRIPTION
Backwards compatibility is maintained, in future versions we can readjust the regular expression (and respective tests) by removing the `?` quantifier at the end of the expression.

Example of old version string: 23.10-0.2.2.0
Example of old version string: 23.10-0.2.2.0.1 (with container version suffix)
Example of new version string: 24.01-0.3.3.1-0

Signed-off-by: Michael Zeevi <mzeevi@nvidia.com>
(cherry picked from commit e35704f1fea50b33926d2dc583ab51dff676bd26)
