### PR TITLE
chore: Bump DOCA driver to v24.04-0.6.6.0-0

### DIFF
--- a/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
+++ b/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 24.04-0.6.5.2-0
+    version: 24.04-0.6.6.0-0
     livenessProbe:
       initialDelaySeconds: 30
       periodSeconds: 30

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -197,7 +197,7 @@ ofedDriver:
   deploy: false
   image: doca-driver
   repository: nvcr.io/nvstaging/mellanox
-  version: 24.04-0.6.5.2-0
+  version: 24.04-0.6.6.0-0
   initContainer:
     enable: true
     repository: ghcr.io/mellanox

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 24.04-0.6.5.2-0
+    version: 24.04-0.6.6.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 24.04-0.6.5.2-0
+    version: 24.04-0.6.6.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 24.04-0.6.5.2-0
+    version: 24.04-0.6.6.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 24.04-0.6.5.2-0
+    version: 24.04-0.6.6.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 24.04-0.6.5.2-0
+    version: 24.04-0.6.6.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -28,7 +28,7 @@ SriovIbCni:
 Mofed:
   image: doca-driver
   repository: nvcr.io/nvstaging/mellanox
-  version: 24.04-0.6.5.2-0
+  version: 24.04-0.6.6.0-0
 RdmaSharedDevicePlugin:
   image: k8s-rdma-shared-dev-plugin
   repository: ghcr.io/mellanox


### PR DESCRIPTION
Bump DOCA driver to v24.04-0.6.6.0-0
