### PR TITLE
chore: implement new assert function for NAD unit tests

### DIFF
--- a/pkg/state/state_ipoib_network_test.go
+++ b/pkg/state/state_ipoib_network_test.go
@@ -70,7 +70,7 @@ var _ = Describe("IPoIBNetwork Network state rendering tests", func() {
 			nad := &netattdefv1.NetworkAttachmentDefinition{}
 			err = client.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: name}, nad)
 			Expect(err).NotTo(HaveOccurred())
-			cfg, err := getNADConfig(nad.Spec.Config)
+			cfg := getNADConfig(nad.Spec.Config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.Type).To(Equal("ipoib"))
 			expectedNad := getExpectedIPoIBNAD(name, cr.Spec.Master, "{}")
@@ -93,7 +93,7 @@ var _ = Describe("IPoIBNetwork Network state rendering tests", func() {
 			nad := &netattdefv1.NetworkAttachmentDefinition{}
 			err = client.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: name}, nad)
 			Expect(err).NotTo(HaveOccurred())
-			cfg, err := getNADConfig(nad.Spec.Config)
+			cfg := getNADConfig(nad.Spec.Config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.Type).To(Equal("ipoib"))
 			Expect(nad.Name).To(Equal(name))

--- a/pkg/state/state_rdma_shared_device_plugin_test.go
+++ b/pkg/state/state_rdma_shared_device_plugin_test.go
@@ -23,8 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -96,24 +94,11 @@ var _ = Describe("RDMA Shared Device Plugin", func() {
 
 func getRDMASharedDevicePlugin() *mellanoxv1alpha1.NicClusterPolicy {
 	cr := getTestClusterPolicyWithBaseFields()
-	imageSpec := getTestImageSpec()
+	imageSpec := addContainerResources(getTestImageSpec(), "rdma-shared-dp", "1", "9")
 	cr.Name = "nic-cluster-policy"
 	cr.Spec.RdmaSharedDevicePlugin = &mellanoxv1alpha1.DevicePluginSpec{
 		ImageSpecWithConfig: mellanoxv1alpha1.ImageSpecWithConfig{
 			ImageSpec: *imageSpec,
-		},
-	}
-	cr.Spec.RdmaSharedDevicePlugin.ContainerResources = []mellanoxv1alpha1.ResourceRequirements{
-		{
-			Name: "rdma-shared-dp",
-			Requests: v1.ResourceList{
-				"cpu":    resource.MustParse("150m"),
-				"memory": resource.MustParse("150Mi"),
-			},
-			Limits: v1.ResourceList{
-				"cpu":    resource.MustParse("150m"),
-				"memory": resource.MustParse("200Mi"),
-			},
 		},
 	}
 	return cr


### PR DESCRIPTION
Todos:

- [x] create new assert func
- [x] adopt for hostdevice network
- [x] adopt for ipoib
- [x] adopt for macvlan
- [x] verify if everything covered (only refactoring necessary IMO)