### PR TITLE
chore: Bump versions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -178,6 +178,7 @@ rules:
   - events
   verbs:
   - create
+  - get
   - patch
   - update
 - apiGroups:

--- a/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
+++ b/config/samples/mellanox.com_v1alpha1_nicclusterpolicy.yaml
@@ -42,7 +42,7 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: ghcr.io/mellanox
-    version: 1.4.0
+    version: v1.5.1
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     config: |

--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -66,7 +66,7 @@ type NicClusterPolicyReconciler struct {
 // +kubebuilder:rbac:groups=mellanox.com,resources=nicclusterpolicies/finalizers,verbs=update
 // +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups="",resources=namespaces;serviceaccounts;pods;pods/status;services;services/finalizers;endpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims;events;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
@@ -88,6 +88,7 @@ type NicClusterPolicyReconciler struct {
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=image.openshift.io,resources=imagestreams,verbs=get;list;watch
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/deployment/network-operator/templates/role.yaml
+++ b/deployment/network-operator/templates/role.yaml
@@ -193,6 +193,7 @@ rules:
   - events
   verbs:
   - create
+  - get
   - patch
   - update
 - apiGroups:

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -115,11 +115,11 @@ sriov-network-operator:
   images:
     operator: nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.4.0-beta.5
     sriovConfigDaemon: nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.4.0-beta.5
-    sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:3e6368077716f6b8368b0e036a1290d1c64cf1fb
-    ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:fc002af57a81855542759d0f77d16dacd7e1aa38
-    ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:6f8174b1a47c47657fe9e59fe448f2a452bb6960
-    # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:latest
-    sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:e6ead1e8f76a407783430ee2666b403db2d76f64
+    sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0
+    ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.1.1
+    ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:v0.34.0
+    # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:v1.2.0
+    sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.7.0
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
     webhook: nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-24.4.0-beta.5
   # imagePullSecrest for SR-IOV Network Operator related images
@@ -263,7 +263,7 @@ rdmaSharedDevicePlugin:
   deploy: true
   image: k8s-rdma-shared-dev-plugin
   repository: ghcr.io/mellanox
-  version: 1.4.0
+  version: v1.5.1
   useCdi: false
   # imagePullSecrets: []
   # containerResources:
@@ -287,7 +287,7 @@ sriovDevicePlugin:
   deploy: false
   image: sriov-network-device-plugin
   repository: ghcr.io/k8snetworkplumbingwg
-  version: e6ead1e8f76a407783430ee2666b403db2d76f64
+  version: v3.7.0
   useCdi: false
   # imagePullSecrets: []
   # containerResources:
@@ -350,7 +350,7 @@ secondaryNetwork:
     deploy: true
     image: plugins
     repository: ghcr.io/k8snetworkplumbingwg
-    version: v1.3.0
+    version: v1.5.0
     # imagePullSecrets: []
     # containerResources:
     #   - name: "cni-plugins"
@@ -379,7 +379,7 @@ secondaryNetwork:
     deploy: false
     image: ipoib-cni
     repository: ghcr.io/mellanox
-    version: 428715a57c0b633e48ec7620f6e3af6863149ccf
+    version: v1.2.0
     # imagePullSecrets: []
     # containerResources:
     #   - name: "ipoib-cni"
@@ -393,7 +393,7 @@ secondaryNetwork:
     deploy: true
     image: whereabouts
     repository: ghcr.io/k8snetworkplumbingwg
-    version: v0.6.2
+    version: v0.7.0
     # imagePullSecrets: []
     # containerResources:
     #   - name: "whereabouts"

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -40,7 +40,7 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: ghcr.io/mellanox
-    version: 1.4.0
+    version: v1.5.1
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     config: |
@@ -60,11 +60,11 @@ spec:
     cniPlugins:
       image: plugins
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v1.3.0
+      version: v1.5.0
     ipoib:
       image: ipoib-cni
       repository: ghcr.io/mellanox
-      version: 428715a57c0b633e48ec7620f6e3af6863149ccf
+      version: v1.2.0
     multus:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
@@ -73,4 +73,4 @@ spec:
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v0.6.2
+      version: v0.7.0

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -40,7 +40,7 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: ghcr.io/mellanox
-    version: 1.4.0
+    version: v1.5.1
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     config: |
@@ -60,7 +60,7 @@ spec:
     cniPlugins:
       image: plugins
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v1.3.0
+      version: v1.5.0
     multus:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
@@ -31,7 +31,7 @@ spec:
   sriovDevicePlugin:
     image: sriov-network-device-plugin
     repository: ghcr.io/k8snetworkplumbingwg
-    version: e6ead1e8f76a407783430ee2666b403db2d76f64
+    version: v3.7.0
     config: |
       {
         "resourceList": [

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -31,7 +31,7 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: ghcr.io/mellanox
-    version: 1.4.0
+    version: v1.5.1
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     config: |

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -40,7 +40,7 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: ghcr.io/mellanox
-    version: 1.4.0
+    version: v1.5.1
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     config: |
@@ -60,7 +60,7 @@ spec:
     cniPlugins:
       image: plugins
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v1.3.0
+      version: v1.5.0
     multus:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
@@ -69,4 +69,4 @@ spec:
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
-      version: v0.6.2
+      version: v0.7.0

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -20,11 +20,11 @@ SriovConfigDaemon:
 SriovCni:
   image: sriov-cni
   repository: ghcr.io/k8snetworkplumbingwg
-  version: 3e6368077716f6b8368b0e036a1290d1c64cf1fb
+  version: v2.8.0
 SriovIbCni:
   image: ib-sriov-cni
   repository: ghcr.io/k8snetworkplumbingwg
-  version: fc002af57a81855542759d0f77d16dacd7e1aa38
+  version: v1.1.1
 Mofed:
   image: doca-driver
   repository: nvcr.io/nvstaging/mellanox
@@ -32,11 +32,11 @@ Mofed:
 RdmaSharedDevicePlugin:
   image: k8s-rdma-shared-dev-plugin
   repository: ghcr.io/mellanox
-  version: 1.4.0
+  version: v1.5.1
 SriovDevicePlugin:
   image: sriov-network-device-plugin
   repository: ghcr.io/k8snetworkplumbingwg
-  version: e6ead1e8f76a407783430ee2666b403db2d76f64
+  version: v3.7.0
 IbKubernetes:
   image: ib-kubernetes
   repository: ghcr.io/mellanox
@@ -44,7 +44,7 @@ IbKubernetes:
 CniPlugins:
   image: plugins
   repository: ghcr.io/k8snetworkplumbingwg
-  version: v1.3.0
+  version: v1.5.0
 Multus:
   image: multus-cni
   repository: ghcr.io/k8snetworkplumbingwg
@@ -52,11 +52,11 @@ Multus:
 Ipoib:
   image: ipoib-cni
   repository: ghcr.io/mellanox
-  version: 428715a57c0b633e48ec7620f6e3af6863149ccf
+  version: v1.2.0
 IpamPlugin:
   image: whereabouts
   repository: ghcr.io/k8snetworkplumbingwg
-  version: v0.6.2
+  version: v0.7.0
 nvIpam:
   image: nvidia-k8s-ipam
   repository: ghcr.io/mellanox
@@ -72,8 +72,8 @@ docaTelemetryService:
 ovsCni:
   image: ovs-cni-plugin
   repository: ghcr.io/k8snetworkplumbingwg
-  version: 6f8174b1a47c47657fe9e59fe448f2a452bb6960
+  version: v0.34.0
 rdmaCni:
   image: rdma-cni
   repository: ghcr.io/k8snetworkplumbingwg
-  version: latest
+  version: v1.2.0

--- a/manifests/state-whereabouts-cni/0010-whereabouts.cni.cncf.io_ippools.yaml
+++ b/manifests/state-whereabouts-cni/0010-whereabouts.cni.cncf.io_ippools.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/state-whereabouts-cni/0015-whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/manifests/state-whereabouts-cni/0015-whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/state-whereabouts-cni/0020-cluster_role.yaml
+++ b/manifests/state-whereabouts-cni/0020-cluster_role.yaml
@@ -46,3 +46,27 @@ rules:
   - pods
   verbs:
   - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+  - get

--- a/manifests/state-whereabouts-cni/0045-whereabouts-config.yaml
+++ b/manifests/state-whereabouts-cni/0045-whereabouts-config.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whereabouts-config
+  namespace: {{ .RuntimeSpec.Namespace }}
+  annotations:
+    kubernetes.io/description: |
+      Configmap containing user customizable cronjob schedule
+data:
+  cron-expression: "30 4 * * *" # Default schedule is once per day at 4:30am. Users may configure this value to their liking.

--- a/manifests/state-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/state-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -55,7 +55,18 @@ spec:
       containers:
       - name: whereabouts
         image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+        command: [ "/bin/sh" ]
+        args:
+        - -c
+        - >
+          SLEEP=false /install-cni.sh &&
+          /ip-control-loop
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: WHEREABOUTS_NAMESPACE
           valueFrom:
             fieldRef:
@@ -88,6 +99,8 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: cni-net-dir
           mountPath: /host/etc/cni/net.d
+        - name: cron-scheduler-configmap
+          mountPath: /cron-schedule
       volumes:
         - name: cnibin
           hostPath:
@@ -95,3 +108,10 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        - name: cron-scheduler-configmap
+          configMap:
+            name: "whereabouts-config"
+            defaultMode: 0744
+            items:
+            - key: "cron-expression"
+              path: "config"


### PR DESCRIPTION
Bump versions of various components deployed by the network operator.

- update rdma-shared-device-plugin to 1.5.1
- update sriov-network-device-plugin to v3.7.0
- update containernetworking plugins to v1.5.0
- update ipoib-cni to v1.2.0
- update whereabouts to v0.7.0
- update ovs-cni-plugin to v0.34.0
- update rdma cni to v1.2.0
- update sriov cni to v2.8.0
- update ib sriov cni to v1.1.1


note: multus cni will be updated in a separate commit.