### PR TITLE
chore: Bump DOCA Driver to 25.01-0.5.4.0-0

### DIFF
--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
@@ -24,7 +24,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 25.01-0.5.3.0-0
+    version: 25.01-0.5.4.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 25.01-0.5.3.0-0
+    version: 25.01-0.5.4.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 25.01-0.5.3.0-0
+    version: 25.01-0.5.4.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp-hostdev.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 25.01-0.5.3.0-0
+    version: 25.01-0.5.4.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ocp.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 25.01-0.5.3.0-0
+    version: 25.01-0.5.4.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -19,7 +19,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvstaging/mellanox
-    version: 25.01-0.5.3.0-0
+    version: 25.01-0.5.4.0-0
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -29,7 +29,7 @@ SriovIbCni:
 Mofed:
   image: doca-driver
   repository: nvcr.io/nvstaging/mellanox
-  version: 25.01-0.5.3.0-0
+  version: 25.01-0.5.4.0-0
 RdmaSharedDevicePlugin:
   image: k8s-rdma-shared-dev-plugin
   repository: ghcr.io/mellanox


### PR DESCRIPTION
Signed-off-by: Ivan Kolodiazhnyi <ikolodiazhny@nvidia.com>
(cherry picked from commit 8a698dfa3214326042f6bf9e8adcf16f60a2e2c4)