### PR TITLE
fix: Align ib-kubernetes RBAC permissions with those of network-operator

### DIFF
--- a/manifests/state-ib-kubernetes/0030-cluster_role.yaml
+++ b/manifests/state-ib-kubernetes/0030-cluster_role.yaml
@@ -20,5 +20,5 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "patch", "watch"]
   - apiGroups: ["k8s.cni.cncf.io"]
-    resources: ["*"]
+    resources: ["network-attachment-definitions"]
     verbs: ["get"]


### PR DESCRIPTION
Network-operator doesn't allow to get * resources from k8s.cni.cncf.io. When ib-k8s deploys, it asks for more permissions thus failing to start