### PR TITLE
fix: allow pr_checker job to override branch protection rules

### DIFF
--- a/.github/workflows/release-pr-checker.yaml
+++ b/.github/workflows/release-pr-checker.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   wait_for_ci:
-    if: ${{ startsWith(github.event.pull_request.title, 'cicd:') }}
+    if: ${{ startsWith(github.event.pull_request.title, 'cicd:') && github.actor == 'nvidia-ci-cd'}}
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -30,4 +30,5 @@ jobs:
         with:
           sparse-checkout: .
       - run:
-          gh pr merge $PR_NUMBER --merge --delete-branch
+          # There are branch protection rules in place, to override them, we need to pass --admin option
+          gh pr merge $PR_NUMBER --merge --delete-branch --admin


### PR DESCRIPTION
Current branch protection rules require at least one approving review. If we want the cicd PRs to be merged automatically, we need to override these rules with `--admin` option