### PR TITLE
chore: downgrade go version for apply-crds package

### DIFF
--- a/cmd/apply-crds/go.mod
+++ b/cmd/apply-crds/go.mod
@@ -1,6 +1,6 @@
 module github.com/mellanox/network-operator/cmd/apply-crds
 
-go 1.23.2
+go 1.22.8
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0


### PR DESCRIPTION
There is a project that wants to consume this package.
As this project sticks to the Go version that is also used by the lates stable Kubernetes version we should also downgrade this version to be compatible.