### PR TITLE
chore: various styling and readability improvements, and simplification of OCP bundle push condition logic 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,31 +91,21 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}  # token must be explicitly set here for push to work in following step
-    - name: Set is_push flag
-      id: set-is-push
+    - name: Determine version, tag, and base branch
       run: |
-        if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
-          echo "is_push=false" >> $GITHUB_ENV
-        else
-          echo "is_push=true" >> $GITHUB_ENV
-        fi
-    - name: Determine version, tag, and base branch - Process based on is_push flag
-      run: |
-        if [[ "$is_push" == "true" ]]; then
-          echo "Setting VERSION_WITH_PREFIX to git commit hash."
-          VERSION_WITH_PREFIX=$(git rev-parse --short HEAD)
-          echo VERSION_WITH_PREFIX=$VERSION_WITH_PREFIX >> $GITHUB_ENV
-        else
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
           git_tag=${{ github.ref_name }}
-          echo VERSION_WITH_PREFIX=$git_tag >> $GITHUB_ENV
-          echo VERSION_WITHOUT_PREFIX=${git_tag:1} >> $GITHUB_ENV  # without the 'v' prefix
+          echo VERSION_WITH_PREFIX=$git_tag | tee -a $GITHUB_ENV
+          echo VERSION_WITHOUT_PREFIX=${git_tag:1} | tee -a $GITHUB_ENV  # without the 'v' prefix
           if echo $git_tag | grep beta; then
             base_branch=$DEFAULT_BRANCH
           else
             v_major_minor=$(echo $git_tag | grep -Eo '^v[0-9]+\.[0-9]+')
             base_branch=$v_major_minor.x
           fi
-          echo BASE_BRANCH=$base_branch >> $GITHUB_ENV
+          echo BASE_BRANCH=$base_branch | tee -a $GITHUB_ENV
+        elif [[ "${{ github.ref_type }}" == "branch" ]]; then
+          echo VERSION_WITH_PREFIX=$(git rev-parse --short HEAD) | tee -a $GITHUB_ENV
         fi
     - uses: docker/login-action@v3
       with:
@@ -124,38 +114,37 @@ jobs:
         password: ${{ secrets.NVCR_TOKEN }}
     - name: Lookup image digest
       run: |
-        if [[ "$is_push" == "false" && "$VERSION_WITH_PREFIX" != *-* ]]; then
+        if [[ "${{ github.ref_type }}" == "tag" && "$VERSION_WITH_PREFIX" != *-* ]]; then
           IMAGE_REGISTRY="nvcr.io/nvidia/cloud-native" # GA release
         else
           IMAGE_REGISTRY=$REGISTRY
         fi
         network_operator_digest=$(skopeo inspect docker://$IMAGE_REGISTRY/$IMAGE_NAME:$VERSION_WITH_PREFIX | jq -r .Digest)
         echo $network_operator_digest | wc -w | grep 1  # verifies value not empty
-        echo NETWORK_OPERATOR_DIGEST=$network_operator_digest >> $GITHUB_ENV
-        echo IMAGE_REGISTRY=$IMAGE_REGISTRY >>  $GITHUB_ENV
+        echo NETWORK_OPERATOR_DIGEST=$network_operator_digest | tee -a $GITHUB_ENV
+        echo IMAGE_REGISTRY=$IMAGE_REGISTRY | tee -a $GITHUB_ENV
     - name: Make bundle
       env:
         TAG: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ env.NETWORK_OPERATOR_DIGEST }}
         BUNDLE_IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ env.VERSION_WITH_PREFIX }}
         NGC_CLI_API_KEY: ${{ secrets.NVCR_TOKEN }}
       run: |
-        if [[ "$is_push" == "false" ]]; then
-          export VERSION=${{ env.VERSION_WITHOUT_PREFIX }}
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
           version_major_minor=$(echo $VERSION_WITH_PREFIX | grep -Eo 'v[0-9]+\.[0-9]+')
           export CHANNELS=stable,$version_major_minor
           export DEFAULT_CHANNEL=$version_major_minor
-        else
-          export DEFAULT_CHANNEL=v1.1 # hard coded
-          export CHANNELS=stable,v1.1 # hard coded
+          export VERSION=${{ env.VERSION_WITHOUT_PREFIX }}
+        elif [[ "${{ github.ref_type }}" == "branch" ]]; then
+          export CHANNELS=stable,v1.1  # hard coded
+          export DEFAULT_CHANNEL=v1.1  # hard coded
           export VERSION=1.1.0-${{ env.VERSION_WITH_PREFIX }}  # using the commit hash
