### PR TITLE
feat: Add description to helm values

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -17,21 +17,27 @@
 # Declare variables to be passed into your templates.
 
 nfd:
+  # -- Deploy Node Feature Discovery operator.
   enabled: true
+  # -- Deploy Node Feature Rules to label the nodes with the discovered features.
   deployNodeFeatureRules: true
 
+# -- Enable CRDs upgrade with helm pre-install and pre-upgrade hooks.
 upgradeCRDs: true
 
 sriovNetworkOperator:
+  # -- Deploy SR-IOV Network Operator.
   enabled: false
 
-# Node Feature discovery chart related values
+# Set both enableNodeFeatureApi and NodeFeatureAPI feature gate to false to disable.
 node-feature-discovery:
-  # set both enableNodeFeatureApi and NodeFeatureAPI feature gate to false to disable
+  # -- The Node Feature API is used to expose node-specific hardware and 
+  # software features to the Kubernetes scheduler.
   enableNodeFeatureApi: true
   featureGates:
     NodeFeatureAPI: true
 
+  # -- NFD master deployment configuration.
   master:
     serviceAccount:
       name: node-feature-discovery
@@ -39,15 +45,23 @@ node-feature-discovery:
     config:
       extraLabelNs: ["nvidia.com"]
   gc:
+    # -- Specifies whether the NFD Garbage Collector should be created
     enable: true
+    # -- Specifies the number of replicas for the NFD Garbage Collector
     replicaCount: 1
     serviceAccount:
-      # disable creation to avoid duplicate serviceaccount creation by master spec above
+      # -- The name of the service account for garbage collector to use.
+      # If not set and create is true, a name is generated using the fullname
+      # template and -gc suffix.
       name: node-feature-discovery
+      # -- disable creation to avoid duplicate serviceaccount creation by master
+      # spec above.
       create: false
+  # -- NFD worker daemonset configuration.
   worker:
     serviceAccount:
-      # disable creation to avoid duplicate serviceaccount creation by master spec above
+      # disable creation to avoid duplicate serviceaccount creation by master spec
+      # above
       name: node-feature-discovery
       create: false
     tolerations:
@@ -69,10 +83,12 @@ node-feature-discovery:
           deviceLabelFields:
           - vendor
 
-# SR-IOV Network Operator chart related values
+# SR-IOV Network Operator chart related values.
 sriov-network-operator:
   operator:
+    # -- Prefix to be used for resources names.
     resourcePrefix: "nvidia.com"
+    # -- Enable admission controller.
     admissionControllers:
       enabled: false
       certificates:
@@ -80,13 +96,14 @@ sriov-network-operator:
           operator: "operator-webhook-cert"
           injector: "network-resources-injector-cert"
         certManager:
-          # When enabled, makes use of certificates managed by cert-manager.
+          # -- When enabled, makes use of certificates managed by cert-manager.
           enabled: true
-          # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
-          # defined above
+          # -- When enabled, certificates are generated via cert-manager and then
+          # name will match the name of the secrets defined above.
           generateSelfSigned: true
-        # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
-        # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
+        # -- If not specified, no secret is created and secrets with the names
+        # defined above are expected to exist in the cluster. In that case,
+        # the ca.crt must be base64 encoded twice since it ends up being an env variable.
         custom:
           enabled: false
       #   operator:
@@ -122,21 +139,29 @@ sriov-network-operator:
       #       ...
       #      -----END EC PRIVATE KEY-----
 
-  # Image URIs for sriov-network-operator components
+  # Image URIs for sriov-network-operator components.
   images:
     operator: nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.7.0-beta.3
     sriovConfigDaemon: nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.7.0-beta.3
+    # -- For ARM-based deployments, it is recommended to use the
+    # ``ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0-arm64`` image.
     sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0
+    # -- For ARM-based deployments, it is recommended to use the
+    # ``ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:1.1.0-arm64`` image.
     ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.1.1
     ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:v0.34.0
     # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:v1.2.0
+    # -- For ARM-based deployments, it is recommended to use the
+    # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-arm64`` image.
     sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.7.0
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
     webhook: nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-24.7.0-beta.3
   # imagePullSecrest for SR-IOV Network Operator related images
   # imagePullSecrets: []
   sriovOperatorConfig:
+    # -- Deploy ``SriovOperatorConfig`` custom resource
     deploy: true
+    # -- Selects the nodes to be configured
     configDaemonNodeSelector:
       beta.kubernetes.io/os: "linux"
       network.nvidia.com/operator.mofed.wait: "false"
@@ -144,6 +169,8 @@ sriov-network-operator:
 # General Operator related values
 # The operator element allows to deploy network operator from an alternate location
 operator:
+  # -- Optional `resource requests and limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`_
+  # for the operator.
   resources:
     limits:
       cpu: 500m
@@ -151,6 +178,7 @@ operator:
     requests:
       cpu: 5m
       memory: 64Mi
+  # -- Set additional tolerations for various Daemonsets deployed by the operator.
   tolerations:
     - key: "node-role.kubernetes.io/master"
       operator: "Equal"
@@ -160,8 +188,10 @@ operator:
       operator: "Equal"
       value: ""
       effect: "NoSchedule"
+  # -- Configure node selector settings for the operator.
   nodeSelector: {}
   affinity:
+    # -- Configure node affinity settings for the operator.
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 1
@@ -176,17 +206,28 @@ operator:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: In
                 values: [ "" ]
+  # -- Network Operator image repository.
   repository: nvcr.io/nvstaging/mellanox
+  # -- Network Operator image name
   image: network-operator
   # imagePullSecrets: []
