### PR TITLE
fix: OCP bundle CI GA use nvstaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,18 +126,12 @@ jobs:
         password: ${{ secrets.NVCR_TOKEN }}
     - name: Lookup image digest
       run: |
-        if [[ "${{ github.ref_type }}" == "tag" && "$VERSION_WITH_PREFIX" != *-* ]]; then
-          IMAGE_REGISTRY="nvcr.io/nvidia/cloud-native" # GA release
-        else
-          IMAGE_REGISTRY=$REGISTRY
-        fi
-        network_operator_digest=$(skopeo inspect docker://$IMAGE_REGISTRY/$IMAGE_NAME:$VERSION_WITH_PREFIX | jq -r .Digest)
+        network_operator_digest=$(skopeo inspect docker://$REGISTRY/$IMAGE_NAME:$VERSION_WITH_PREFIX | jq -r .Digest)
         echo $network_operator_digest | wc -w | grep 1  # verifies value not empty
         echo NETWORK_OPERATOR_DIGEST=$network_operator_digest | tee -a $GITHUB_ENV
-        echo IMAGE_REGISTRY=$IMAGE_REGISTRY | tee -a $GITHUB_ENV
     - name: Make bundle
       env:
-        TAG: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ env.NETWORK_OPERATOR_DIGEST }}
+        TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ env.NETWORK_OPERATOR_DIGEST }}
         BUNDLE_IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ env.VERSION_WITH_PREFIX }}
         NGC_CLI_API_KEY: ${{ secrets.NVCR_TOKEN }}
       run: |


### PR DESCRIPTION
Since the GA image is not yet published on GA tag, the OCP bundle CI should use the nvstaging registry.