### PR TITLE
fix: Add openshift rolebinding to DOCA Telemetry Service

### DIFF
--- a/manifests/state-doca-telemetry-service/0010-doca-telemetry-service.yaml
+++ b/manifests/state-doca-telemetry-service/0010-doca-telemetry-service.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       # Required by the sysfs collector only.
       hostNetwork: true
+      serviceAccount: doca-telemetry-service
       {{- if .NodeAffinity }}
       affinity:
         nodeAffinity:

--- a/manifests/state-doca-telemetry-service/0010_service-account.yaml
+++ b/manifests/state-doca-telemetry-service/0010_service-account.yaml
@@ -1,0 +1,18 @@
+# 2024 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: doca-telemetry-service
+  namespace: {{ .RuntimeSpec.Namespace }}

--- a/manifests/state-doca-telemetry-service/0020_role.openshift.yaml
+++ b/manifests/state-doca-telemetry-service/0020_role.openshift.yaml
@@ -1,0 +1,16 @@
+{{ if .RuntimeSpec.IsOpenshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: doca-telemetry-service
+  namespace: {{ .RuntimeSpec.Namespace }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+{{end}}

--- a/manifests/state-doca-telemetry-service/0030_rolebinding.openshift.yaml
+++ b/manifests/state-doca-telemetry-service/0030_rolebinding.openshift.yaml
@@ -1,0 +1,14 @@
+{{ if .RuntimeSpec.IsOpenshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: doca-telemetry-service
+  namespace: {{ .RuntimeSpec.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: doca-telemetry-service
+subjects:
+- kind: ServiceAccount
+  name: doca-telemetry-service
+{{end}}

--- a/pkg/state/common_test.go
+++ b/pkg/state/common_test.go
@@ -385,3 +385,17 @@ func runFuncForObjectInSlice(objects []*unstructured.Unstructured, objectKind st
 	}
 	return found
 }
+
+// assertUnstructuredListHasKinds will check that there is an object in the list for each Kind in `kinds`.
+// kinds may have duplicates and the length of kinds must exactly match the length of objects.
+// If multiple objects have the same kind it should be in the `kinds` list multiple times.
+func assertUnstructuredListHasExactKinds(objects []*unstructured.Unstructured, kinds []string) {
+	Expect(len(objects)).To(Equal(len(kinds)))
+	maps := []map[string]interface{}{}
+	for _, obj := range objects {
+		maps = append(maps, obj.Object)
+	}
+	for _, kind := range kinds {
+		Expect(maps).To(ContainElement(HaveKeyWithValue("kind", kind)))
+	}
+}

--- a/pkg/state/common_test.go
+++ b/pkg/state/common_test.go
@@ -389,13 +389,11 @@ func runFuncForObjectInSlice(objects []*unstructured.Unstructured, objectKind st
 // assertUnstructuredListHasKinds will check that there is an object in the list for each Kind in `kinds`.
 // kinds may have duplicates and the length of kinds must exactly match the length of objects.
 // If multiple objects have the same kind it should be in the `kinds` list multiple times.
-func assertUnstructuredListHasExactKinds(objects []*unstructured.Unstructured, kinds []string) {
+func assertUnstructuredListHasExactKinds(objects []*unstructured.Unstructured, kinds ...string) {
 	Expect(len(objects)).To(Equal(len(kinds)))
-	maps := []map[string]interface{}{}
+	actualKinds := []string{}
 	for _, obj := range objects {
-		maps = append(maps, obj.Object)
+		actualKinds = append(actualKinds, obj.Object["kind"].(string))
 	}
-	for _, kind := range kinds {
-		Expect(maps).To(ContainElement(HaveKeyWithValue("kind", kind)))
-	}
+	Expect(actualKinds).To(ConsistOf(kinds))
 }

--- a/pkg/state/state_doca_telemetry_service_test.go
+++ b/pkg/state/state_doca_telemetry_service_test.go
@@ -41,14 +41,13 @@ var _ = Describe("DOCATelemetryService Controller", func() {
 		"../../manifests/state-doca-telemetry-service")
 	Expect(err).ToNot(HaveOccurred())
 
-	It("should test fields are set correctly", func() {
-		GetManifestObjectsTest(ctx, cr, getTestCatalog(), imageSpec, s)
-	})
-
 	It("should test the configmap is rendered with the default name", func() {
 		defaultConfigMapName := "doca-telemetry-service"
 		got, err := s.GetManifestObjects(ctx, cr, getTestCatalog(), log.FromContext(ctx))
 		Expect(err).ToNot(HaveOccurred())
+		expectedKinds := []string{"ServiceAccount", "DaemonSet", "ConfigMap"}
+		assertUnstructuredListHasExactKinds(got, expectedKinds)
+
 		for _, obj := range got {
 			// The configMap should be rendered with the default name.
 			if obj.GetKind() == "ConfigMap" {
@@ -76,6 +75,9 @@ var _ = Describe("DOCATelemetryService Controller", func() {
 		}
 		got, err := s.GetManifestObjects(ctx, withConfig, getTestCatalog(), log.FromContext(ctx))
 		Expect(err).ToNot(HaveOccurred())
+		expectedKinds := []string{"ServiceAccount", "DaemonSet"}
+		assertUnstructuredListHasExactKinds(got, expectedKinds)
+
 		for _, obj := range got {
 			// The configMap should not be rendered.
 			if obj.GetKind() == "ConfigMap" {
@@ -93,5 +95,12 @@ var _ = Describe("DOCATelemetryService Controller", func() {
 				}
 			}
 		}
+	})
+	It("should test OpenShift specific role and rolebinding rendered when the cluster is OpenShift", func() {
+		withConfig := cr.DeepCopy()
+		got, err := s.GetManifestObjects(ctx, withConfig, getTestCatalogForOpenshift(true), log.FromContext(ctx))
+		Expect(err).ToNot(HaveOccurred())
+		expectedKinds := []string{"ServiceAccount", "DaemonSet", "ConfigMap", "Role", "RoleBinding"}
+		assertUnstructuredListHasExactKinds(got, expectedKinds)
 	})
 })

--- a/pkg/state/state_doca_telemetry_service_test.go
+++ b/pkg/state/state_doca_telemetry_service_test.go
@@ -46,7 +46,7 @@ var _ = Describe("DOCATelemetryService Controller", func() {
 		got, err := s.GetManifestObjects(ctx, cr, getTestCatalog(), log.FromContext(ctx))
 		Expect(err).ToNot(HaveOccurred())
 		expectedKinds := []string{"ServiceAccount", "DaemonSet", "ConfigMap"}
-		assertUnstructuredListHasExactKinds(got, expectedKinds)
+		assertUnstructuredListHasExactKinds(got, expectedKinds...)
 
 		for _, obj := range got {
 			// The configMap should be rendered with the default name.
@@ -76,7 +76,7 @@ var _ = Describe("DOCATelemetryService Controller", func() {
 		got, err := s.GetManifestObjects(ctx, withConfig, getTestCatalog(), log.FromContext(ctx))
 		Expect(err).ToNot(HaveOccurred())
 		expectedKinds := []string{"ServiceAccount", "DaemonSet"}
-		assertUnstructuredListHasExactKinds(got, expectedKinds)
+		assertUnstructuredListHasExactKinds(got, expectedKinds...)
 
 		for _, obj := range got {
 			// The configMap should not be rendered.
@@ -101,6 +101,6 @@ var _ = Describe("DOCATelemetryService Controller", func() {
 		got, err := s.GetManifestObjects(ctx, withConfig, getTestCatalogForOpenshift(true), log.FromContext(ctx))
 		Expect(err).ToNot(HaveOccurred())
 		expectedKinds := []string{"ServiceAccount", "DaemonSet", "ConfigMap", "Role", "RoleBinding"}
-		assertUnstructuredListHasExactKinds(got, expectedKinds)
+		assertUnstructuredListHasExactKinds(got, expectedKinds...)
 	})
 })


### PR DESCRIPTION
Add support for OpenShift to the DOCA Telemetry Services deployment by adding a service account associated roles / rolebinding which gives access to the privileged securityContextConstraint.