+  # -- Name to be used as part of objects name generation.
   nameOverride: ""
+  # -- Name to be used to replace generated names.
   fullnameOverride: ""
-  # tag, if defined will use the given image tag, else Chart.AppVersion will be used
+  # tag, if defined will use the given image tag, else Chart. AppVersion will be used.
   # tag
+  # -- Directory, where CNI binaries will be deployed on the nodes. Setting for 
+  # the sriov-network-operator is set with ``sriov-network-operator.cniBinPath``
+  # parameter. Note that the CNI bin directory should be aligned with the CNI bin
+  # directory in the container runtime.
   cniBinDirectory: /opt/cni/bin
+  # -- Enable the use of Driver ToolKit to compile OFED drivers (OpenShift only).
   useDTK: true
   admissionController:
+    # -- Deploy with admission controller.
     enabled: false
+    # -- Use cert-manager for generating self-signed certificate.
     useCertManager: true
     # certificate:
       # tlsCrt: |
@@ -200,19 +241,30 @@ operator:
       #   ...
       #  -----END EC PRIVATE KEY-----
 
+# -- An optional list of references to secrets to use for pulling any of the
+# Network Operator images.
 imagePullSecrets: []
 
 # NicClusterPolicy CR values:
+# -- Deploy ``NicClusterPolicy`` custom resource according to the provided parameters.
 deployCR: false
 ofedDriver:
+  # -- Deploy the  NVIDIA DOCA Driver driver container.
   deploy: false
+  # -- NVIDIA DOCA Driver image name.
   image: doca-driver
+  # -- NVIDIA DOCA Driver image repository.
   repository: nvcr.io/nvstaging/mellanox
+  # -- NVIDIA DOCA Driver version.
   version: 24.07-0.4.7.0-0
   initContainer:
+    # -- Deploy init container.
     enable: true
+    # -- Init container image repository.
     repository: ghcr.io/mellanox
+    # -- Init container image name.
     image: network-operator-init-container
+    # -- Init container image version.
     version: v0.0.2
   # imagePullSecrets: []
   # env, if defined will pass environment variables to the OFED container
@@ -228,53 +280,76 @@ ofedDriver:
   #       cpu: "300m"
   #       memory: "300Mi"
   terminationGracePeriodSeconds: 300
-  # Private mirror repository configuration
+  # -- Private mirror repository configuration.
   repoConfig:
     name: ""
-  # Custom ssl key/certificate configuration
+  # Custom ssl key/certificate configuration.
   certConfig:
+    # -- Custom TLS key/certificate configuration configMap name.
     name: ""
   startupProbe:
+    # -- NVIDIA DOCA Driver startup probe initial delay.
     initialDelaySeconds: 10
+    # -- NVIDIA DOCA Driver startup probe interval.
     periodSeconds: 20
   livenessProbe:
+    # -- NVIDIA DOCA Driver liveness probe initial delay.
     initialDelaySeconds: 30
+    # -- NVIDIA DOCA Driver liveness probe interval.
     periodSeconds: 30
   readinessProbe:
+    # -- NVIDIA DOCA Driver readiness probe initial delay.
     initialDelaySeconds: 10
+    # -- NVIDIA DOCA Driver readiness probe interval.
     periodSeconds: 30
   upgradePolicy:
-    # global switch for automatic upgrade feature
-    # if set to false all other options are ignored
+    # -- Global switch for automatic upgrade feature,
+    # if set to false all other options are ignored.
     autoUpgrade: true
-    # how many nodes can be upgraded in parallel (default: 1)
-    # 0 means no limit, all nodes will be upgraded in parallel
+    # -- Number of nodes that can be upgraded in parallel (default: 1).
+    # 0 means no limit, all nodes will be upgraded in parallel.
     maxParallelUpgrades: 1
-    # cordon and drain (if enabled) a node before loading the driver on it
+    # -- Cordon and drain (if enabled) a node before loading the driver on it.
     safeLoad: false
-    # options for node drain (`kubectl drain`) before the driver reload
-    # if auto upgrade is enabled but drain.enable is false,
-    # then driver POD will be reloaded immediately without
-    # removing PODs from the node
+    # -- Options for node drain (`kubectl drain`) before the driver reload.
+    # If auto upgrade is enabled but drain.enable is false, then driver POD will be
+    # reloaded immediately without removing PODs from the node.
     drain:
+      # -- Options for node drain (``kubectl drain``) before driver reload, if
+      # auto upgrade is enabled.
       enable: true
+      # -- Use force drain of pods.
       force: true
+      # -- Pod selector to specify which pods will be drained from the node.
+      # An empty selector means all pods.
       podSelector: ""
-      # It's recommended to set a timeout to avoid infinite drain in case non-fatal error keeps happening on retries
+      # -- It's recommended to set a timeout to avoid infinite drain in case
+      # non-fatal error keeps happening on retries.
       timeoutSeconds: 300
+      # -- Delete pods local storage.
       deleteEmptyDir: true
     waitForCompletion:
       # specifies a label selector for the pods to wait for completion
       # podSelector: "app=myapp"
-      # specify the length of time in seconds to wait before giving up for workload to finish, zero means infinite
+      # specify the length of time in seconds to wait before giving up for
+      # workload to finish, zero means infinite
       # timeoutSeconds: 300
+  # -- Fail Mellanox OFED deployment if precompiled OFED driver container image
+  # does not exists.
   forcePrecompiled: false
 
 rdmaSharedDevicePlugin:
+  # -- Deploy RDMA shared device plugin.
   deploy: true
+  # -- RDMA shared device plugin image name.
   image: k8s-rdma-shared-dev-plugin
