### PR TITLE
doc: add full NCP example for OCP

### DIFF
--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.yaml
@@ -1,0 +1,105 @@
+# 2024 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ##### Note #####
+# This example contains all the components supported as a reference.
+# User should edit the example and keep only the required components.
+#
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+spec:
+  ofedDriver:
+    image: doca-driver
+    repository: nvcr.io/nvstaging/mellanox
+    version: 25.01-0.6.0.0-0
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        deleteEmptyDir: true
+        enable: true
+        force: true
+        timeoutSeconds: 300
+      maxParallelUpgrades: 1
+    startupProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+    livenessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+  rdmaSharedDevicePlugin:
+    image: k8s-rdma-shared-dev-plugin
+    repository: ghcr.io/mellanox
+    version: v1.5.2
+    # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
+    # Replace 'devices' with your (RDMA capable) netdevice name.
+    config: |
+      {
+        "configList": [
+          {
+            "resourceName": "rdma_shared_device_a",
+            "rdmaHcaMax": 63,
+            "selectors": {
+              "vendors": ["15b3"],
+              "deviceIDs": ["101b"]
+            }
+          }
+        ]
+      }
+  sriovDevicePlugin:
+    image: sriov-network-device-plugin
+    repository: ghcr.io/k8snetworkplumbingwg
+    version: v3.9.0
+    config: |
+      {
+        "resourceList": [
+          {
+            "resourcePrefix": "nvidia.com",
+            "resourceName": "hostdev",
+            "selectors": {
+              "vendors": ["15b3"],
+              "isRdma": true
+            }
+          }
+        ]
+      }
+  secondaryNetwork:
+    ipoib:
+      image: ipoib-cni
+      repository: ghcr.io/mellanox
+      version: v1.2.1
+    ipamPlugin:
+      image: whereabouts
+      repository: ghcr.io/k8snetworkplumbingwg
+      version: v0.7.0
+  nvIpam:
+    image: nvidia-k8s-ipam
+    repository: ghcr.io/mellanox
+    version: v0.2.0
+    enableWebhook: false
+  ibKubernetes:
+    image: ib-kubernetes
+    repository: ghcr.io/mellanox
+    version: v1.1.0
+    pKeyGUIDPoolRangeStart: "02:00:00:00:00:00:00:00"
+    pKeyGUIDPoolRangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"
+    ufmSecret: ufm-secret
+  nicFeatureDiscovery:
+    image: nic-feature-discovery
+    repository: ghcr.io/mellanox
+    version: v0.0.1

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.template
@@ -1,0 +1,105 @@
+# 2024 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ##### Note #####
+# This example contains all the components supported as a reference.
+# User should edit the example and keep only the required components.
+#
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+spec:
+  ofedDriver:
+    image: {{ .Mofed.Image }}
+    repository: {{ .Mofed.Repository }}
+    version: {{ .Mofed.Version }}
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        deleteEmptyDir: true
+        enable: true
+        force: true
+        timeoutSeconds: 300
+      maxParallelUpgrades: 1
+    startupProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+    livenessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+  rdmaSharedDevicePlugin:
+    image: {{ .RdmaSharedDevicePlugin.Image }}
+    repository: {{ .RdmaSharedDevicePlugin.Repository }}
+    version: {{ .RdmaSharedDevicePlugin.Version }}
+    # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
+    # Replace 'devices' with your (RDMA capable) netdevice name.
+    config: |
+      {
+        "configList": [
+          {
+            "resourceName": "rdma_shared_device_a",
+            "rdmaHcaMax": 63,
+            "selectors": {
+              "vendors": ["15b3"],
+              "deviceIDs": ["101b"]
+            }
+          }
+        ]
+      }
+  sriovDevicePlugin:
+    image: {{ .SriovDevicePlugin.Image }}
+    repository: {{ .SriovDevicePlugin.Repository }}
+    version: {{ .SriovDevicePlugin.Version }}
+    config: |
+      {
+        "resourceList": [
+          {
+            "resourcePrefix": "nvidia.com",
+            "resourceName": "hostdev",
+            "selectors": {
+              "vendors": ["15b3"],
+              "isRdma": true
+            }
+          }
+        ]
+      }
+  secondaryNetwork:
+    ipoib:
+      image: {{ .Ipoib.Image }}
+      repository: {{ .Ipoib.Repository }}
+      version: {{ .Ipoib.Version }}
+    ipamPlugin:
+      image: {{ .IpamPlugin.Image }}
+      repository: {{ .IpamPlugin.Repository }}
+      version: {{ .IpamPlugin.Version }}
+  nvIpam:
+    image: {{ .NvIPAM.Image }}
+    repository: {{ .NvIPAM.Repository }}
+    version: {{ .NvIPAM.Version }}
+    enableWebhook: false
+  ibKubernetes:
+    image: {{ .IbKubernetes.Image }}
+    repository: {{ .IbKubernetes.Repository }}
+    version: {{ .IbKubernetes.Version }}
+    pKeyGUIDPoolRangeStart: "02:00:00:00:00:00:00:00"
+    pKeyGUIDPoolRangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"
+    ufmSecret: ufm-secret
+  nicFeatureDiscovery:
+    image: {{ .NicFeatureDiscovery.Image }}
+    repository: {{ .NicFeatureDiscovery.Repository }}
+    version: {{ .NicFeatureDiscovery.Version }}


### PR DESCRIPTION
- multus and cni plugins are installed by default in OCP
