### PR TITLE
chore: Drop duplicated fields from the sriov-network-operator chart values

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -61,34 +61,7 @@ node-feature-discovery:
 # SR-IOV Network Operator chart related values
 sriov-network-operator:
   operator:
-    tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-        effect: "NoSchedule"
-    nodeSelector: {}
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/master"
-                  operator: In
-                  values: [""]
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/control-plane"
-                  operator: In
-                  values: [ "" ]
-    nameOverride: ""
-    fullnameOverride: ""
     resourcePrefix: "nvidia.com"
-    cniBinPath: "/opt/cni/bin"
-    clusterType: "kubernetes"
     admissionControllers:
       enabled: false
       certificates:

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -61,34 +61,7 @@ node-feature-discovery:
 # SR-IOV Network Operator chart related values
 sriov-network-operator:
   operator:
-    tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-        effect: "NoSchedule"
-    nodeSelector: {}
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/master"
-                  operator: In
-                  values: [""]
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/control-plane"
-                  operator: In
-                  values: [ "" ]
-    nameOverride: ""
-    fullnameOverride: ""
     resourcePrefix: "nvidia.com"
-    cniBinPath: "/opt/cni/bin"
-    clusterType: "kubernetes"
     admissionControllers:
       enabled: false
       certificates:


### PR DESCRIPTION
Based on https://github.com/Mellanox/network-operator/issues/531

The deleted fields copy the default values of the sriov-network-operator chart. Dropping them doesn't affect the deployment.