### PR TITLE
fix: Bump DTS to 1.16.5-doca2.6.0-host

### DIFF
--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -664,7 +664,7 @@ to advertise NIC specific labels on K8s Node objects.
 | `docaTelemetryService.deploy`             | bool   | `false`                 | Deploy DOCA Telemetry Service                                                                           |
 | `docaTelemetryService.image`              | string | `doca_telemetry`        | DOCA Telemetry Service image name                                                                       |
 | `docaTelemetryService.repository`         | string | `nvcr.io/nvidia/doca`   | DOCA Telemetry Service image repository                                                                 |
-| `docaTelemetryService.version`            | string | `1.15.5-doca2.5.0-host` | DOCA Telemetry Service image version                                                                    |
+| `docaTelemetryService.version`            | string | `1.16.5-doca2.6.0-host` | DOCA Telemetry Service image version                                                                    |
 | `docaTelemetryService.imagePullSecrets`   | string | not set                 | An optional list of references to secrets to use for pulling the DOCA Telemetry Service images          |
 | `docaTelemetryService.containerResources` | []     | not set                 | Optional [resource requests and limits](#container-resources) for the `nic-feature-discovery` container |
 

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -445,7 +445,7 @@ docaTelemetryService:
   deploy: false
   image: doca_telemetry
   repository: nvcr.io/nvidia/doca
-  version: 1.15.5-doca2.5.0-host
+  version: 1.16.5-doca2.6.0-host
   # imagePullSecrets: []
   # containerResources:
   #   - name: "doca-telemetry-service"

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -68,4 +68,4 @@ nicFeatureDiscovery:
 docaTelemetryService:
   image: doca_telemetry
   repository: nvcr.io/nvidia/doca
-  version: 1.15.5-doca2.5.0-host
+  version: 1.16.5-doca2.6.0-host


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@nvidia.com>

Bump the DOCA Telemetry Service version to 1.16.5-doca2.6.0-host. This version enables the pod_resources endpoint which links pods to the devices they are using.