### PR TITLE
fix: cherrypick new docker & helm CI to release branch

### DIFF
--- a/.github/workflows/network-operator-docker-and-helm-ci.yaml
+++ b/.github/workflows/network-operator-docker-and-helm-ci.yaml
@@ -1,0 +1,94 @@
+name: Network Operator Docker and Helm CI
+
+on:
+  push:
+    branches:
+    - "master"
+    - "v[0-9]+.[0-9]+.x"
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+*"
+
+env:
+  DEFAULT_BRANCH: master
+
+jobs:
+  docker-build-push:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: nvcr.io/nvstaging/mellanox
+      IMAGE_NAME: network-operator  # used in makefile
+    steps:
+    - uses: actions/checkout@v4
+    - if: github.ref_type == 'branch'
+      name: Determine docker tags (when git branch)
+      run: |
+        git_sha=$(git rev-parse --short HEAD)  # short git commit hash
+        latest=${{ github.ref_name == env.DEFAULT_BRANCH && 'latest' || '' }}  # 'latest', if branch is master
+        echo DOCKER_TAGS=""$git_sha $latest"" >> $GITHUB_ENV
+    - if: github.ref_type == 'tag'
+      name: Determine docker tags (when git tag)
+      run: |
+        git_tag=${{ github.ref_name }}
+        echo DOCKER_TAGS=""$git_tag"" >> $GITHUB_ENV
+    - uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.NVCR_USERNAME }}
+        password: ${{ secrets.NVCR_TOKEN }}
+    - name: Make build and push
+      run: |
+        echo "Docker tags will be: $DOCKER_TAGS"
+        for docker_tag in $DOCKER_TAGS; do
+          make VERSION=$docker_tag image-build-multiarch image-push-multiarch
+        done
+
+  helm-package-publish:
+    needs: docker-build-push
+    runs-on: ubuntu-latest
+    env:
+      NGC_REPO: nvstaging/mellanox/network-operator
+    steps:
+    - if: github.ref_name == env.DEFAULT_BRANCH || github.ref_type == 'tag'
+      uses: actions/checkout@v4
+    - if: github.ref_name == env.DEFAULT_BRANCH
+      name: Determine versions (when git branch)
+      run: |
+        app_version=$(git rev-parse --short HEAD)  # short git commit hash
+        current_chart_version=$(yq '.version' deployment/network-operator/Chart.yaml)
+        echo APP_VERSION=""$app_version""                    >> $GITHUB_ENV
+        echo VERSION=""$current_chart_version-$app_version"" >> $GITHUB_ENV
+    - if: github.ref_type == 'tag'
+      name: Determine versions (when git tag)
+      run: |
+        git_tag=${{ github.ref_name }}
+        app_version=$git_tag
+        chart_version=${git_tag:1}  # without the 'v' prefix
+        echo APP_VERSION=""$app_version"" >> $GITHUB_ENV
+        echo VERSION=""$chart_version""   >> $GITHUB_ENV
+    - if: github.ref_name == env.DEFAULT_BRANCH || github.ref_type == 'tag'
+      name: NGC authentication
+      run: |
+        wget \
+          --no-verbose \
+          --content-disposition \
+          -O ngccli_linux.zip \
+          https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/3.41.4/files/ngccli_linux.zip
+        unzip -q ngccli_linux.zip
+        echo "./ngc-cli" >> $GITHUB_PATH
+
+        ngc-cli/ngc config set <<EOF
+          ${{ secrets.NVCR_TOKEN }}
+          json
+          nvstaging
+          mellanox
+          no-ace
+        EOF
+    - if: github.ref_name == env.DEFAULT_BRANCH || github.ref_type == 'tag'
+      name: Make package and push
+      run: |
+        make chart-build chart-push
+    - if: github.ref_name == env.DEFAULT_BRANCH || github.ref_type == 'tag'
+      name: NGC logout
+      run: |
+        ngc config clear-cache
+        ngc config clear


### PR DESCRIPTION
Backporting the new CI workflow to a pre-created release branch.