### PR TITLE
fix: update NIC Configuration Operator helm chart

### DIFF
--- a/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -63,7 +63,8 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector contains labels required on the node
+                description: NodeSelector contains labels required on the node. When
+                  empty, the template will be applied to matching devices on all nodes.
                 type: object
               resetToDefault:
                 default: false
@@ -162,7 +163,8 @@ spec:
             description: Defines the observed state of NicConfigurationTemplate
             properties:
               nicDevices:
-                description: NicDevice CRs matching this configuration template
+                description: NicDevice CRs matching this configuration / firmware
+                  template
                 items:
                   type: string
                 type: array

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -135,6 +135,25 @@ spec:
                     - numVfs
                     type: object
                 type: object
+              firmware:
+                description: Firmware specifies the fw upgrade policy requested by
+                  NicFirmwareTemplate
+                properties:
+                  nicFirmwareSourceRef:
+                    description: NicFirmwareSourceRef refers to existing NicFirmwareSource
+                      CR on where to get the FW from
+                    type: string
+                  updatePolicy:
+                    description: UpdatePolicy indicates whether the operator needs
+                      to validate installed FW or upgrade it
+                    enum:
+                    - Validate
+                    - Update
+                    type: string
+                required:
+                - nicFirmwareSourceRef
+                - updatePolicy
+                type: object
             type: object
           status:
             description: NicDeviceStatus defines the observed state of NicDevice

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaresources.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaresources.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: nicfirmwaresources.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicFirmwareSource
+    listKind: NicFirmwareSourceList
+    plural: nicfirmwaresources
+    singular: nicfirmwaresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicFirmwareSource is the Schema for the nicfirmwaresources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NicFirmwareSourceSpec represents a list of url sources for
+              FW
+            properties:
+              binUrlSources:
+                description: BinUrlSources represents a list of url sources for FW
+                items:
+                  type: string
+                minItems: 1
+                type: array
+            required:
+            - binUrlSources
+            type: object
+          status:
+            description: NicFirmwareSourceStatus represents the status of the FW from
+              given sources, e.g. version available for PSIDs
+            properties:
+              reason:
+                description: Reason shows an error message if occurred
+                type: string
+              state:
+                description: State represents the firmware processing state
+                enum:
+                - Downloading
+                - Processing
+                - Success
+                - ProcessingFailed
+                - DownloadFailed
+                - CacheVerificationFailed
+                type: string
+              versions:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Versions is a map of available FW versions to PSIDs
+                  a PSID should have only a single FW version available for it
+                type: object
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: nicfirmwaretemplates.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicFirmwareTemplate
+    listKind: NicFirmwareTemplateList
+    plural: nicfirmwaretemplates
+    singular: nicfirmwaretemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicFirmwareTemplate is the Schema for the nicfirmwaretemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NicFirmwareTemplateSpec defines the FW templates and node/nic
+              selectors for it
+            properties:
+              nicSelector:
+                description: NIC selector configuration
+                properties:
+                  nicType:
+                    description: Type of the NIC to be selected, e.g. 101d,1015,a2d6
+                      etc.
+                    type: string
+                  pciAddresses:
+                    description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
+                    items:
+                      type: string
+                    type: array
+                  serialNumbers:
+                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    items:
+                      type: string
+                    type: array
+                required:
+                - nicType
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector contains labels required on the node. When
+                  empty, the template will be applied to matching devices on all nodes.
+                type: object
+              template:
+                description: Firmware update template
+                properties:
+                  nicFirmwareSourceRef:
+                    description: NicFirmwareSourceRef refers to existing NicFirmwareSource
+                      CR on where to get the FW from
+                    type: string
+                  updatePolicy:
+                    description: UpdatePolicy indicates whether the operator needs
+                      to validate installed FW or upgrade it
+                    enum:
+                    - Validate
+                    - Update
+                    type: string
+                required:
+                - nicFirmwareSourceRef
+                - updatePolicy
+                type: object
+            required:
+            - nicSelector
+            - template
+            type: object
+          status:
+            description: NicTemplateStatus defines the observed state of NicConfigurationTemplate
+              and NicFirmwareTemplate
+            properties:
+              nicDevices:
+                description: NicDevice CRs matching this configuration / firmware
+                  template
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/templates/config-daemon.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/templates/config-daemon.yaml
@@ -55,7 +55,11 @@ spec:
               readOnly: false
             - name: host
               mountPath: /host
+            {{- if .Values.nicFirmwareStorage.pvcName }}
+            - name: firmware-cache
+              mountPath: /nic-firmware
               readOnly: true
+            {{- end }}
       volumes:
         - name: sys
           hostPath:
@@ -66,3 +70,8 @@ spec:
         - name: host
           hostPath:
             path: /
+        {{- if .Values.nicFirmwareStorage.pvcName }}
+        - name: firmware-cache
+          persistentVolumeClaim:
+            claimName: {{ .Values.nicFirmwareStorage.pvcName }}
+        {{- end }}

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/templates/nic-fw-storage-pvc.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/templates/nic-fw-storage-pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.nicFirmwareStorage.create }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.nicFirmwareStorage.pvcName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.nicFirmwareStorage.storageClassName}}
+  storageClassName: {{ .Values.nicFirmwareStorage.storageClassName }}
+  {{- end}}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ default "1Gi" .Values.nicFirmwareStorage.availableStorageSize}}
+{{- end }}

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/templates/operator.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/templates/operator.yaml
@@ -27,6 +27,7 @@ spec:
       affinity: {{- toYaml .Values.operator.affinity | nindent 8 }}
       imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       securityContext:
+        fsGroup: 65532
         runAsNonRoot: true
       serviceAccountName: {{ include "nic-configuration-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
@@ -59,3 +60,15 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.nicFirmwareStorage.pvcName }}
+          volumeMounts:
+            - name: firmware-cache
+              mountPath: /nic-firmware
+              readOnly: false
+          {{- end }}
+      {{- if .Values.nicFirmwareStorage.pvcName }}
+      volumes:
+        - name: firmware-cache
+          persistentVolumeClaim:
+            claimName: {{ .Values.nicFirmwareStorage.pvcName }}
+      {{- end }}

--- a/deployment/network-operator/charts/nic-configuration-operator-chart/templates/role.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/templates/role.yaml
@@ -103,3 +103,68 @@ rules:
     - patch
     - update
     - watch
+
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicfirmwaresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicfirmwaresources/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicfirmwaresources/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicfirmwaretemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicfirmwaretemplates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicfirmwaretemplates/status
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
missing CRDs lead to errors in the deployment