+  # -- RDMA shared device plugin image repository.
   repository: ghcr.io/mellanox
+  # -- RDMA shared device plugin version.
   version: v1.5.1
+  # -- Enable Container Device Interface (CDI) mode.
+  # **NOTE**: NVIDIA Network Operator does not configure container runtime to
+  # enable CDI.
   useCdi: false
   # imagePullSecrets: []
   # containerResources:
@@ -285,20 +360,29 @@ rdmaSharedDevicePlugin:
   #     limits:
   #       cpu: "150m"
   #       memory: "100Mi"
-  # The following defines the RDMA resources in the cluster
-  # it must be provided by the user when deploying the chart
-  # each entry in the resources element will create a resource with the provided <name> and list of devices
-  # example:
+  # -- The following defines the RDMA resources in the cluster.
+  # It must be provided by the user when deploying the chart.
+  # Each entry in the resources element will create a resource with the provided
+  # <name> and list of devices.
   resources:
     - name: rdma_shared_device_a
       vendors: [15b3]
       rdmaHcaMax: 63
 
 sriovDevicePlugin:
+  # -- Deploy SR-IOV Network device plugin.
   deploy: false
+  # -- SR-IOV Network device plugin image name.
   image: sriov-network-device-plugin
+  # -- SR-IOV Network device plugin image repository.
   repository: ghcr.io/k8snetworkplumbingwg
+  # -- SR-IOV Network device plugin version
+  # For ARM-based deployments, it is recommended to use the
+  # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-amd64`` image.
   version: v3.7.0
+  # -- Enable Container Device Interface (CDI) mode.
+  # **NOTE**: NVIDIA Network Operator does not configure container runtime to
+  # enable CD.
   useCdi: false
   # imagePullSecrets: []
   # containerResources:
@@ -309,14 +393,20 @@ sriovDevicePlugin:
   #     limits:
   #       cpu: "150m"
   #       memory: "100Mi"
+  # -- Optional `resource requests and limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`_
+  # for the ``kube-sriovdp`` container.
   resources:
     - name: hostdev
       vendors: [15b3]
 
 ibKubernetes:
+  # -- Deploy IB Kubernetes.
   deploy: false
+  # -- IB Kubernetes image name.
   image: ib-kubernetes
+  # -- IB Kubernetes image repository.
   repository: ghcr.io/mellanox
+  # -- IB Kubernetes version.
   version: v1.0.2
   # imagePullSecrets: []
   # containerResources:
@@ -327,16 +417,25 @@ ibKubernetes:
   #     limits:
   #       cpu: "100m"
   #       memory: "300Mi"
+  # -- Interval of periodic update in seconds.
   periodicUpdateSeconds: 5
+  # -- Minimal available GUID value to be allocated for the pod.
   pKeyGUIDPoolRangeStart: "02:00:00:00:00:00:00:00"
+  # -- Maximal available GUID value to be allocated for the pod.
   pKeyGUIDPoolRangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"
+  # -- Name of the Secret with the NVIDIA UFM access credentials, deployed in advance.
   ufmSecret: '' # specify the secret name here
 
 nvIpam:
+  # -- Deploy NVIDIA IPAM Plugin.
   deploy: true
+  # -- NVIDIA IPAM Plugin image name.
   image: nvidia-k8s-ipam
+  # -- NVIDIA IPAM Plugin image repository.
   repository: ghcr.io/mellanox
+  # -- NVIDIA IPAM Plugin image version.
   version: v0.2.0
+  # -- Enable deployment of the validataion webhook for IPPool CRD.
   enableWebhook: false
   # imagePullSecrets: []
   # containerResources:
@@ -356,11 +455,16 @@ nvIpam:
   #       memory: "300Mi"
 
 secondaryNetwork:
+  # -- Deploy Secondary Network.
   deploy: true
   cniPlugins:
+    # -- Deploy CNI Plugins Secondary Network.
     deploy: true
+    # -- CNI Plugins image name.
     image: plugins
+    # -- CNI Plugins image repository.
     repository: ghcr.io/k8snetworkplumbingwg
+    # -- CNI Plugins image version.
     version: v1.5.0
     # imagePullSecrets: []
     # containerResources:
@@ -372,9 +476,13 @@ secondaryNetwork:
     #       cpu: "100m"
     #       memory: "50Mi"
   multus:
+    # -- Deploy Multus Secondary Network.
     deploy: true
+    # -- Multus image name.
     image: multus-cni
+    # -- Multus image repository.
     repository: ghcr.io/k8snetworkplumbingwg
+    # -- Multus image version.
     version: v3.9.3
     # imagePullSecrets: []
     # config: ''
@@ -387,9 +495,13 @@ secondaryNetwork:
     #       cpu: "100m"
     #       memory: "50Mi"
   ipoib:
+    # -- Deploy IPoIB CNI.
     deploy: false
+    # -- IPoIB CNI image name.
     image: ipoib-cni
+    # -- IPoIB CNI image repository.
     repository: ghcr.io/mellanox
+    # -- IPoIB CNI image version.
     version: v1.2.0
     # imagePullSecrets: []
     # containerResources:
@@ -401,9 +513,13 @@ secondaryNetwork:
     #       cpu: "100m"
     #       memory: "50Mi"
   ipamPlugin:
+    # -- Deploy IPAM CNI Plugin Secondary Network.
     deploy: false
+    # -- IPAM CNI Plugin image name.
     image: whereabouts
+    # -- IPAM CNI Plugin image repository.
     repository: ghcr.io/k8snetworkplumbingwg
