### PR TITLE
chore: backport a pre-delete helm hook for sriov-network-operator

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/templates/predeletehook.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/predeletehook.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.operator.admissionControllers.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "sriov-network-operator.fullname" . }}-post-delete-hook"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "sriov-network-operator.fullname" . }}
+      containers:
+        - name: cleanup
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              kubectl delete MutatingWebhookConfiguration -n {{ .Release.Namespace }} sriov-operator-webhook-config network-resources-injector-config
+              kubectl delete ValidatingWebhookConfiguration -n {{ .Release.Namespace }} sriov-operator-webhook-config
+      restartPolicy: Never
+{{ end }}


### PR DESCRIPTION
Mutating and Validating webhook configs are created programmatically and are not managed by helm.
To clean them up on helm delete, adding a small pre-delete hook
Backport of: https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/751