### PR TITLE
chore: release ci without sparse checkout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,6 @@ jobs:
       ISSUE_TITLE: ${{ github.event.issue.title }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .
       - run:
           echo "RELEASE_VERSION=`echo $ISSUE_TITLE | awk '{ print $2 }'`" >> $GITHUB_ENV
       - name: Determine base branch


### PR DESCRIPTION
Job failed with:
```
2025-01-20T06:34:22.5666372Z Switched to a new branch 'cidi/update-network-operator-to-v25.1.0-beta.3'
2025-01-20T06:34:23.3239441Z Error: stat hack/release.yaml: no such file or directory
```