+    # -- IPAM CNI Plugin image version.
     version: v0.7.0
     # imagePullSecrets: []
     # containerResources:
@@ -416,9 +532,13 @@ secondaryNetwork:
     #       memory: "200Mi"
 
 nicFeatureDiscovery:
+  # -- Deploy NVIDIA NIC Feature Discovery.
   deploy: false
+  # -- NVIDIA NIC Feature Discovery image name.
   image: nic-feature-discovery
+  # -- NVIDIA NIC Feature Discovery repository.
   repository: ghcr.io/mellanox
+  # -- NVIDIA NIC Feature Discovery image version.
   version: v0.0.1
   # imagePullSecrets: []
   # containerResources:
@@ -431,9 +551,13 @@ nicFeatureDiscovery:
   #       memory: "150Mi"
 
 docaTelemetryService:
+  # -- Deploy DOCA Telemetry Service.
   deploy: false
+  # -- DOCA Telemetry Service image name.
   image: doca_telemetry
+  # -- DOCA Telemetry Service image repository.
   repository: nvcr.io/nvidia/doca
+  # -- DOCA Telemetry Service image version.
   version: 1.16.5-doca2.6.0-host
   # imagePullSecrets: []
   # containerResources:
@@ -452,5 +576,6 @@ docaTelemetryService:
 # Can be set to nicclusterpolicy to add extra tolerations to ds
 #tolerations:
 
+# @ignore
 test:
   pf: ens2f0

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -31,8 +31,8 @@ sriovNetworkOperator:
 
 # Set both enableNodeFeatureApi and NodeFeatureAPI feature gate to false to disable.
 node-feature-discovery:
-  # -- The Node Feature API is used to expose node-specific hardware and 
-  # software features to the Kubernetes scheduler.
+  # -- The Node Feature API enable communication between nfd master and worker
+  # through NodeFeature CRs. Otherwise communication is through gRPC.
   enableNodeFeatureApi: true
   featureGates:
     NodeFeatureAPI: true
@@ -143,16 +143,10 @@ sriov-network-operator:
   images:
     operator: nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.7.0-beta.3
     sriovConfigDaemon: nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.7.0-beta.3
-    # -- For ARM-based deployments, it is recommended to use the
-    # ``ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0-arm64`` image.
     sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0
-    # -- For ARM-based deployments, it is recommended to use the
-    # ``ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:1.1.0-arm64`` image.
     ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.1.1
     ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:v0.34.0
     # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:v1.2.0
-    # -- For ARM-based deployments, it is recommended to use the
-    # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-arm64`` image.
     sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.7.0
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
     webhook: nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-24.7.0-beta.3
@@ -279,6 +273,7 @@ ofedDriver:
   #     limits:
   #       cpu: "300m"
   #       memory: "300Mi"
+  # -- The grace period before the driver containeris forcibly removed.
   terminationGracePeriodSeconds: 300
   # -- Private mirror repository configuration.
   repoConfig:
@@ -377,8 +372,6 @@ sriovDevicePlugin:
   # -- SR-IOV Network device plugin image repository.
   repository: ghcr.io/k8snetworkplumbingwg
   # -- SR-IOV Network device plugin version
-  # For ARM-based deployments, it is recommended to use the
-  # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-amd64`` image.
   version: v3.7.0
   # -- Enable Container Device Interface (CDI) mode.
   # **NOTE**: NVIDIA Network Operator does not configure container runtime to
@@ -393,8 +386,8 @@ sriovDevicePlugin:
   #     limits:
   #       cpu: "150m"
   #       memory: "100Mi"
-  # -- Optional `resource requests and limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`_
-  # for the ``kube-sriovdp`` container.
+  # Each entry in the resources elements will be an entry in a ``resourceList``
+  # created as part of the ``kube-sriovdp`` container configuration.
   resources:
     - name: hostdev
       vendors: [15b3]

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -31,8 +31,8 @@ sriovNetworkOperator:
 
 # Set both enableNodeFeatureApi and NodeFeatureAPI feature gate to false to disable.
 node-feature-discovery:
-  # -- The Node Feature API is used to expose node-specific hardware and 
-  # software features to the Kubernetes scheduler.
+  # -- The Node Feature API enable communication between nfd master and worker
+  # through NodeFeature CRs. Otherwise communication is through gRPC.
   enableNodeFeatureApi: true
   featureGates:
     NodeFeatureAPI: true
@@ -143,16 +143,10 @@ sriov-network-operator:
   images:
     operator: {{ .SriovNetworkOperator.Repository }}/{{ .SriovNetworkOperator.Image }}:{{ .SriovNetworkOperator.Version }}
     sriovConfigDaemon: {{ .SriovConfigDaemon.Repository }}/{{ .SriovConfigDaemon.Image }}:{{ .SriovConfigDaemon.Version }}
-    # -- For ARM-based deployments, it is recommended to use the
-    # ``ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0-arm64`` image.
     sriovCni: {{ .SriovCni.Repository }}/{{ .SriovCni.Image }}:{{ .SriovCni.Version }}
-    # -- For ARM-based deployments, it is recommended to use the
-    # ``ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:1.1.0-arm64`` image.
     ibSriovCni: {{ .SriovIbCni.Repository }}/{{ .SriovIbCni.Image }}:{{ .SriovIbCni.Version }}
     ovsCni: {{ .OVSCni.Repository }}/{{ .OVSCni.Image }}:{{ .OVSCni.Version }}
     # rdmaCni: {{ .RDMACni.Repository }}/{{ .RDMACni.Image }}:{{ .RDMACni.Version }}
