### PR TITLE
fix: spectrumx-operator optional config map

### DIFF
--- a/manifests/state-spectrum-x-operator/0040-spectrumx-operator.yaml
+++ b/manifests/state-spectrum-x-operator/0040-spectrumx-operator.yaml
@@ -41,7 +41,7 @@ spec:
             - --health-probe-bind-address=:8081
             - --cm-namespace={{ .RuntimeSpec.Namespace }}
             - --cidrpools-namespace={{ .RuntimeSpec.Namespace }}
-            {{- if .CrSpec.SpectrumXConfig.Name }}
+            {{- if and .CrSpec.SpectrumXConfig .CrSpec.SpectrumXConfig.Name }}
             - --cm-name={{ .CrSpec.SpectrumXConfig.Name }}
             {{- end }}
             {{- if .CrSpec.SriovObjNamespace }}

--- a/manifests/state-spectrum-x-operator/0050-flowcontroller-ds.yaml
+++ b/manifests/state-spectrum-x-operator/0050-flowcontroller-ds.yaml
@@ -38,7 +38,7 @@ spec:
             - /flowcontroller
           args:
             - --cm-namespace={{ .RuntimeSpec.Namespace }}
-            {{- if .CrSpec.SpectrumXConfig.Name }}
+            {{- if and .CrSpec.SpectrumXConfig .CrSpec.SpectrumXConfig.Name }}
             - --cm-name={{ .CrSpec.SpectrumXConfig.Name }}
             {{- end }}
             - --metrics-bind-address=:8082


### PR DESCRIPTION
Check if CM is specified before using it in template.