### PR TITLE
chore: update nv-ipam to v0.2.0

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -309,6 +309,23 @@ rules:
 - apiGroups:
   - nv-ipam.nvidia.com
   resources:
+  - cidrpools
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nv-ipam.nvidia.com
+  resources:
+  - cidrpools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - nv-ipam.nvidia.com
+  resources:
   - ippools
   verbs:
   - create

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -83,6 +83,8 @@ type NicClusterPolicyReconciler struct {
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=nv-ipam.nvidia.com,resources=ippools,verbs=get;list;watch;create;
 // +kubebuilder:rbac:groups=nv-ipam.nvidia.com,resources=ippools/status,verbs=get;update;patch;
+// +kubebuilder:rbac:groups=nv-ipam.nvidia.com,resources=cidrpools,verbs=get;list;watch;create;
+// +kubebuilder:rbac:groups=nv-ipam.nvidia.com,resources=cidrpools/status,verbs=get;update;patch;
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=image.openshift.io,resources=imagestreams,verbs=get;list;watch

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -325,6 +325,7 @@ rules:
   - nv-ipam.nvidia.com
   resources:
   - ippools
+  - cidrpools
   verbs:
   - create
   - get
@@ -334,6 +335,7 @@ rules:
   - nv-ipam.nvidia.com
   resources:
   - ippools/status
+  - cidrpools/status
   verbs:
   - get
   - patch

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -325,7 +325,7 @@ nvIpam:
   deploy: false
   image: nvidia-k8s-ipam
   repository: ghcr.io/mellanox
-  version: v0.1.2
+  version: v0.2.0
   enableWebhook: false
   # imagePullSecrets: []
   # containerResources:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -69,5 +69,5 @@ spec:
   nvIpam:
     image: nvidia-k8s-ipam
     repository: ghcr.io/mellanox
-    version: v0.1.2
+    version: v0.2.0
     enableWebhook: false

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -60,7 +60,7 @@ IpamPlugin:
 nvIpam:
   image: nvidia-k8s-ipam
   repository: ghcr.io/mellanox
-  version: v0.1.2
+  version: v0.2.0
 nicFeatureDiscovery:
   image: nic-feature-discovery
   repository: ghcr.io/mellanox

--- a/manifests/state-nv-ipam-cni/005-nv-ipam.nvidia.com_cidrpools.yaml
+++ b/manifests/state-nv-ipam-cni/005-nv-ipam.nvidia.com_cidrpools.yaml
@@ -1,4 +1,4 @@
-# 2023 NVIDIA CORPORATION & AFFILIATES
+# 2024 NVIDIA CORPORATION & AFFILIATES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,30 +17,30 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: ippools.nv-ipam.nvidia.com
+  name: cidrpools.nv-ipam.nvidia.com
 spec:
   group: nv-ipam.nvidia.com
   names:
-    kind: IPPool
-    listKind: IPPoolList
-    plural: ippools
-    singular: ippool
+    kind: CIDRPool
+    listKind: CIDRPoolList
+    plural: cidrpools
+    singular: cidrpool
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.subnet
-      name: Subnet
+    - jsonPath: .spec.cidr
+      name: CIDR
       type: string
-    - jsonPath: .spec.gateway
-      name: Gateway
+    - jsonPath: .spec.gatewayIndex
+      name: Gateway index
       type: string
-    - jsonPath: .spec.perNodeBlockSize
-      name: Block Size
+    - jsonPath: .spec.perNodeNetworkPrefix
+      name: Per Node Network Prefix
       type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IPPool contains configuration for IPAM controller
+        description: CIDRPool contains configuration for CIDR pool
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -55,8 +55,13 @@ spec:
           metadata:
             type: object
           spec:
-            description: IPPoolSpec contains configuration for IP pool
+            description: CIDRPoolSpec contains configuration for CIDR pool
             properties:
+              cidr:
+                description: pool CIDR block which will be split to smaller prefixes(size
+                  is define in perNodeNetworkPrefix) and distributed between matching
+                  nodes
+                type: string
               exclusions:
                 description: contains reserved IP addresses that should not be allocated
                   by nv-ipam
@@ -73,9 +78,10 @@ spec:
                   - startIP
                   type: object
                 type: array
-              gateway:
-                description: gateway for the pool
-                type: string
+              gatewayIndex:
+                description: use IP with this index from the host prefix as a gateway,
+                  skip gateway configuration if the value not set
+                type: integer
               nodeSelector:
                 description: selector for nodes, if empty match all nodes
                 properties:
@@ -160,35 +166,57 @@ spec:
                 - nodeSelectorTerms
                 type: object
                 x-kubernetes-map-type: atomic
-              perNodeBlockSize:
-                description: amount of IPs to allocate for each node, must be less
-                  than amount of available IPs in the subnet
+              perNodeNetworkPrefix:
+                description: size of the network prefix for each host, the network
+                  defined in "cidr" field will be split to multiple networks with
+                  this size.
                 type: integer
-              subnet:
-                description: subnet of the pool
-                type: string
-            required:
-            - perNodeBlockSize
-            - subnet
-            type: object
-          status:
-            description: IPPoolStatus contains the IP ranges allocated to nodes
-            properties:
-              allocations:
-                description: IP allocations for Nodes
+              staticAllocations:
+                description: static allocations for the pool
                 items:
-                  description: Allocation contains IP Allocation for a specific Node
+                  description: CIDRPoolStaticAllocation contains static allocation
+                    for a CIDR pool
                   properties:
-                    endIP:
+                    gateway:
+                      description: gateway for the node
                       type: string
                     nodeName:
+                      description: name of the node for static allocation, can be
+                        empty in case if the prefix should be preallocated without
+                        assigning it for a specific node
                       type: string
-                    startIP:
+                    prefix:
+                      description: statically allocated prefix
                       type: string
                   required:
-                  - endIP
+                  - prefix
+                  type: object
+                type: array
+            required:
+            - cidr
+            - perNodeNetworkPrefix
+            type: object
+          status:
+            description: CIDRPoolStatus contains the IP prefixes allocated to nodes
+            properties:
+              allocations:
+                description: prefixes allocations for Nodes
+                items:
+                  description: CIDRPoolAllocation contains prefix allocated for a
+                    specific Node
+                  properties:
+                    gateway:
+                      description: gateway for the node
+                      type: string
+                    nodeName:
+                      description: name of the node which owns this allocation
+                      type: string
+                    prefix:
+                      description: allocated prefix
+                      type: string
+                  required:
                   - nodeName
-                  - startIP
+                  - prefix
                   type: object
                 type: array
             required:

--- a/manifests/state-nv-ipam-cni/020-cluster-role.yaml
+++ b/manifests/state-nv-ipam-cni/020-cluster-role.yaml
@@ -29,6 +29,7 @@ rules:
       - nv-ipam.nvidia.com
     resources:
       - ippools
+      - cidrpools
     verbs:
       - get
       - list
@@ -62,6 +63,7 @@ rules:
       - nv-ipam.nvidia.com
     resources:
       - ippools
+      - cidrpools
     verbs:
       - get
       - list
@@ -71,6 +73,7 @@ rules:
       - nv-ipam.nvidia.com
     resources:
       - ippools/status
+      - cidrpools/status
     verbs:
       - get
       - update

--- a/manifests/state-nv-ipam-cni/035-webhook.yaml
+++ b/manifests/state-nv-ipam-cni/035-webhook.yaml
@@ -43,4 +43,24 @@ webhooks:
         resources:
           - ippools
     sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: nv-ipam-webhook-service
+        namespace: {{ .RuntimeSpec.Namespace }}
+        path: /validate-nv-ipam-nvidia-com-v1alpha1-cidrpool
+    failurePolicy: Fail
+    name: validate-cidrpool.nv-ipam.nvidia.com
+    rules:
+      - apiGroups:
+          - nv-ipam.nvidia.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cidrpools
+    sideEffects: None
 {{ end }}


### PR DESCRIPTION
This version contains support for static IPs and new CIDRPool API.

Changelog: https://github.com/Mellanox/nvidia-k8s-ipam/releases/tag/v0.2.0