-    # -- For ARM-based deployments, it is recommended to use the
-    # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-arm64`` image.
     sriovDevicePlugin: {{ .SriovDevicePlugin.Repository }}/{{ .SriovDevicePlugin.Image }}:{{ .SriovDevicePlugin.Version }}
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
     webhook: {{ .SriovNetworkOperatorWebhook.Repository }}/{{ .SriovNetworkOperatorWebhook.Image }}:{{ .SriovNetworkOperatorWebhook.Version }}
@@ -279,6 +273,7 @@ ofedDriver:
   #     limits:
   #       cpu: "300m"
   #       memory: "300Mi"
+  # -- The grace period before the driver containeris forcibly removed.
   terminationGracePeriodSeconds: 300
   # -- Private mirror repository configuration.
   repoConfig:
@@ -377,8 +372,6 @@ sriovDevicePlugin:
   # -- SR-IOV Network device plugin image repository.
   repository: {{ .SriovDevicePlugin.Repository }}
   # -- SR-IOV Network device plugin version
-  # For ARM-based deployments, it is recommended to use the
-  # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-amd64`` image.
   version: {{ .SriovDevicePlugin.Version }}
   # -- Enable Container Device Interface (CDI) mode.
   # **NOTE**: NVIDIA Network Operator does not configure container runtime to
@@ -393,8 +386,8 @@ sriovDevicePlugin:
   #     limits:
   #       cpu: "150m"
   #       memory: "100Mi"
-  # -- Optional `resource requests and limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`_
-  # for the ``kube-sriovdp`` container.
+  # Each entry in the resources elements will be an entry in a ``resourceList``
+  # created as part of the ``kube-sriovdp`` container configuration.
   resources:
     - name: hostdev
       vendors: [15b3]

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -17,21 +17,27 @@
 # Declare variables to be passed into your templates.
 
 nfd:
+  # -- Deploy Node Feature Discovery operator.
   enabled: true
+  # -- Deploy Node Feature Rules to label the nodes with the discovered features.
   deployNodeFeatureRules: true
 
+# -- Enable CRDs upgrade with helm pre-install and pre-upgrade hooks.
 upgradeCRDs: true
 
 sriovNetworkOperator:
+  # -- Deploy SR-IOV Network Operator.
   enabled: false
 
-# Node Feature discovery chart related values
+# Set both enableNodeFeatureApi and NodeFeatureAPI feature gate to false to disable.
 node-feature-discovery:
-  # set both enableNodeFeatureApi and NodeFeatureAPI feature gate to false to disable
+  # -- The Node Feature API is used to expose node-specific hardware and 
+  # software features to the Kubernetes scheduler.
   enableNodeFeatureApi: true
   featureGates:
     NodeFeatureAPI: true
 
+  # -- NFD master deployment configuration.
   master:
     serviceAccount:
       name: node-feature-discovery
@@ -39,15 +45,23 @@ node-feature-discovery:
     config:
       extraLabelNs: ["nvidia.com"]
   gc:
+    # -- Specifies whether the NFD Garbage Collector should be created
     enable: true
+    # -- Specifies the number of replicas for the NFD Garbage Collector
     replicaCount: 1
     serviceAccount:
-      # disable creation to avoid duplicate serviceaccount creation by master spec above
+      # -- The name of the service account for garbage collector to use.
+      # If not set and create is true, a name is generated using the fullname
+      # template and -gc suffix.
       name: node-feature-discovery
+      # -- disable creation to avoid duplicate serviceaccount creation by master
+      # spec above.
       create: false
+  # -- NFD worker daemonset configuration.
   worker:
     serviceAccount:
-      # disable creation to avoid duplicate serviceaccount creation by master spec above
+      # disable creation to avoid duplicate serviceaccount creation by master spec
+      # above
       name: node-feature-discovery
       create: false
     tolerations:
@@ -69,10 +83,12 @@ node-feature-discovery:
           deviceLabelFields:
           - vendor
 
-# SR-IOV Network Operator chart related values
+# SR-IOV Network Operator chart related values.
 sriov-network-operator:
   operator:
+    # -- Prefix to be used for resources names.
     resourcePrefix: "nvidia.com"
+    # -- Enable admission controller.
     admissionControllers:
       enabled: false
       certificates:
@@ -80,13 +96,14 @@ sriov-network-operator:
           operator: "operator-webhook-cert"
           injector: "network-resources-injector-cert"
         certManager:
-          # When enabled, makes use of certificates managed by cert-manager.
+          # -- When enabled, makes use of certificates managed by cert-manager.
           enabled: true
-          # When enabled, certificates are generated via cert-manager and then name will match the name of the secrets
-          # defined above
+          # -- When enabled, certificates are generated via cert-manager and then
+          # name will match the name of the secrets defined above.
           generateSelfSigned: true
-        # If not specified, no secret is created and secrets with the names defined above are expected to exist in the
-        # cluster. In that case, the ca.crt must be base64 encoded twice since it ends up being an env variable.
+        # -- If not specified, no secret is created and secrets with the names
+        # defined above are expected to exist in the cluster. In that case,
+        # the ca.crt must be base64 encoded twice since it ends up being an env variable.
         custom:
           enabled: false
       #   operator:
@@ -122,21 +139,29 @@ sriov-network-operator:
       #       ...
       #      -----END EC PRIVATE KEY-----
 
-  # Image URIs for sriov-network-operator components
+  # Image URIs for sriov-network-operator components.
   images:
     operator: {{ .SriovNetworkOperator.Repository }}/{{ .SriovNetworkOperator.Image }}:{{ .SriovNetworkOperator.Version }}
     sriovConfigDaemon: {{ .SriovConfigDaemon.Repository }}/{{ .SriovConfigDaemon.Image }}:{{ .SriovConfigDaemon.Version }}
