### PR TITLE
chore: adjust sriov netop chart dependency to enable automation

### DIFF
--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -17,9 +17,9 @@ dependencies:
   repository: http://kubernetes-sigs.github.io/node-feature-discovery/charts
   version: 0.15.6
 - condition: sriovNetworkOperator.enabled
-  name: sriov-network-operator
+  name: sriov-network-operator-chart
   repository: ''
-  version: 0.1.0
+  version: 0.0.0-dev
 - condition: nicConfigurationOperator.enabled
   name: nic-configuration-operator-chart
   repository: ''

--- a/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: sriov-network-operator
-version: 0.1.0
+name: sriov-network-operator-chart
+version: 0.0.0-dev
 kubeVersion: '>= 1.16.0-0'
 appVersion: 1.2.0
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster


### PR DESCRIPTION
Given that we will copy over the chart on each release from now on, this PR aligns the chart dependency with the upstream chart to ensure we can still install without problems.