### PR TITLE
chore: upgrade whereabouts to version 0.7.0

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -393,7 +393,7 @@ secondaryNetwork:
     deploy: true
     image: whereabouts
     repository: ghcr.io/k8snetworkplumbingwg
-    version: v0.6.2
+    version: v0.7.0
     # imagePullSecrets: []
     # containerResources:
     #   - name: "whereabouts"

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -73,4 +73,4 @@ spec:
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v0.6.2
+      version: v0.7.0

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -69,4 +69,4 @@ spec:
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v0.6.2
+      version: v0.7.0

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -56,7 +56,7 @@ Ipoib:
 IpamPlugin:
   image: whereabouts
   repository: ghcr.io/k8snetworkplumbingwg
-  version: v0.6.2
+  version: v0.7.0
 nvIpam:
   image: nvidia-k8s-ipam
   repository: ghcr.io/mellanox


### PR DESCRIPTION
Upgrade whereabouts version to 0.7.0
to fix the version incompatibility with SRIOV-network-operator