### PR TITLE
bug: fix doc workflow

### DIFF
--- a/.github/workflows/docs-ci-trigger.yaml
+++ b/.github/workflows/docs-ci-trigger.yaml
@@ -9,6 +9,5 @@ jobs:
   trigger_downstream_workflow:
     uses: Mellanox/network-operator-docs/.github/workflows/docs-ci.yaml@main
     with:
-      token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
       git_tag: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
Invalid workflow file: .github/workflows/docs-ci-trigger.yaml#L12

The workflow is not valid. .github/workflows/docs-ci-trigger.yaml
 (Line: 12, Col: 14): Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.GH_TOKEN_NVIDIA_CI_CD