+    # -- For ARM-based deployments, it is recommended to use the
+    # ``ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0-arm64`` image.
     sriovCni: {{ .SriovCni.Repository }}/{{ .SriovCni.Image }}:{{ .SriovCni.Version }}
+    # -- For ARM-based deployments, it is recommended to use the
+    # ``ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:1.1.0-arm64`` image.
     ibSriovCni: {{ .SriovIbCni.Repository }}/{{ .SriovIbCni.Image }}:{{ .SriovIbCni.Version }}
     ovsCni: {{ .OVSCni.Repository }}/{{ .OVSCni.Image }}:{{ .OVSCni.Version }}
     # rdmaCni: {{ .RDMACni.Repository }}/{{ .RDMACni.Image }}:{{ .RDMACni.Version }}
+    # -- For ARM-based deployments, it is recommended to use the
+    # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-arm64`` image.
     sriovDevicePlugin: {{ .SriovDevicePlugin.Repository }}/{{ .SriovDevicePlugin.Image }}:{{ .SriovDevicePlugin.Version }}
     resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
     webhook: {{ .SriovNetworkOperatorWebhook.Repository }}/{{ .SriovNetworkOperatorWebhook.Image }}:{{ .SriovNetworkOperatorWebhook.Version }}
   # imagePullSecrest for SR-IOV Network Operator related images
   # imagePullSecrets: []
   sriovOperatorConfig:
+    # -- Deploy ``SriovOperatorConfig`` custom resource
     deploy: true
+    # -- Selects the nodes to be configured
     configDaemonNodeSelector:
       beta.kubernetes.io/os: "linux"
       network.nvidia.com/operator.mofed.wait: "false"
@@ -144,6 +169,8 @@ sriov-network-operator:
 # General Operator related values
 # The operator element allows to deploy network operator from an alternate location
 operator:
+  # -- Optional `resource requests and limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`_
+  # for the operator.
   resources:
     limits:
       cpu: 500m
@@ -151,6 +178,7 @@ operator:
     requests:
       cpu: 5m
       memory: 64Mi
+  # -- Set additional tolerations for various Daemonsets deployed by the operator.
   tolerations:
     - key: "node-role.kubernetes.io/master"
       operator: "Equal"
@@ -160,8 +188,10 @@ operator:
       operator: "Equal"
       value: ""
       effect: "NoSchedule"
+  # -- Configure node selector settings for the operator.
   nodeSelector: {}
   affinity:
+    # -- Configure node affinity settings for the operator.
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 1
@@ -176,17 +206,28 @@ operator:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: In
                 values: [ "" ]
-  repository: {{ .NetworkOperator.Repository }}
-  image: {{ .NetworkOperator.Image }}
+  # -- Network Operator image repository.
+  repository: nvcr.io/nvstaging/mellanox
+  # -- Network Operator image name
+  image: network-operator
   # imagePullSecrets: []
+  # -- Name to be used as part of objects name generation.
   nameOverride: ""
+  # -- Name to be used to replace generated names.
   fullnameOverride: ""
-  # tag, if defined will use the given image tag, else Chart.AppVersion will be used
+  # tag, if defined will use the given image tag, else Chart. AppVersion will be used.
   # tag
+  # -- Directory, where CNI binaries will be deployed on the nodes. Setting for 
+  # the sriov-network-operator is set with ``sriov-network-operator.cniBinPath``
+  # parameter. Note that the CNI bin directory should be aligned with the CNI bin
+  # directory in the container runtime.
   cniBinDirectory: /opt/cni/bin
+  # -- Enable the use of Driver ToolKit to compile OFED drivers (OpenShift only).
   useDTK: true
   admissionController:
+    # -- Deploy with admission controller.
     enabled: false
+    # -- Use cert-manager for generating self-signed certificate.
     useCertManager: true
     # certificate:
       # tlsCrt: |
@@ -200,19 +241,30 @@ operator:
       #   ...
       #  -----END EC PRIVATE KEY-----
 
+# -- An optional list of references to secrets to use for pulling any of the
+# Network Operator images.
 imagePullSecrets: []
 
 # NicClusterPolicy CR values:
+# -- Deploy ``NicClusterPolicy`` custom resource according to the provided parameters.
 deployCR: false
 ofedDriver:
+  # -- Deploy the  NVIDIA DOCA Driver driver container.
   deploy: false
+  # -- NVIDIA DOCA Driver image name.
   image: {{ .Mofed.Image }}
+  # -- NVIDIA DOCA Driver image repository.
   repository: {{ .Mofed.Repository }}
+  # -- NVIDIA DOCA Driver version.
   version: {{ .Mofed.Version }}
   initContainer:
+    # -- Deploy init container.
     enable: true
+    # -- Init container image repository.
     repository: {{ .NetworkOperatorInitContainer.Repository }}
+    # -- Init container image name.
     image: {{ .NetworkOperatorInitContainer.Image }}
+    # -- Init container image version.
     version: {{ .NetworkOperatorInitContainer.Version }}
   # imagePullSecrets: []
   # env, if defined will pass environment variables to the OFED container
@@ -228,53 +280,76 @@ ofedDriver:
   #       cpu: "300m"
   #       memory: "300Mi"
   terminationGracePeriodSeconds: 300
-  # Private mirror repository configuration
+  # -- Private mirror repository configuration.
   repoConfig:
     name: ""
-  # Custom ssl key/certificate configuration
+  # Custom ssl key/certificate configuration.
   certConfig:
