### PR TITLE
chore: bump sriov netop chart

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/README.md
+++ b/deployment/network-operator/charts/sriov-network-operator/README.md
@@ -59,6 +59,7 @@ We have introduced the following Chart parameters.
 | Name | Type | Default | description |
 | ---- |------|---------|-------------|
 | `imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling any of the SR-IOV Network Operator image |
+| `supportedExtraNICs` | list | `[]` | An optional list of whitelisted NICs |
 
 ### Operator parameters
 

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -37,8 +37,8 @@ spec:
             description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
             properties:
               bridge:
-                description: contains bridge configuration for matching PF valid only
-                  for eSwitchMode==switchdev
+                description: contains bridge configuration for matching PFs, valid
+                  only for eSwitchMode==switchdev
                 properties:
                   ovs:
                     description: contains configuration for the OVS bridge,
@@ -79,8 +79,8 @@ spec:
                               options:
                                 additionalProperties:
                                   type: string
-                                description: type filed in the Interface table in
-                                  OVSDB
+                                description: options field in the Interface table
+                                  in OVSDB
                                 type: object
                               otherConfig:
                                 additionalProperties:

--- a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -54,6 +54,8 @@ spec:
                 properties:
                   ovs:
                     items:
+                      description: OVSConfigExt contains configuration for the concrete
+                        OVS bridge
                       properties:
                         bridge:
                           description: bridge-level configuration for the bridge
@@ -82,6 +84,8 @@ spec:
                           description: uplink-level bridge configuration for each
                             uplink(PF). currently must contain only one element
                           items:
+                            description: OVSUplinkConfigExt contains configuration
+                              for the concrete OVS uplink(PF)
                             properties:
                               interface:
                                 description: configuration from the Interface OVS
@@ -96,7 +100,7 @@ spec:
                                   options:
                                     additionalProperties:
                                       type: string
-                                    description: type filed in the Interface table
+                                    description: options field in the Interface table
                                       in OVSDB
                                     type: object
                                   otherConfig:
@@ -125,8 +129,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              dpConfigVersion:
-                type: string
               interfaces:
                 items:
                   properties:
@@ -177,6 +179,8 @@ spec:
                 properties:
                   ovs:
                     items:
+                      description: OVSConfigExt contains configuration for the concrete
+                        OVS bridge
                       properties:
                         bridge:
                           description: bridge-level configuration for the bridge
@@ -205,6 +209,8 @@ spec:
                           description: uplink-level bridge configuration for each
                             uplink(PF). currently must contain only one element
                           items:
+                            description: OVSUplinkConfigExt contains configuration
+                              for the concrete OVS uplink(PF)
                             properties:
                               interface:
                                 description: configuration from the Interface OVS
@@ -219,7 +225,7 @@ spec:
                                   options:
                                     additionalProperties:
                                       type: string
-                                    description: type filed in the Interface table
+                                    description: options field in the Interface table
                                       in OVSDB
                                     type: object
                                   otherConfig:
@@ -262,6 +268,8 @@ spec:
                             type: string
                           driver:
                             type: string
+                          guid:
+                            type: string
                           mac:
                             type: string
                           mtu:
@@ -291,6 +299,8 @@ spec:
                       type: string
                     externallyManaged:
                       type: boolean
+                    linkAdminState:
+                      type: string
                     linkSpeed:
                       type: string
                     linkType:

--- a/deployment/network-operator/charts/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/configmap.yaml
@@ -38,3 +38,6 @@ data:
   Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"
   Marvell_OCTEON10_CN10XXX: "177d b900 b903"
   Marvell_OCTEON_Fusion_CNF105XX: "177d ba00 ba03"
+  {{- range .Values.supportedExtraNICs }}
+  {{ . }}
+  {{- end }}

--- a/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/role.yaml
@@ -59,6 +59,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - 'coordination.k8s.io'
+    resources:
+      - 'leases'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -89,6 +89,9 @@ sriovOperatorConfig:
   # sriov-network-config-daemon configuration mode. either "daemon" or "systemd"
   configurationMode: daemon
 
+# Example for supportedExtraNICs values ['MyNIC: "8086 1521 1520"']
+supportedExtraNICs: []
+
 # Image URIs for sriov-network-operator components
 images:
   operator: ghcr.io/k8snetworkplumbingwg/sriov-network-operator


### PR DESCRIPTION
Bump chart to https://github.com/k8snetworkplumbingwg/sriov-network-operator/tree/8d32f42b42b59a27864043ad22afa3741f197d9a/deployment/sriov-network-operator

This PR does not introduce 1o1 mapping with the upstream chart. There additional configuration related to RDMA CNI.

Here is the diff that is not committed when trying to create 1o1 mapping with the upstream chart.

<details>
<summary>Current Drift</summary>

```
diff --git b/deployment/network-operator/charts/sriov-network-operator/Chart.yaml a/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
index 4fffae2..8c7a62e 100644
--- b/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
+++ a/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sriov-network-operator
-version: 1.2.0
+version: 0.1.0
 kubeVersion: '>= 1.16.0-0'
 appVersion: 1.2.0
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster
diff --git b/deployment/network-operator/charts/sriov-network-operator/README.md a/deployment/network-operator/charts/sriov-network-operator/README.md
index 56d7c1d..3df54be 100644
--- b/deployment/network-operator/charts/sriov-network-operator/README.md
+++ a/deployment/network-operator/charts/sriov-network-operator/README.md
@@ -126,6 +126,7 @@ This section contains general parameters that apply to both the operator and dae
 | `images.sriovCni` | SR-IOV CNI image |
 | `images.ibSriovCni` | InfiniBand SR-IOV CNI image |
 | `images.ovsCni` | OVS CNI image |
