### PR TITLE
chore: use sha for init container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,7 @@ generate: $(CONTROLLER_GEN) ## Generate code
 
 .PHONY: bundle
 bundle: $(OPERATOR_SDK) $(KUSTOMIZE) manifests ## Generate bundle manifests and metadata, then validate generated files.
+	cd hack && $(GO) run release.go --with-sha256 --templateDir ./templates/config/manager --outputDir ../config/manager/
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(TAG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
@@ -412,7 +413,6 @@ release-build:
 	cd hack && $(GO) run release.go --templateDir ./templates/samples/ --outputDir ../config/samples/
 	cd hack && $(GO) run release.go --templateDir ./templates/crs/ --outputDir ../example/crs
 	cd hack && $(GO) run release.go --templateDir ./templates/values/ --outputDir ../deployment/network-operator/
-	cd hack && $(GO) run release.go --templateDir ./templates/config/manager --outputDir ../config/manager/
 
 # dev environment
 

--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -89,7 +89,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-05T08:32:23Z"
+    createdAt: "2025-01-07T07:14:11Z"
     description: Deploy and manage NVIDIA networking resources in Kubernetes
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -455,7 +455,7 @@ spec:
                 - name: USE_DTK
                   value: "true"
                 - name: OFED_INIT_CONTAINER_IMAGE
-                  value: ghcr.io/mellanox/network-operator-init-container:v0.0.2
+                  value: ghcr.io/mellanox/network-operator-init-container@sha256:1699d23027ea30c9fa59575a914114bdfd5a87a359caf8c0a9b16d409ec0d068
                 image: nvcr.io/nvstaging/mellanox/network-operator@sha256:e8de2ff64f2d2b6c19602b4a6817bbff4bfd4aaba0b73e7a60993f4d819c1bdf
                 imagePullPolicy: IfNotPresent
                 livenessProbe:

--- a/config/manager/init_container_image_name_patch.yaml
+++ b/config/manager/init_container_image_name_patch.yaml
@@ -2,4 +2,4 @@
   path: "/spec/template/spec/containers/0/env/-"
   value:
     name: OFED_INIT_CONTAINER_IMAGE
-    value: "ghcr.io/mellanox/network-operator-init-container:v0.0.2"
+    value: "ghcr.io/mellanox/network-operator-init-container@sha256:1699d23027ea30c9fa59575a914114bdfd5a87a359caf8c0a9b16d409ec0d068"

--- a/hack/templates/config/manager/init_container_image_name_patch.template
+++ b/hack/templates/config/manager/init_container_image_name_patch.template
@@ -2,4 +2,4 @@
   path: "/spec/template/spec/containers/0/env/-"
   value:
     name: OFED_INIT_CONTAINER_IMAGE
-    value: "{{ .NetworkOperatorInitContainer.Repository }}/{{ .NetworkOperatorInitContainer.Image }}:{{ .NetworkOperatorInitContainer.Version }}"
+    value: "{{ (imageAsSha .NetworkOperatorInitContainer) }}"


### PR DESCRIPTION
For disconnected environment, OCP bundle should use only SHA  format for container images.