+    # -- Custom TLS key/certificate configuration configMap name.
     name: ""
   startupProbe:
+    # -- NVIDIA DOCA Driver startup probe initial delay.
     initialDelaySeconds: 10
+    # -- NVIDIA DOCA Driver startup probe interval.
     periodSeconds: 20
   livenessProbe:
+    # -- NVIDIA DOCA Driver liveness probe initial delay.
     initialDelaySeconds: 30
+    # -- NVIDIA DOCA Driver liveness probe interval.
     periodSeconds: 30
   readinessProbe:
+    # -- NVIDIA DOCA Driver readiness probe initial delay.
     initialDelaySeconds: 10
+    # -- NVIDIA DOCA Driver readiness probe interval.
     periodSeconds: 30
   upgradePolicy:
-    # global switch for automatic upgrade feature
-    # if set to false all other options are ignored
+    # -- Global switch for automatic upgrade feature,
+    # if set to false all other options are ignored.
     autoUpgrade: true
-    # how many nodes can be upgraded in parallel (default: 1)
-    # 0 means no limit, all nodes will be upgraded in parallel
+    # -- Number of nodes that can be upgraded in parallel (default: 1).
+    # 0 means no limit, all nodes will be upgraded in parallel.
     maxParallelUpgrades: 1
-    # cordon and drain (if enabled) a node before loading the driver on it
+    # -- Cordon and drain (if enabled) a node before loading the driver on it.
     safeLoad: false
-    # options for node drain (`kubectl drain`) before the driver reload
-    # if auto upgrade is enabled but drain.enable is false,
-    # then driver POD will be reloaded immediately without
-    # removing PODs from the node
+    # -- Options for node drain (`kubectl drain`) before the driver reload.
+    # If auto upgrade is enabled but drain.enable is false, then driver POD will be
+    # reloaded immediately without removing PODs from the node.
     drain:
+      # -- Options for node drain (``kubectl drain``) before driver reload, if
+      # auto upgrade is enabled.
       enable: true
+      # -- Use force drain of pods.
       force: true
+      # -- Pod selector to specify which pods will be drained from the node.
+      # An empty selector means all pods.
       podSelector: ""
-      # It's recommended to set a timeout to avoid infinite drain in case non-fatal error keeps happening on retries
+      # -- It's recommended to set a timeout to avoid infinite drain in case
+      # non-fatal error keeps happening on retries.
       timeoutSeconds: 300
+      # -- Delete pods local storage.
       deleteEmptyDir: true
     waitForCompletion:
       # specifies a label selector for the pods to wait for completion
       # podSelector: "app=myapp"
-      # specify the length of time in seconds to wait before giving up for workload to finish, zero means infinite
+      # specify the length of time in seconds to wait before giving up for
+      # workload to finish, zero means infinite
       # timeoutSeconds: 300
+  # -- Fail Mellanox OFED deployment if precompiled OFED driver container image
+  # does not exists.
   forcePrecompiled: false
 
 rdmaSharedDevicePlugin:
+  # -- Deploy RDMA shared device plugin.
   deploy: true
+  # -- RDMA shared device plugin image name.
   image: {{ .RdmaSharedDevicePlugin.Image }}
+  # -- RDMA shared device plugin image repository.
   repository: {{ .RdmaSharedDevicePlugin.Repository }}
+  # -- RDMA shared device plugin version.
   version: {{ .RdmaSharedDevicePlugin.Version }}
+  # -- Enable Container Device Interface (CDI) mode.
+  # **NOTE**: NVIDIA Network Operator does not configure container runtime to
+  # enable CDI.
   useCdi: false
   # imagePullSecrets: []
   # containerResources:
@@ -285,20 +360,29 @@ rdmaSharedDevicePlugin:
   #     limits:
   #       cpu: "150m"
   #       memory: "100Mi"
-  # The following defines the RDMA resources in the cluster
-  # it must be provided by the user when deploying the chart
-  # each entry in the resources element will create a resource with the provided <name> and list of devices
-  # example:
+  # -- The following defines the RDMA resources in the cluster.
+  # It must be provided by the user when deploying the chart.
+  # Each entry in the resources element will create a resource with the provided
+  # <name> and list of devices.
   resources:
     - name: rdma_shared_device_a
       vendors: [15b3]
       rdmaHcaMax: 63
 
 sriovDevicePlugin:
+  # -- Deploy SR-IOV Network device plugin.
   deploy: false
+  # -- SR-IOV Network device plugin image name.
   image: {{ .SriovDevicePlugin.Image }}
+  # -- SR-IOV Network device plugin image repository.
   repository: {{ .SriovDevicePlugin.Repository }}
+  # -- SR-IOV Network device plugin version
+  # For ARM-based deployments, it is recommended to use the
+  # ``ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.6.2-amd64`` image.
   version: {{ .SriovDevicePlugin.Version }}
+  # -- Enable Container Device Interface (CDI) mode.
+  # **NOTE**: NVIDIA Network Operator does not configure container runtime to
+  # enable CD.
   useCdi: false
   # imagePullSecrets: []
   # containerResources:
@@ -309,14 +393,20 @@ sriovDevicePlugin:
   #     limits:
   #       cpu: "150m"
   #       memory: "100Mi"
+  # -- Optional `resource requests and limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`_
+  # for the ``kube-sriovdp`` container.
   resources:
     - name: hostdev
       vendors: [15b3]
 
 ibKubernetes:
+  # -- Deploy IB Kubernetes.
   deploy: false
+  # -- IB Kubernetes image name.
   image: {{ .IbKubernetes.Image }}
