### PR TITLE
bug: fix admission_controller template while not using cert-manager

### DIFF
--- a/deployment/network-operator/templates/admission_controller.yaml
+++ b/deployment/network-operator/templates/admission_controller.yaml
@@ -76,7 +76,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate-mellanox-com-v1alpha1-hostdevicenetwork
     {{- if not .Values.operator.admissionController.useCertManager }}
-    caBundle: {{ .Values.operator.admissionController.certificate.tlsCrt | b64enc | quote }}
+    caBundle: {{ .Values.operator.admissionController.certificate.caCrt | b64enc | quote }}
     {{- end }}
   failurePolicy: Fail
   name: vhostdevicenetwork.kb.io
@@ -99,7 +99,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate-mellanox-com-v1alpha1-nicclusterpolicy
     {{- if not .Values.operator.admissionController.useCertManager }}
-    caBundle: {{ .Values.operator.admissionController.certificate.tlsCrt | b64enc | quote }}
+    caBundle: {{ .Values.operator.admissionController.certificate.caCrt | b64enc | quote }}
     {{- end }}
   failurePolicy: Fail
   name: vnicclusterpolicy.kb.io

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -275,6 +275,11 @@ operator:
     # -- Use cert-manager for generating self-signed certificate.
     useCertManager: true
     # certificate:
+      # caCrt: |
+      #   -----BEGIN CERTIFICATE-----
+      #   MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #   ...
+      #   -----END CERTIFICATE-----    
       # tlsCrt: |
       #   -----BEGIN CERTIFICATE-----
       #   MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -275,6 +275,11 @@ operator:
     # -- Use cert-manager for generating self-signed certificate.
     useCertManager: true
     # certificate:
+      # caCrt: |
+      #   -----BEGIN CERTIFICATE-----
+      #   MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      #   ...
+      #   -----END CERTIFICATE-----    
       # tlsCrt: |
       #   -----BEGIN CERTIFICATE-----
       #   MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G


### PR DESCRIPTION
In `ValidatingWebhookConfiguration` template `caBundle` was using server side tls cert instead of CA cert