### PR TITLE
bug: bump network-resources-injector version to support multi-arch

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -159,7 +159,7 @@ sriov-network-operator:
     ovsCni: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:v0.37.0
     # rdmaCni: ghcr.io/k8snetworkplumbingwg/rdma-cni:v1.2.0
     sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.8.0
-    resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
+    resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.7.0
     webhook: nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-25.1.0-beta.2
   # imagePullSecrest for SR-IOV Network Operator related images
   # imagePullSecrets: []

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -159,7 +159,7 @@ sriov-network-operator:
     ovsCni: {{ .OVSCni.Repository }}/{{ .OVSCni.Image }}:{{ .OVSCni.Version }}
     # rdmaCni: {{ .RDMACni.Repository }}/{{ .RDMACni.Image }}:{{ .RDMACni.Version }}
     sriovDevicePlugin: {{ .SriovDevicePlugin.Repository }}/{{ .SriovDevicePlugin.Image }}:{{ .SriovDevicePlugin.Version }}
-    resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:8810e6a127366cc1eb829d3f7cb3f866d096946e
+    resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.7.0
     webhook: {{ .SriovNetworkOperatorWebhook.Repository }}/{{ .SriovNetworkOperatorWebhook.Image }}:{{ .SriovNetworkOperatorWebhook.Version }}
   # imagePullSecrest for SR-IOV Network Operator related images
   # imagePullSecrets: []


### PR DESCRIPTION
Previous version didn't support multi-arch

![Screenshot 2025-01-09 at 14 57 09](https://github.com/user-attachments/assets/94acc865-d9f0-4643-928b-06379335f908)
