### PR TITLE
fix: Set required fields in ibKubernetes

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -248,11 +248,11 @@ type IBKubernetesSpec struct {
 	// +kubebuilder:validation:Minimum:=0
 	PeriodicUpdateSeconds int `json:"periodicUpdateSeconds,omitempty"`
 	// The first guid in the pool
-	PKeyGUIDPoolRangeStart string `json:"pKeyGUIDPoolRangeStart,omitempty"`
+	PKeyGUIDPoolRangeStart string `json:"pKeyGUIDPoolRangeStart"`
 	// The last guid in the pool
-	PKeyGUIDPoolRangeEnd string `json:"pKeyGUIDPoolRangeEnd,omitempty"`
+	PKeyGUIDPoolRangeEnd string `json:"pKeyGUIDPoolRangeEnd"`
 	// Secret containing credentials to UFM service
-	UfmSecret string `json:"ufmSecret,omitempty"`
+	UfmSecret string `json:"ufmSecret"`
 }
 
 // NVIPAMSpec describes configuration options for nv-ipam

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -210,7 +210,10 @@ spec:
                     type: string
                 required:
                 - image
+                - pKeyGUIDPoolRangeEnd
+                - pKeyGUIDPoolRangeStart
                 - repository
+                - ufmSecret
                 - version
                 type: object
               nicFeatureDiscovery:

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -210,7 +210,10 @@ spec:
                     type: string
                 required:
                 - image
+                - pKeyGUIDPoolRangeEnd
+                - pKeyGUIDPoolRangeStart
                 - repository
+                - ufmSecret
                 - version
                 type: object
               nicFeatureDiscovery:


### PR DESCRIPTION
Set the following fileds as required:
 - pKeyGUIDPoolRangeStart
 - pKeyGUIDPoolRangeEnd
 - ufmSecret