### PR TITLE
chore: Bump golang to 1.24 on CI and go.mod

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: checkout
         uses: actions/checkout@v4
       - name: lint
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: checkout
         uses: actions/checkout@v4
       - name: check manifests
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: checkout
         uses: actions/checkout@v4
       - name: check go modules
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: checkout
         uses: actions/checkout@v4
       - name: check release-build
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: checkout
         uses: actions/checkout@v4
       - name: test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mellanox/network-operator
 
-go 1.23.2
+go 1.24.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
We already use golang v1.24 as for Docker base image.