### PR TITLE
[v24.1.x] fix: update nv-ipam to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ spec:
   nvIpam:
     image: nvidia-k8s-ipam
     repository: ghcr.io/mellanox
-    version: v0.1.1
+    version: v0.1.2
     enableWebhook: false
 ```
 

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -629,7 +629,7 @@ optionally deployed components:
 | `nvIpam.deploy`             | bool   | `false`                  | Deploy NVIDIA IPAM Plugin                                                                                                |
 | `nvIpam.image`              | string | `nvidia-k8s-ipam`        | NVIDIA IPAM Plugin image name                                                                                            |
 | `nvIpam.repository`         | string | `ghcr.io/mellanox`       | NVIDIA IPAM Plugin image repository                                                                                      |
-| `nvIpam.version`            | string | `v0.1.1`                 | NVIDIA IPAM Plugin image version                                                                                         |
+| `nvIpam.version`            | string | `v0.1.2`                 | NVIDIA IPAM Plugin image version                                                                                         |
 | `nvIpam.imagePullSecrets`   | list   | `[]`                     | An optional list of references to secrets to use for pulling any of the Plugin image                                     |
 | `nvIpam.config`             | string | Deprecated               | This field is ignored. Configuration is done by using IPPool CRD                                                         |
 | `nvIpam.enableWebhook`      | bool   | `false`                  | Enable deployment of the validataion webhook for IPPool CRD                                                              |

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -347,7 +347,7 @@ nvIpam:
   deploy: false
   image: nvidia-k8s-ipam
   repository: ghcr.io/mellanox
-  version: v0.1.1
+  version: v0.1.2
   enableWebhook: false
   # imagePullSecrets: []
   # containerResources:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -69,5 +69,5 @@ spec:
   nvIpam:
     image: nvidia-k8s-ipam
     repository: ghcr.io/mellanox
-    version: v0.1.1
+    version: v0.1.2
     enableWebhook: false

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -60,7 +60,7 @@ IpamPlugin:
 nvIpam:
   image: nvidia-k8s-ipam
   repository: ghcr.io/mellanox
-  version: v0.1.1
+  version: v0.1.2
 nicFeatureDiscovery:
   image: nic-feature-discovery
   repository: ghcr.io/mellanox


### PR DESCRIPTION
This version contains bug fixes and other improvements.

Change log for the version: https://github.com/Mellanox/nvidia-k8s-ipam/releases/tag/v0.1.2

Backport to v24.1.x

(cherry picked from commit de0d6b3d6db708fc9e8751276702305474c366e3)