-          export NETWORK_OPERATOR_VERSION=${{ env.VERSION_WITH_PREFIX }} # for push use commit sha
+          export NETWORK_OPERATOR_VERSION=${{ env.VERSION_WITH_PREFIX }} #  for push use commit sha
         fi
         make bundle bundle-build bundle-push
-        if [[ "$is_push" == "true" ]]; then
+        if [[ "${{ github.ref_type }}" == "branch" ]]; then
           export BUNDLE_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:latest  # hard coded
           make bundle-build bundle-push
         fi
-
     - name: Create PR with bundle to Network Operator
       if: github.ref_type == 'tag'
       env:
@@ -179,14 +168,14 @@ jobs:
     - name: Determine if to send bundle to RedHat
       if: github.ref_type == 'tag'
       run: |
-        echo SEND_BUNDLE_TO_REDHAT=$(echo ${{ github.ref_name}} | grep -qE "v[0-9]+.[0-9]+.[0-9]+$" && echo true || echo false) >> $GITHUB_ENV
-    - if: ${{ github.ref_type == 'tag' && env.SEND_BUNDLE_TO_REDHAT == 'true' }}
+        echo SEND_BUNDLE_TO_REDHAT=$(echo ${{ github.ref_name}} | grep -qE "v[0-9]+.[0-9]+.[0-9]+$" && echo true || echo false) | tee -a $GITHUB_ENV
+    - if: github.ref_type == 'tag' && env.SEND_BUNDLE_TO_REDHAT == 'true'
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}  # token must be explicitly set here for push to work in following step
         repository: ${{ env.UPSTREAM_REPO_OWNER }}/certified-operators
         path: certified-operators
-    - if: ${{ github.ref_type == 'tag' && env.SEND_BUNDLE_TO_REDHAT == 'true' }}
+    - if: github.ref_type == 'tag' && env.SEND_BUNDLE_TO_REDHAT == 'true'
       name: Create PR with bundle to RedHat
       env:
         UPSTREAM_DEFAULT_BRANCH: main

--- a/.github/workflows/release-pr-checker.yaml
+++ b/.github/workflows/release-pr-checker.yaml
@@ -5,8 +5,8 @@ on:
       - "v*.x"
 
 jobs:
-  wait_for_ci:
-    if: ${{ startsWith(github.event.pull_request.title, 'cicd:') && github.actor == 'nvidia-ci-cd'}}
+  wait-for-ci:
+    if: startsWith(github.event.pull_request.title, 'cicd:') && github.actor == 'nvidia-ci-cd'
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     permissions:
@@ -20,7 +20,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CURRENT_JOB_NAME: wait_for_ci
+          CURRENT_JOB_NAME: wait-for-ci
           REQUIRED_CHECKS: |
             nic_operator_helm CI
             nic_operator_kind CI
@@ -65,10 +65,10 @@ jobs:
               sleep $WAIT_INTERVAL
             fi
           done
-  update_network_operator_version:
+  update-network-operator-version:
     needs:
-      - wait_for_ci
-    if: ${{ startsWith(github.event.pull_request.title, 'cicd:') }}
+      - wait-for-ci
+    if: startsWith(github.event.pull_request.title, 'cicd:')
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,8 @@ on:
       - opened
 
 jobs:
-  update_network_operator_version:
-    if: ${{ startsWith(github.event.issue.title, 'Release v') }}
+  update-network-operator-version:
+    if: startsWith(github.event.issue.title, 'Release v')
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
@@ -13,21 +13,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          echo "RELEASE_VERSION=$(echo $ISSUE_TITLE | awk '{ print $2 }')" >> $GITHUB_ENV
+          echo "APP_VERSION=$(echo $ISSUE_TITLE | awk '{ print $2 }')" | tee -a $GITHUB_ENV
       - run: |
-          echo "CHART_VERSION=$(echo ${RELEASE_VERSION#v})" >> $GITHUB_ENV
+          echo "CHART_VERSION=$(echo ${APP_VERSION#v})" | tee -a $GITHUB_ENV
       - name: Determine base branch
         run: |
-          if echo $RELEASE_VERSION | grep -q beta; then
+          if echo $APP_VERSION | grep -q beta; then
             base_branch=master
           else
-            v_major_minor=$(echo $RELEASE_VERSION | grep -Eo '^v[0-9]+\.[0-9]+')
+            v_major_minor=$(echo $APP_VERSION | grep -Eo '^v[0-9]+\.[0-9]+')
             base_branch=$v_major_minor.x
           fi
           echo BASE_BRANCH=$base_branch | tee -a $GITHUB_ENV
       - name: Verify release branch exists if "rc" version
         run: |
