### PR TITLE
feat: add trigger for docs ci

### DIFF
--- a/.github/workflows/docs-ci-trigger.yaml
+++ b/.github/workflows/docs-ci-trigger.yaml
@@ -1,0 +1,17 @@
+name: documentation CI - call downstream workflow
+
+on:
+  push:
+    tags:
+    - "v*"
+
+env:
+  DOWNSTREAM_WORKFLOW_REPO: Mellanox/network-operator-docs
+  DOWNSTREAM_WORKFLOW_PATH: .github/workflows/docs-ci.yaml
+  DOWNSTREAM_WORKFLOW_BRANCH: main
+
+jobs:
+  trigger_downstream_workflow:
+    uses: ${{ env.DOWNSTREAM_WORKFLOW_REPO }}/${{ env.DOWNSTREAM_WORKFLOW_PATH }}@${{ env.DOWNSTREAM_WORKFLOW_BRANCH }}
+    with:
+      git_tag: ${{ github.ref_name }}


### PR DESCRIPTION
This short workflow is used to trigger the new [downstream documentation CI workflow](https://github.com/Mellanox/network-operator-docs/pull/91).