### PR TITLE
chore:  Sync post delete label with upsteam

### DIFF
--- a/deployment/network-operator/charts/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/templates/post-delete-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cleanupLabels }}
+{{- if .Values.postDeleteCleanup }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deployment/network-operator/charts/node-feature-discovery/values.yaml
+++ b/deployment/network-operator/charts/node-feature-discovery/values.yaml
@@ -15,7 +15,7 @@ featureGates:
 
 priorityClassName: ""
 
-cleanupLabels: true
+postDeleteCleanup: true
 
 master:
   enable: true

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -46,7 +46,7 @@ node-feature-discovery:
   featureGates:
     NodeFeatureAPI: true
   # -- Enable labels cleanup when uninstalling NFD
-  cleanupLabels: false
+  postDeleteCleanup: false
 
   # -- NFD master deployment configuration.
   # @notationType -- yaml

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -46,7 +46,7 @@ node-feature-discovery:
   featureGates:
     NodeFeatureAPI: true
   # -- Enable labels cleanup when uninstalling NFD
-  cleanupLabels: false
+  postDeleteCleanup: false
 
   # -- NFD master deployment configuration.
   # @notationType -- yaml


### PR DESCRIPTION
Rename previously created cleanupLabel variable to postDeleteCleanup in order to sync with community upstream