### PR TITLE
fix: Make apply-crds binary public useable

### DIFF
--- a/cmd/apply-crds/main.go
+++ b/cmd/apply-crds/main.go
@@ -67,6 +67,10 @@ func initFlags() {
 }
 
 func main() {
+	Run()
+}
+
+func Run() {
 	ctx := context.Background()
 
 	initFlags()


### PR DESCRIPTION
We want to make this package public to make it re-usable for other projects.