### PR TITLE
chore: upgrade ipoib-cni to v1.2.1 in v25.1.x

### DIFF
--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
@@ -86,7 +86,7 @@ spec:
     ipoib:
       image: ipoib-cni
       repository: ghcr.io/mellanox
-      version: v1.2.0
+      version: v1.2.1
     multus:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -64,7 +64,7 @@ spec:
     ipoib:
       image: ipoib-cni
       repository: ghcr.io/mellanox
-      version: v1.2.0
+      version: v1.2.1
     multus:
       image: multus-cni
       repository: ghcr.io/k8snetworkplumbingwg

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -53,7 +53,7 @@ Multus:
 Ipoib:
   image: ipoib-cni
   repository: ghcr.io/mellanox
-  version: v1.2.0
+  version: v1.2.1
 IpamPlugin:
   image: whereabouts
   repository: ghcr.io/k8snetworkplumbingwg


### PR DESCRIPTION
changelog: https://github.com/Mellanox/ipoib-cni/releases/tag/v1.2.1 CVE fixes and go version upgrade