### PR TITLE
bug: fix make ocp-bundle ci on push 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,7 @@ jobs:
           export DEFAULT_CHANNEL=v1.1 # hard coded
           export CHANNELS=stable,v1.1 # hard coded
           export VERSION=1.1.0-${{ env.VERSION_WITH_PREFIX }}  # using the commit hash
+          export NETWORK_OPERATOR_VERSION=${{ env.VERSION_WITH_PREFIX }} # for push use commit sha
         fi
         make bundle bundle-build bundle-push
         if [[ "$is_push" == "true" ]]; then


### PR DESCRIPTION
```
export NETWORK_OPERATOR_VERSION=37831e1
go run -v  release.go --with-sha256 --templateDir ./templates/config/manager --outputDir ../config/manager/

ref nvcr.io/nvstaging/mellanox/network-operator:37831e1
ref ghcr.io/mellanox/network-operator-init-container:v0.0.3
ref nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-25.1.0-rc.1
```