### PR TITLE
bug: add bundle.Dockerfile to CI PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,6 +147,7 @@ jobs:
         git checkout -b $FEATURE_BRANCH
         git status
         git add bundle
+        git add bundle.Dockerfile
         git commit -sm "task: update bundle to $VERSION_WITH_PREFIX"
 
         git push -u origin $FEATURE_BRANCH


### PR DESCRIPTION
When creating the CI PR with updates to OCP bundle, the `bundle.Dockerfile` should be also commited.