### PR TITLE
bug: remove empty config in multus examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ spec:
       repository: ghcr.io/k8snetworkplumbingwg
       version: v3.9.3
       # if config is missing or empty then multus config will be automatically generated from the CNI configuration file of the master plugin (the first file in lexicographical order in cni-conf-dir)
-      config: ''
+      # config: ''
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg
@@ -215,7 +215,6 @@ spec:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
       version: v3.9.3
-      config: ''
   nvIpam:
     image: nvidia-k8s-ipam
     repository: ghcr.io/mellanox

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
@@ -91,7 +91,6 @@ spec:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
       version: v4.1.0
-      config: ''
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -69,7 +69,6 @@ spec:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
       version: v4.1.0
-      config: ''
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -65,7 +65,6 @@ spec:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
       version: v4.1.0
-      config: ''
   nvIpam:
     image: nvidia-k8s-ipam
     repository: ghcr.io/mellanox

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -65,7 +65,6 @@ spec:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg
       version: v4.1.0
-      config: ''
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/dgx-helm-values.yaml
+++ b/example/dgx-helm-values.yaml
@@ -38,7 +38,6 @@ secondaryNetwork:
     repository: ghcr.io/k8snetworkplumbingwg
     version: v3.8
     imagePullSecrets: []
-    config: ''
   ipamPlugin:
     deploy: true
     image: whereabouts

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.template
@@ -91,7 +91,6 @@ spec:
       image: {{ .Multus.Image }}
       repository: {{ .Multus.Repository }}
       version: {{ .Multus.Version }}
-      config: ''
     ipamPlugin:
       image: {{ .IpamPlugin.Image }}
       repository: {{ .IpamPlugin.Repository }}

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.template
@@ -69,7 +69,6 @@ spec:
       image: {{ .Multus.Image }}
       repository: {{ .Multus.Repository }}
       version: {{ .Multus.Version }}
-      config: ''
     ipamPlugin:
       image: {{ .IpamPlugin.Image }}
       repository: {{ .IpamPlugin.Repository }}

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.template
@@ -65,7 +65,6 @@ spec:
       image: {{ .Multus.Image }}
       repository: {{ .Multus.Repository }}
       version: {{ .Multus.Version }}
-      config: ''
   nvIpam:
     image: {{ .NvIPAM.Image }}
     repository: {{ .NvIPAM.Repository }}

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.template
@@ -65,7 +65,6 @@ spec:
       image: {{ .Multus.Image }}
       repository: {{ .Multus.Repository }}
       version: {{ .Multus.Version }}
-      config: ''
     ipamPlugin:
       image: {{ .IpamPlugin.Image }}
       repository: {{ .IpamPlugin.Repository }}


### PR DESCRIPTION
Empty config in multus, empty multus config is created causing nodes to be in not ready state.