### PR TITLE
fix: if chart version already exists then *won't* fail on chart-push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,8 @@ jobs:
       run: |
         git_sha=$(git rev-parse --short HEAD)  # short git commit hash
         current_chart_version=$(yq '.version' deployment/network-operator/Chart.yaml)
-        APP_VERSION=$git_sha VERSION=$current_chart_version-$git_sha make chart-build chart-push
+        APP_VERSION=$git_sha VERSION=$current_chart_version-$git_sha make chart-build chart-push \
+          2> >(tee error.log) || grep 'already exists in the repository' error.log  # catches any errors to `error.log`; if there is a specific error - passes (exit 0)
     - name: Make package and push (`git_tag` as chart version)
       if: github.ref_type == 'tag'
       run: |


### PR DESCRIPTION
Caveat:
If the specific error (`Chart '<chart>' already exists in the repository.`) occurs then the CI workflow (`ci.yaml`) *won't* fail. However it's important to note that the `make` command will behave normally around the failure (i.e. it will exit) - this is fine in the current configuration (Makefile & ci.yaml), however - it could cause issues in the following cases:
- Expantion of the make target with additional lines (will fail and exit on the current/single line).
- Addition of make goal(s) *after* the `chart-push` target (will fail and exit and not run any following targets).