+  # -- IB Kubernetes image repository.
   repository: {{ .IbKubernetes.Repository }}
+  # -- IB Kubernetes version.
   version: {{ .IbKubernetes.Version }}
   # imagePullSecrets: []
   # containerResources:
@@ -327,16 +417,25 @@ ibKubernetes:
   #     limits:
   #       cpu: "100m"
   #       memory: "300Mi"
+  # -- Interval of periodic update in seconds.
   periodicUpdateSeconds: 5
+  # -- Minimal available GUID value to be allocated for the pod.
   pKeyGUIDPoolRangeStart: "02:00:00:00:00:00:00:00"
+  # -- Maximal available GUID value to be allocated for the pod.
   pKeyGUIDPoolRangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"
+  # -- Name of the Secret with the NVIDIA UFM access credentials, deployed in advance.
   ufmSecret: '' # specify the secret name here
 
 nvIpam:
+  # -- Deploy NVIDIA IPAM Plugin.
   deploy: true
+  # -- NVIDIA IPAM Plugin image name.
   image: {{ .NvIPAM.Image }}
+  # -- NVIDIA IPAM Plugin image repository.
   repository: {{ .NvIPAM.Repository }}
+  # -- NVIDIA IPAM Plugin image version.
   version: {{ .NvIPAM.Version }}
+  # -- Enable deployment of the validataion webhook for IPPool CRD.
   enableWebhook: false
   # imagePullSecrets: []
   # containerResources:
@@ -356,11 +455,16 @@ nvIpam:
   #       memory: "300Mi"
 
 secondaryNetwork:
+  # -- Deploy Secondary Network.
   deploy: true
   cniPlugins:
+    # -- Deploy CNI Plugins Secondary Network.
     deploy: true
+    # -- CNI Plugins image name.
     image: {{ .CniPlugins.Image }}
+    # -- CNI Plugins image repository.
     repository: {{ .CniPlugins.Repository }}
+    # -- CNI Plugins image version.
     version: {{ .CniPlugins.Version }}
     # imagePullSecrets: []
     # containerResources:
@@ -372,9 +476,13 @@ secondaryNetwork:
     #       cpu: "100m"
     #       memory: "50Mi"
   multus:
+    # -- Deploy Multus Secondary Network.
     deploy: true
+    # -- Multus image name.
     image: {{ .Multus.Image }}
+    # -- Multus image repository.
     repository: {{ .Multus.Repository }}
+    # -- Multus image version.
     version: {{ .Multus.Version }}
     # imagePullSecrets: []
     # config: ''
@@ -387,9 +495,13 @@ secondaryNetwork:
     #       cpu: "100m"
     #       memory: "50Mi"
   ipoib:
+    # -- Deploy IPoIB CNI.
     deploy: false
+    # -- IPoIB CNI image name.
     image: {{ .Ipoib.Image }}
+    # -- IPoIB CNI image repository.
     repository: {{ .Ipoib.Repository }}
+    # -- IPoIB CNI image version.
     version: {{ .Ipoib.Version }}
     # imagePullSecrets: []
     # containerResources:
@@ -401,9 +513,13 @@ secondaryNetwork:
     #       cpu: "100m"
     #       memory: "50Mi"
   ipamPlugin:
+    # -- Deploy IPAM CNI Plugin Secondary Network.
     deploy: false
+    # -- IPAM CNI Plugin image name.
     image: {{ .IpamPlugin.Image }}
+    # -- IPAM CNI Plugin image repository.
     repository: {{ .IpamPlugin.Repository }}
+    # -- IPAM CNI Plugin image version.
     version: {{ .IpamPlugin.Version }}
     # imagePullSecrets: []
     # containerResources:
@@ -416,9 +532,13 @@ secondaryNetwork:
     #       memory: "200Mi"
 
 nicFeatureDiscovery:
+  # -- Deploy NVIDIA NIC Feature Discovery.
   deploy: false
+  # -- NVIDIA NIC Feature Discovery image name.
   image: {{ .NicFeatureDiscovery.Image }}
+  # -- NVIDIA NIC Feature Discovery repository.
   repository: {{ .NicFeatureDiscovery.Repository }}
+  # -- NVIDIA NIC Feature Discovery image version.
   version: {{ .NicFeatureDiscovery.Version }}
   # imagePullSecrets: []
   # containerResources:
@@ -431,9 +551,13 @@ nicFeatureDiscovery:
   #       memory: "150Mi"
 
 docaTelemetryService:
+  # -- Deploy DOCA Telemetry Service.
   deploy: false
+  # -- DOCA Telemetry Service image name.
   image: {{ .DOCATelemetryService.Image }}
+  # -- DOCA Telemetry Service image repository.
   repository: {{ .DOCATelemetryService.Repository }}
+  # -- DOCA Telemetry Service image version.
   version: {{ .DOCATelemetryService.Version }}
   # imagePullSecrets: []
   # containerResources:
@@ -452,5 +576,6 @@ docaTelemetryService:
 # Can be set to nicclusterpolicy to add extra tolerations to ds
 #tolerations:
 
+# @ignore
 test:
   pf: ens2f0


### PR DESCRIPTION
The `values.template` is updated to render a `values.yaml` containing the needed descriptions, and has to be updated for new fields if needed.

This is needed in order to properly render the `helm.rst` in Network-Operator-docs. **Note** All new fields will be in `General Parameters` section by default. If this is not desirable, the `helm.rst.gotmpl` has to be update in Network-Operator-docs.

See rendered doc: https://github.com/Mellanox/network-operator/blob/6ae08a018f019d12fc13d4630209e25cd22cc5ef/docs/charts/helm.rst