### PR TITLE
ci: PR checker interval

### DIFF
--- a/.github/workflows/release-pr-checker.yaml
+++ b/.github/workflows/release-pr-checker.yaml
@@ -15,7 +15,8 @@ jobs:
         uses: poseidon/wait-for-status-checks@v0.6.0
         with:
           token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
-          timeout: 4h
+          timeout: 14400
+          interval: 60
   update_network_operator_version:
     needs:
       - wait_for_ci
@@ -29,4 +30,4 @@ jobs:
         with:
           sparse-checkout: .
       - run:
-          gh pr merge $PR_NUMBER
+          gh pr merge $PR_NUMBER --merge --delete-branch


### PR DESCRIPTION
Need to specify flag with 'gh pr merge'
```
--merge, --rebase, or --squash required when not running interactively
```

See failure:
https://github.com/Mellanox/network-operator/actions/runs/13098322826/job/36544958292