### PR TITLE
Keep node features

### DIFF
--- a/deployment/network-operator/charts/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/post-delete-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cleanupLabels }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -92,3 +93,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/deployment/network-operator/charts/node-feature-discovery/values.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/values.yaml
@@ -15,6 +15,8 @@ featureGates:
 
 priorityClassName: ""
 
+cleanupLabels: true
+
 master:
   enable: true
   extraArgs: []


### PR DESCRIPTION
When uninstalling network-operator, keep labels added by node-feature-discovery.

This is done by adding cleanupLabels value to node-feature-discover chart

Note:
The name of value probably needs to be  improved