### PR TITLE
chore: remove check doca validation

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -78,22 +78,6 @@ jobs:
         uses: actions/checkout@v4
       - name: check release-build
         run: make check-release-build
-  check-doca-drivers:
-    name: check doca-drivers
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: check doca-drivers
-        env:
-          NGC_CLI_API_KEY: ${{ secrets.NVCR_TOKEN }}
-        run: make check-doca-drivers
   unit-tests:
     name: Unit-tests
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Reading secrets is not allowed in PRs
    
Make target still available for local check