### PR TITLE
fix: Bump SR-IOV CNI to v2.8.1

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -143,7 +143,7 @@ sriov-network-operator:
   images:
     operator: nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.7.0-beta.4
     sriovConfigDaemon: nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.7.0-beta.4
-    sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.0
+    sriovCni: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.8.1
     ibSriovCni: ghcr.io/k8snetworkplumbingwg/ib-sriov-cni:v1.1.1
     ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:v0.34.0
     # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:v1.2.0

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -21,7 +21,7 @@ SriovConfigDaemon:
 SriovCni:
   image: sriov-cni
   repository: ghcr.io/k8snetworkplumbingwg
-  version: v2.8.0
+  version: v2.8.1
 SriovIbCni:
   image: ib-sriov-cni
   repository: ghcr.io/k8snetworkplumbingwg


### PR DESCRIPTION
We need to update SR-IOV CNI to have it working with the latest Linux kernels and have [1] fix included.

[1] https://github.com/k8snetworkplumbingwg/sriov-cni/issues/303