### PR TITLE
feat(ci): set pr-body-regex action input to *not* require commit body

### DIFF
--- a/.github/workflows/commit-msg-chk.yaml
+++ b/.github/workflows/commit-msg-chk.yaml
@@ -1,4 +1,4 @@
-name: "Conventional Commit PR message check"
+name: Conventional Commit PR message check
 
 on:
   pull_request:
@@ -12,3 +12,5 @@ jobs:
       - name: check-for-cc
         id: check-for-cc
         uses: agenthunt/conventional-commit-checker-action@v2.0.0
+        with:
+          pr-body-regex: '.*'


### PR DESCRIPTION
As discussed with @e0ne , we wish to make commit message checking slightly less strict in PRs, i.e. to not enforce the commit message to have both a _message_ **and** _body_; instead of only enforce a _message_.

Reference commit as example:
```bash
git commit -m "this is the commit *message* (which will be enforced)

this is the commit *body* (which shall become optional).
it's separeted from the message by a blank line, often contains details
over several more lines, and finally closed by the same opening quote
as the message."
```

This is achieved by changing [the default behavior](https://github.com/agenthunt/conventional-commit-checker-action/blob/master/action.yml#L14) of the existing conventional-commit-checker action.