+| `images.rdmaCni` | RDMA CNI image |
 | `images.sriovDevicePlugin` | SR-IOV device plugin image |
 | `images.resourcesInjector` | Resources Injector image |
 | `images.webhook` | Operator Webhook image |
diff --git b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
index b819999..9b1b2ee 100644
--- b/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
+++ a/deployment/network-operator/charts/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
@@ -103,6 +103,12 @@ spec:
                       offload'
                     type: string
                 type: object
+              rdmaMode:
+                description: RDMA subsystem. Allowed value "shared", "exclusive".
+                enum:
+                - shared
+                - exclusive
+                type: string
             type: object
           status:
             description: SriovNetworkPoolConfigStatus defines the observed state of
diff --git b/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml a/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
index 7cd8fd0..3d5afcf 100644
--- b/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
+++ a/deployment/network-operator/charts/sriov-network-operator/templates/clusterrole.yaml
@@ -58,3 +58,6 @@ rules:
   - apiGroups: [ "config.openshift.io" ]
     resources: [ "infrastructures" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "sriovnetwork.openshift.io" ]
+    resources: [ "sriovnetworkpoolconfigs" ]
+    verbs: [ "get", "list", "watch" ]
diff --git b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
index 1200e34..aa2801b 100644
--- b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
+++ a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
@@ -58,6 +58,8 @@ spec:
               value: {{ .Values.images.ibSriovCni }}
             - name: OVS_CNI_IMAGE
               value: {{ .Values.images.ovsCni }}
+            - name: RDMA_CNI_IMAGE
+              value: {{ .Values.images.rdmaCni }}
             - name: SRIOV_DEVICE_PLUGIN_IMAGE
               value: {{ .Values.images.sriovDevicePlugin }}
             - name: NETWORK_RESOURCES_INJECTOR_IMAGE
diff --git b/deployment/network-operator/charts/sriov-network-operator/values.yaml a/deployment/network-operator/charts/sriov-network-operator/values.yaml
index 28a4d06..dc76711 100644
--- b/deployment/network-operator/charts/sriov-network-operator/values.yaml
+++ a/deployment/network-operator/charts/sriov-network-operator/values.yaml
@@ -99,6 +99,7 @@ images:
   sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni
   ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni
   ovsCni: quay.io/kubevirt/ovs-cni-plugin
+  rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni
   sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin
   resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector
   webhook: ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook
```
</details>