### PR TITLE
fix: Add 'nodeSelector' field for DTS deployment

### DIFF
--- a/manifests/state-doca-telemetry-service/0010-doca-telemetry-service.yaml
+++ b/manifests/state-doca-telemetry-service/0010-doca-telemetry-service.yaml
@@ -18,6 +18,10 @@ spec:
       # Required by the sysfs collector only.
       hostNetwork: true
       serviceAccount: doca-telemetry-service
+      nodeSelector:
+        # We need to run it after DOCA driver is started to be able successfully restart driver by a container.
+        feature.node.kubernetes.io/pci-15b3.present: "true"
+        network.nvidia.com/operator.mofed.wait: "false"
       {{- if .NodeAffinity }}
       affinity:
         nodeAffinity:


### PR DESCRIPTION
We need to run it after DOCA driver is started to be able successfully restart driver by a container.