### PR TITLE
bug: support container image SHA256 version

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -51,7 +51,6 @@ type ImageSpec struct {
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\.\-\/]+
 	Repository string `json:"repository"`
 	// Version of the image to use
-	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\.-]+
 	Version string `json:"version"`
 	// ImagePullSecrets is an optional list of references to secrets in the same
 	// namespace to use for pulling the image

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -121,7 +121,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -208,7 +207,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -280,7 +278,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -552,7 +549,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -887,7 +883,6 @@ spec:
                     type: object
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -965,7 +960,6 @@ spec:
                     type: boolean
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -1041,7 +1035,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1108,7 +1101,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1175,7 +1167,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1245,7 +1236,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1324,7 +1314,6 @@ spec:
                     type: boolean
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image

--- a/controllers/nicclusterpolicy_controller_test.go
+++ b/controllers/nicclusterpolicy_controller_test.go
@@ -305,7 +305,7 @@ var _ = Describe("NicClusterPolicyReconciler Controller", func() {
 		imageRepo := "nvcr.io/nvidia/doca"
 		imageName := "doca-telemetry-service"
 		imageVersion := "1.15.5-doca2.5.0"
-		updatedVersion := "v9.9.9-doca2.5.0"
+		updatedVersion := "sha256:1699d23027ea30c9fa"
 		ctx := context.Background()
 		It("should create, update and delete doca-telemetry-service through NICClusterPolicy", func() {
 			By("Create doca-telemetry-service through NICClusterPolicy")
@@ -355,7 +355,7 @@ var _ = Describe("NicClusterPolicyReconciler Controller", func() {
 			}, timeout*3, interval).Should(BeTrue())
 
 			By("Update DOCATelemetryService through NICClusterPolicy")
-			expectedImageName := fmt.Sprintf("%v/%v:%v", imageRepo, imageName, updatedVersion)
+			expectedImageName := fmt.Sprintf("%v/%v@%v", imageRepo, imageName, updatedVersion)
 
 			// Patch the NICClusterPolicy with the updated DOCATelemetryService version number.
 			patch := []byte(fmt.Sprintf(`{"spec": {"docaTelemetryService":{"version": %q}}}`, updatedVersion))

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -121,7 +121,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -208,7 +207,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -280,7 +278,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -552,7 +549,6 @@ spec:
                     type: string
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -887,7 +883,6 @@ spec:
                     type: object
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -965,7 +960,6 @@ spec:
                     type: boolean
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image
@@ -1041,7 +1035,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1108,7 +1101,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1175,7 +1167,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1245,7 +1236,6 @@ spec:
                         type: string
                       version:
                         description: Version of the image to use
-                        pattern: '[a-zA-Z0-9\.-]+'
                         type: string
                     required:
                     - image
@@ -1324,7 +1314,6 @@ spec:
                     type: boolean
                   version:
                     description: Version of the image to use
-                    pattern: '[a-zA-Z0-9\.-]+'
                     type: string
                 required:
                 - image

--- a/manifests/state-container-networking-plugins/0010-container-networking-plugins-ds.yml
+++ b/manifests/state-container-networking-plugins/0010-container-networking-plugins-ds.yml
@@ -51,7 +51,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cni-plugins
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/manifests/state-doca-telemetry-service/0010-doca-telemetry-service.yaml
+++ b/manifests/state-doca-telemetry-service/0010-doca-telemetry-service.yaml
@@ -42,7 +42,7 @@ spec:
           effect: NoSchedule
       containers:
       - name: doca-telemetry-service
-        image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+        image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
         {{- with .RuntimeSpec.ContainerResources }}
         {{- with index . "doca-telemetry-service" }}
         resources:

--- a/manifests/state-ib-kubernetes/0070-deployment.yaml
+++ b/manifests/state-ib-kubernetes/0070-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: ib-kubernetes
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           imagePullPolicy: IfNotPresent
           command: ["/usr/bin/ib-kubernetes"]
           {{- with .RuntimeSpec.ContainerResources }}

--- a/manifests/state-ipoib-cni/0050-ipoib-cni-ds.yml
+++ b/manifests/state-ipoib-cni/0050-ipoib-cni-ds.yml
@@ -57,7 +57,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: ipoib-cni
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           {{- with .RuntimeSpec.ContainerResources }}
           {{- with index . "ipoib-cni" }}
           resources:

--- a/manifests/state-multus-cni/0050-multus-ds.yml
+++ b/manifests/state-multus-cni/0050-multus-ds.yml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 10        
       initContainers:
         - name: install-multus-binary
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           command: ["/install_multus"]
           args:
             - "--type"
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       containers:
         - name: kube-multus
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           {{- if hasPrefix .CrSpec.Version "v4" }}
           command: ["/thin_entrypoint"]
           args:

--- a/manifests/state-nic-feature-discovery/030-nic-feature-discovery-ds.yaml
+++ b/manifests/state-nic-feature-discovery/030-nic-feature-discovery-ds.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       containers:
         - name: nic-feature-discovery
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           command: [ "/nic-feature-discovery" ]
           args:
             - --v=0

--- a/manifests/state-nv-ipam-cni/040-nv-ipam-controller.yaml
+++ b/manifests/state-nv-ipam-cni/040-nv-ipam-controller.yaml
@@ -87,7 +87,7 @@ spec:
       {{- end }}
       containers:
         - name: nv-ipam-controller
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           imagePullPolicy: IfNotPresent
           command: ["/ipam-controller"]
           args:

--- a/manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
+++ b/manifests/state-nv-ipam-cni/040-nv-ipam-node.yaml
@@ -56,7 +56,7 @@ spec:
       {{- end }}
       containers:
       - name: nv-ipam-node
-        image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+        image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME

--- a/manifests/state-rdma-shared-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/state-rdma-shared-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -40,7 +40,7 @@ spec:
 {{if .DeployInitContainer}}
       initContainers:
         - name: ofed-driver-validation
-          image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
           imagePullPolicy: IfNotPresent
           command: [ 'sh', '-c' ]
           args: [ "until lsmod | grep mlx5_core; do echo waiting for OFED drivers to be loaded; sleep 30; done" ]
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-      - image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+      - image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
         name: rdma-shared-dp
         command: [ "/bin/k8s-rdma-shared-dp" ]
         {{- if .CrSpec.UseCdi }}

--- a/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yaml
+++ b/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yaml
@@ -57,14 +57,14 @@ spec:
 {{- if .DeployInitContainer}}
       initContainers:
         - name: ofed-driver-validation
-          image: {{ .CrSpec.ImageSpec.Repository }}/{{ .CrSpec.ImageSpec.Image }}:{{ .CrSpec.ImageSpec.Version }}
+          image: {{ imagePath .CrSpec.ImageSpec.Repository .CrSpec.ImageSpec.Image .CrSpec.ImageSpec.Version }}
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c']
           args: ["until lsmod | grep mlx5_core; do echo waiting for OFED drivers to be loaded; sleep 30; done"]
 {{- end}}
       containers:
         - name: kube-sriovdp
-          image: {{ .CrSpec.ImageSpec.Repository }}/{{ .CrSpec.ImageSpec.Image }}:{{ .CrSpec.ImageSpec.Version }}
+          image: {{ imagePath .CrSpec.ImageSpec.Repository .CrSpec.ImageSpec.Image .CrSpec.ImageSpec.Version }}
           imagePullPolicy: IfNotPresent
           args:
             - --log-dir=sriovdp

--- a/manifests/state-whereabouts-cni/0050-whereabouts-ds.yaml
+++ b/manifests/state-whereabouts-cni/0050-whereabouts-ds.yaml
@@ -54,7 +54,7 @@ spec:
           effect: NoSchedule
       containers:
       - name: whereabouts
-        image: {{ .CrSpec.Repository }}/{{ .CrSpec.Image }}:{{ .CrSpec.Version }}
+        image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
         command: [ "/bin/sh" ]
         args:
         - -c

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -103,6 +103,14 @@ func nindentPrefix(spaces int, prefix, v string) string {
 	return strings.Replace(nindent(spaces, prefix+v), " ", "", len(prefix))
 }
 
+// imagePath returns container image path, supporting sha256 format
+func imagePath(repository, image, version string) string {
+	if strings.HasPrefix(version, "sha256:") {
+		return repository + "/" + image + "@" + version
+	}
+	return repository + "/" + image + ":" + version
+}
+
 // renderFile renders a single file to a list of k8s unstructured objects
 func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData) ([]*unstructured.Unstructured, error) {
 	// Read file
@@ -125,6 +133,7 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 		"nindent":       nindent,
 		"nindentPrefix": nindentPrefix,
 		"hasPrefix":     strings.HasPrefix,
+		"imagePath":     imagePath,
 	})
 
 	if data.Funcs != nil {

--- a/pkg/state/state_ipoib_cni_test.go
+++ b/pkg/state/state_ipoib_cni_test.go
@@ -46,6 +46,14 @@ var _ = Describe("IPoIB CNI State tests", func() {
 			Expect(len(objs)).To(Equal(1))
 			GetManifestObjectsTest(ts.context, cr, ts.catalog, cr.Spec.SecondaryNetwork.IPoIB, ts.renderer)
 		})
+		It("manifests with IPoIB CNI - image as SHA256", func() {
+			cr := getNICForIPoIBCNI()
+			cr.Spec.SecondaryNetwork.IPoIB.Version = defaultTestVersionSha256
+			objs, err := ts.renderer.GetManifestObjects(context.TODO(), cr, ts.catalog, testLogger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(objs)).To(Equal(1))
+			GetManifestObjectsTest(ts.context, cr, ts.catalog, cr.Spec.SecondaryNetwork.IPoIB, ts.renderer)
+		})
 		It("manifests with IPoIB CNI for Openshift", func() {
 			cr := getNICForIPoIBCNI()
 			objs, err := ts.renderer.GetManifestObjects(context.TODO(), cr, ts.openshiftCatalog, testLogger)

--- a/pkg/state/state_multus_cni_test.go
+++ b/pkg/state/state_multus_cni_test.go
@@ -113,6 +113,22 @@ var _ = Describe("Multus CNI state", func() {
 		})).To(BeTrue())
 	})
 
+	It("should render Daemonset image with SHA256 format", func() {
+		cr := getMinimalNicClusterPolicyWithMultus()
+		cr.Spec.SecondaryNetwork.Multus.Version = "sha256:1699d23027ea30c9fa"
+
+		objs, err := ts.renderer.GetManifestObjects(context.TODO(), cr, ts.catalog, testLogger)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(runFuncForObjectInSlice(objs, "DaemonSet", func(obj *unstructured.Unstructured) {
+			var daemonSet appsv1.DaemonSet
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &daemonSet)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(daemonSet.Spec.Template.Spec.Containers[0].Image).To(Equal("myrepo/myimage@sha256:1699d23027ea30c9fa"))
+		})).To(BeTrue())
+	})
+
 	It("should render Daemonset with NodeAffinity when specified in CR", func() {
 		cr := getMinimalNicClusterPolicyWithMultus()
 

--- a/pkg/state/state_nic_feature_discovery_test.go
+++ b/pkg/state/state_nic_feature_discovery_test.go
@@ -41,4 +41,11 @@ var _ = Describe("NicClusterPolicyReconciler Controller", func() {
 	It("should test fields are set correctly", func() {
 		GetManifestObjectsTest(ctx, cr, getTestCatalog(), imageSpec, s)
 	})
+	It("should use SHA256 format", func() {
+		withSha256 := cr.DeepCopy()
+		withSha256.Spec.NicFeatureDiscovery.Version = defaultTestVersionSha256
+		imageSpecWithSha256 := imageSpec.DeepCopy()
+		imageSpecWithSha256.Version = defaultTestVersionSha256
+		GetManifestObjectsTest(ctx, withSha256, getTestCatalog(), imageSpecWithSha256, s)
+	})
 })

--- a/pkg/state/state_nv_ipam_cni_test.go
+++ b/pkg/state/state_nv_ipam_cni_test.go
@@ -95,6 +95,34 @@ var _ = Describe("NVIPAM Controller", func() {
 			assertCommonDeploymentFields(d, &cr.Spec.NvIpam.ImageSpec)
 		})
 
+		It("should create Daemonset - SHA256 image format", func() {
+			By("Sync")
+			cr := getMinimalNicClusterPolicyWithNVIpam("nv-ipam-node")
+			cr.Spec.NvIpam.Version = defaultTestVersionSha256
+			status, err := nvIpamState.Sync(context.Background(), cr, catalog)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeEquivalentTo(state.SyncStateNotReady))
+			By("Verify DaemonSet")
+			ds := &appsv1.DaemonSet{}
+			err = client.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: "nv-ipam-node"}, ds)
+			Expect(err).NotTo(HaveOccurred())
+			assertCommonDaemonSetFields(ds, &cr.Spec.NvIpam.ImageSpec, cr)
+		})
+
+		It("should create Deployment - SHA256 image format", func() {
+			By("Sync")
+			cr := getMinimalNicClusterPolicyWithNVIpam("nv-ipam-controller")
+			cr.Spec.NvIpam.Version = defaultTestVersionSha256
+			status, err := nvIpamState.Sync(context.Background(), cr, catalog)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeEquivalentTo(state.SyncStateNotReady))
+			By("Verify Deployment")
+			d := &appsv1.Deployment{}
+			err = client.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: "nv-ipam-controller"}, d)
+			Expect(err).NotTo(HaveOccurred())
+			assertCommonDeploymentFields(d, &cr.Spec.NvIpam.ImageSpec)
+		})
+
 		It("should create Deployment with Webhook when specified in CR", func() {
 			By("Sync")
 			cr := getMinimalNicClusterPolicyWithNVIpam("nv-ipam-controller")

--- a/pkg/state/state_rdma_shared_device_plugin_test.go
+++ b/pkg/state/state_rdma_shared_device_plugin_test.go
@@ -42,6 +42,14 @@ var _ = Describe("RDMA Shared Device Plugin", func() {
 			Expect(len(objs)).To(Equal(1))
 			GetManifestObjectsTest(ts.context, cr, ts.catalog, &cr.Spec.RdmaSharedDevicePlugin.ImageSpec, ts.renderer)
 		})
+		It("manifests with RdmaSharedDevicePlugin - image as SHA256", func() {
+			cr := getRDMASharedDevicePlugin()
+			cr.Spec.RdmaSharedDevicePlugin.Version = defaultTestVersionSha256
+			objs, err := ts.renderer.GetManifestObjects(ts.context, cr, ts.catalog, testLogger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(objs)).To(Equal(1))
+			GetManifestObjectsTest(ts.context, cr, ts.catalog, &cr.Spec.RdmaSharedDevicePlugin.ImageSpec, ts.renderer)
+		})
 		It("Openshift manifests", func() {
 			cr := getRDMASharedDevicePlugin()
 			objs, err := ts.renderer.GetManifestObjects(ts.context, cr, ts.openshiftCatalog, testLogger)


### PR DESCRIPTION
In OCP disconnected environment, the mirrored images are not using tags but SHA256.

This change support boths format in the NCP except for DOCA-Driver.