-          if echo $RELEASE_VERSION | grep -q 'rc'; then
+          if echo $APP_VERSION | grep -q 'rc'; then
             git fetch origin
             if ! git ls-remote --heads origin $BASE_BRANCH | grep -q "$BASE_BRANCH"; then
               git config user.name  nvidia-ci-cd
@@ -40,27 +40,27 @@ jobs:
           git config user.name  nvidia-ci-cd
           git config user.email svc-cloud-orch-gh@nvidia.com
           git fetch origin $BASE_BRANCH
-          git checkout -b cicd/update-network-operator-to-$RELEASE_VERSION origin/$BASE_BRANCH
-          yq -i e '.NetworkOperator.version = "${{ env.RELEASE_VERSION }}"' hack/release.yaml
-          yq -i e '.version = "${{ env.CHART_VERSION }}"' deployment/network-operator/Chart.yaml
-          yq -i e '.appVersion = "${{ env.RELEASE_VERSION }}"' deployment/network-operator/Chart.yaml
+          git checkout -b cicd/update-network-operator-to-$APP_VERSION origin/$BASE_BRANCH
+          yq -i '.NetworkOperator.version = "${{ env.APP_VERSION }}"' hack/release.yaml
+          yq -i '.version = "${{ env.CHART_VERSION }}"'               deployment/network-operator/Chart.yaml
+          yq -i '.appVersion = "${{ env.APP_VERSION }}"'              deployment/network-operator/Chart.yaml
           make release-build
-          
+
           if ! git diff --color --unified=0 --exit-code; then
             git add deployment/network-operator/
             git add hack/release.yaml
-            git commit -sam "cicd: update Network Operator to $RELEASE_VERSION in chart values"
-            git push -u origin cicd/update-network-operator-to-$RELEASE_VERSION
+            git commit -sam "cicd: update Network Operator to $APP_VERSION in chart values"
+            git push -u origin cicd/update-network-operator-to-$APP_VERSION
             gh pr create \
               --repo ${{ github.repository_owner }}/network-operator \
               --base $BASE_BRANCH \
               --head $(git branch --show-current) \
-              --title "cicd: update Network Operator to $RELEASE_VERSION in chart values" \
+              --title "cicd: update Network Operator to $APP_VERSION in chart values" \
               --body "Created by the *${{ github.job }}* job."
           fi
 
-  update_sriov_operator_version:
-    if: ${{ startsWith(github.event.issue.title, 'Release v') }}
+  update-sriov-network-operator-version:
+    if: startsWith(github.event.issue.title, 'Release v')
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
@@ -73,10 +73,10 @@ jobs:
           path: sriov-network-operator-fork
           fetch-depth: 0
       - run: |
-          echo "RELEASE_VERSION=$(echo $ISSUE_TITLE | awk -F 'Release v' '{ print $2 }')" >> $GITHUB_ENV
+          echo "APP_VERSION=$(echo $ISSUE_TITLE | awk -F 'Release v' '{ print $2 }')" | tee -a $GITHUB_ENV
       - name: Determine sriov-network-operator branch
         run: |
-          major_minor=$(echo $RELEASE_VERSION | grep -Eo '[0-9]+\.[0-9]+')
+          major_minor=$(echo $APP_VERSION | grep -Eo '[0-9]+\.[0-9]+')
           echo BASE_BRANCH=network-operator-$major_minor.x | tee -a $GITHUB_ENV
       - name: Create tag to trigger PR that update image tags in network-operator values
         run: |
@@ -84,7 +84,6 @@ jobs:
           git config user.name  nvidia-ci-cd
           git config user.email svc-cloud-orch-gh@nvidia.com
 
-          git checkout -b $RELEASE_VERSION origin/$BASE_BRANCH
-          git tag network-operator-$RELEASE_VERSION
+          git checkout -b $APP_VERSION origin/$BASE_BRANCH
+          git tag network-operator-$APP_VERSION
           git push origin --tags
-    


### PR DESCRIPTION
Changes summary:
- Made job names kebab-case in GitHub actions, since that’s more commonly used in GH.
- The job name in automatically created PR body message will link to the respective job’s run.
- Remove redundant curly braces for expressions in workflow's `if:` conditions.
- `yq` command’s default action is `e[val]` - doesn’t need to be explicitly in code.
- Clean extra whitespace.
- Rename workflow variable `RELEASE_VERSION` to `APP_VERSION` to match how it’s used as and referenced within the actual Makefiles, etc.
- Environment variable declaration method (`>> GITHUB_ENV`) changed to use  `tee` in order for them to also be printed to workflow run log (for easier troubleshooting and traceability).
- Simplify/shorten the logic that was added in PR #1221, to improve brevity and readability.