### PR TITLE
chore: fixing dosc-ci to auto trigger docs repo PRS for helm, api changes

### DIFF
--- a/.github/workflows/docs-ci-trigger.yaml
+++ b/.github/workflows/docs-ci-trigger.yaml
@@ -4,10 +4,20 @@ on:
   push:
     tags:
     - "v*"
+    paths:
+    - deployment/**/values.yaml
+    - api/**    
+
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - edited
+    paths:
+    - deployment/**/values.yaml
+    - api/**
 
 jobs:
   trigger_downstream_workflow:
     uses: Mellanox/network-operator-docs/.github/workflows/docs-ci.yaml@main
-    with:
-      git_tag: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
Following `docs-ci-trigger` changes will initiate new `network-operator-docs` repo PR for new `tag`, `pull-request` cases, whenever there are helm values or api changes.

This PR is based on changes done in [#Mellanox/network-operator-docs/132](https://github.com/Mellanox/network-operator-docs/pull/132)