### PR TITLE
chore: fixing failed network-operator upgrade to 24.10 over crashing multus pod

### DIFF
--- a/manifests/state-multus-cni/0050-multus-ds.yml
+++ b/manifests/state-multus-cni/0050-multus-ds.yml
@@ -21,8 +21,6 @@ spec:
         name: multus
     spec:
       hostNetwork: true
-      priorityClassName: "system-node-critical"
-      terminationGracePeriodSeconds: 10
       {{- if .NodeAffinity }}
       affinity:
         nodeAffinity:
@@ -42,6 +40,9 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      {{- if hasPrefix .CrSpec.Version "v4" }}
+      priorityClassName: "system-node-critical"
+      terminationGracePeriodSeconds: 10        
       initContainers:
         - name: install-multus-binary
           image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
@@ -60,9 +61,11 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
               mountPropagation: Bidirectional
+      {{- end }}
       containers:
         - name: kube-multus
           image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          {{- if hasPrefix .CrSpec.Version "v4" }}
           command: ["/thin_entrypoint"]
           args:
             # /tmp/multus-conf/00-multus.conf is where multus-cfg ConfigMap is mounted then entrypoint.sh copy it to
@@ -72,6 +75,18 @@ spec:
             - "--cni-conf-dir=/host/etc/cni/net.d"
             - "--cleanup-config-on-exit"
             - "--skip-config-watch"
+          {{- else }}
+          command: ["/entrypoint.sh"]
+          args:
+            - "--cni-version=0.3.1"
+            - "--multus-conf-file={{- if .CrSpec.Config -}}/tmp/multus-conf/00-multus.conf{{- else -}}auto{{- end -}}"
+          # Remove multus config file to prevent failing of creating/deleting pods since multus will fail due to
+          # permission issue, https://github.com/intel/multus-cni/issues/592
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -f /host/etc/cni/net.d/00-multus.conf"]
+          {{- end }}
           {{- with .RuntimeSpec.ContainerResources }}
           {{- with index . "kube-multus" }}
           resources:

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -124,6 +124,7 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 		"indent":        indent,
 		"nindent":       nindent,
 		"nindentPrefix": nindentPrefix,
+		"hasPrefix":     strings.HasPrefix,
 	})
 
 	if data.Funcs != nil {


### PR DESCRIPTION
Multus pod has crashed due to changes in multus DS template, mainly command/args, between versions 24.7 and 24.10
The following solution is only a short term solution for fixing failed multus DS.
For next version we should introduce an inclusive solution for any other workloads dependencies provisioned by network-operator templates