### PR TITLE
feat: Support errors on NCP status

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -291,6 +291,9 @@ type AppliedState struct {
 	Name string `json:"name"`
 	// +kubebuilder:validation:Enum={"ready", "notReady", "ignore", "error"}
 	State State `json:"state"`
+	// Message is a human readable message indicating details about why
+	// the state is in this condition
+	Message string `json:"message,omitempty"`
 }
 
 // NicClusterPolicyStatus defines the observed state of NicClusterPolicy

--- a/config/crd/bases/mellanox.com_hostdevicenetworks.yaml
+++ b/config/crd/bases/mellanox.com_hostdevicenetworks.yaml
@@ -65,6 +65,11 @@ spec:
                   description: AppliedState defines a finer-grained view of the observed
                     state of NicClusterPolicy
                   properties:
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about why
+                        the state is in this condition
+                      type: string
                     name:
                       type: string
                     state:

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -1238,6 +1238,11 @@ spec:
                   description: AppliedState defines a finer-grained view of the observed
                     state of NicClusterPolicy
                   properties:
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about why
+                        the state is in this condition
+                      type: string
                     name:
                       type: string
                     state:

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -298,6 +298,11 @@ NextResult:
 		for i := range cr.Status.AppliedStates {
 			if cr.Status.AppliedStates[i].Name == stateStatus.StateName {
 				cr.Status.AppliedStates[i].State = mellanoxv1alpha1.State(stateStatus.Status)
+				if stateStatus.ErrInfo != nil {
+					cr.Status.AppliedStates[i].Message = stateStatus.ErrInfo.Error()
+				} else {
+					cr.Status.AppliedStates[i].Message = ""
+				}
 				continue NextResult
 			}
 		}

--- a/deployment/network-operator/crds/mellanox.com_hostdevicenetworks.yaml
+++ b/deployment/network-operator/crds/mellanox.com_hostdevicenetworks.yaml
@@ -65,6 +65,11 @@ spec:
                   description: AppliedState defines a finer-grained view of the observed
                     state of NicClusterPolicy
                   properties:
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about why
+                        the state is in this condition
+                      type: string
                     name:
                       type: string
                     state:

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -1238,6 +1238,11 @@ spec:
                   description: AppliedState defines a finer-grained view of the observed
                     state of NicClusterPolicy
                   properties:
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about why
+                        the state is in this condition
+                      type: string
                     name:
                       type: string
                     state:

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -298,7 +298,7 @@ func (s *stateOFED) Sync(ctx context.Context, customResource interface{}, infoCa
 	objs, err := s.GetManifestObjects(ctx, cr, infoCatalog, log.FromContext(ctx))
 
 	if err != nil {
-		return SyncStateNotReady, errors.Wrap(err, "failed to create k8s objects from manifest")
+		return SyncStateError, errors.Wrap(err, "failed to create k8s objects from manifest")
 	}
 	if len(objs) == 0 {
 		// GetManifestObjects returned no objects, this means that no objects need to be applied to the cluster
@@ -455,7 +455,7 @@ func renderObjects(ctx context.Context, nodePool *nodeinfo.NodePool, useDtk bool
 	precompiledExists := docaProvider.TagExists(precompiledTag)
 	reqLogger.V(consts.LogLevelDebug).Info("Precompiled tag", "tag:", precompiledTag, "found:", precompiledExists)
 	if !precompiledExists && cr.Spec.OFEDDriver.ForcePrecompiled {
-		return nil, fmt.Errorf("ForcePrecompiled is enabled and precompiled image was not found")
+		return nil, fmt.Errorf("ForcePrecompiled is enabled and precompiled tag was not found: %s", precompiledTag)
 	}
 
 	if precompiledExists {


### PR DESCRIPTION
Fixes #533

Example status:
```
status:
  appliedStates:
  - name: state-multus-cni
    state: ignore
  - name: state-container-networking-plugins
    state: ignore
  - name: state-ipoib-cni
    state: ignore
  - name: state-whereabouts-cni
    state: ignore
  - error: 'failed to create k8s objects from manifest: failed to render objects:
      ForcePrecompiled is enabled and precompiled image was not found'
    name: state-OFED
    state: notReady
  - name: state-SRIOV-device-plugin
    state: ignore

```