### PR TITLE
[v24.4.x] chore: Update ovs-cni to latest upstream version

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -117,8 +117,7 @@ sriov-network-operator:
     sriovConfigDaemon: nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.4.0-beta.5
     sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:3e6368077716f6b8368b0e036a1290d1c64cf1fb
     ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:fc002af57a81855542759d0f77d16dacd7e1aa38
-    ovsCni: "" # skip deployment by default
-    # ovsCni: nvcr.io/nvstaging/mellanox/ovs-cni-plugin:8b231bb
+    ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:6f8174b1a47c47657fe9e59fe448f2a452bb6960
     # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:latest
     sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:e6ead1e8f76a407783430ee2666b403db2d76f64
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -71,8 +71,8 @@ docaTelemetryService:
   version: 1.16.5-doca2.6.0-host
 ovsCni:
   image: ovs-cni-plugin
-  repository: nvcr.io/nvstaging/mellanox
-  version: 8b231bb
+  repository: ghcr.io/k8snetworkplumbingwg
+  version: 6f8174b1a47c47657fe9e59fe448f2a452bb6960
 rdmaCni:
   image: rdma-cni
   repository: ghcr.io/k8snetworkplumbingwg

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -117,8 +117,7 @@ sriov-network-operator:
     sriovConfigDaemon: {{ .SriovConfigDaemon.Repository }}/{{ .SriovConfigDaemon.Image }}:{{ .SriovConfigDaemon.Version }}
     sriovCni: {{ .SriovCni.Repository }}/{{ .SriovCni.Image }}:{{ .SriovCni.Version }}
     ibSriovCni: {{ .SriovIbCni.Repository }}/{{ .SriovIbCni.Image }}:{{ .SriovIbCni.Version }}
-    ovsCni: "" # skip deployment by default
-    # ovsCni: {{ .OVSCni.Repository }}/{{ .OVSCni.Image }}:{{ .OVSCni.Version }}
+    ovsCni: {{ .OVSCni.Repository }}/{{ .OVSCni.Image }}:{{ .OVSCni.Version }}
     # rdmaCni: {{ .RDMACni.Repository }}/{{ .RDMACni.Image }}:{{ .RDMACni.Version }}
     sriovDevicePlugin: {{ .SriovDevicePlugin.Repository }}/{{ .SriovDevicePlugin.Image }}:{{ .SriovDevicePlugin.Version }}
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e


### PR DESCRIPTION
update ovs-cni to the latest version and
enabled deployment by default

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>
(cherry picked from commit 412f7aca105325542cea611820e3c5851130dea8)