### PR TITLE
chore: update go version to 1.24

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.x'
       - name: checkout
         uses: actions/checkout@v4
       - name: lint
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.x'
       - name: checkout
         uses: actions/checkout@v4
       - name: check manifests
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.x'
       - name: checkout
         uses: actions/checkout@v4
       - name: check go modules
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.x'
       - name: checkout
         uses: actions/checkout@v4
       - name: check release-build
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.x'
       - name: checkout
         uses: actions/checkout@v4
       - name: test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,13 +27,11 @@ linters-settings:
     local-prefixes: github.com/Mellanox/network-operator
   golint:
     min-confidence: 0
-  gomnd:
+  mnd:
     settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+      # don't include the "operation" and "assign"
+      checks: argument,case,condition,return
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -61,7 +59,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - funlen
       #- gochecknoinits
       #- goconst
@@ -69,7 +67,7 @@ linters:
     - gocognit
     - gofmt
     - goimports
-    - gomnd
+    - mnd
     - goprintffuncname
     - gosec
     - gosimple
@@ -104,11 +102,12 @@ issues:
       text: "should not use dot imports"
     - path: _test\.go
       linters:
-        - gomnd
+        - mnd
         - goconst
+        - typecheck
     - text: "Magic number: 1"
       linters:
-        - gomnd
+        - mnd
     # controller-gen generates zz_generated.deepcopy.go that doesn't comply with some golangci-lint checks
     - path: api/v1alpha1/zz_generated.deepcopy.go
       linters:

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ GO = go
 # golangci-lint is used to lint go code.
 GOLANGCI_LINT_PKG=github.com/golangci/golangci-lint/cmd/golangci-lint
 GOLANGCI_LINT_BIN= golangci-lint
-GOLANGCI_LINT_VER = v1.61.0
+GOLANGCI_LINT_VER = v1.64.8
 GOLANGCI_LINT = $(TOOLSDIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT_PKG),$(GOLANGCI_LINT_BIN),$(GOLANGCI_LINT_VER))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mellanox/network-operator
 
-go 1.23.3
+go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/pkg/nodeinfo/node_info.go
+++ b/pkg/nodeinfo/node_info.go
@@ -74,7 +74,6 @@ func (p *provider) GetNodePools(filters ...Filter) []NodePool {
 	nodePoolMap := make(map[string]NodePool)
 
 	for _, node := range filtered {
-		node := node
 		nodeLabels := node.GetLabels()
 
 		nodePool := NodePool{}

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -101,6 +101,13 @@ const (
 	defaultDriversInventoryPath = "/mnt/drivers-inventory"
 )
 
+const (
+	defaultInitialDelaySeconds      = 10
+	defaultPeriodSeconds            = 30
+	startupProbePeriodSeconds       = 10
+	initialDelayStartupProbeSeconds = 30
+)
+
 // CertConfigPathMap indicates standard OS specific paths for ssl keys/certificates.
 // Where Go looks for certs: https://golang.org/src/crypto/x509/root_linux.go
 // Where OCP mounts proxy certs on RHCOS nodes:
@@ -804,22 +811,22 @@ func (e envVarsWithGet) Get(name string) *v1.EnvVar {
 func setProbesDefaults(cr *mellanoxv1alpha1.NicClusterPolicy) {
 	if cr.Spec.OFEDDriver.StartupProbe == nil {
 		cr.Spec.OFEDDriver.StartupProbe = &mellanoxv1alpha1.PodProbeSpec{
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       10,
+			InitialDelaySeconds: defaultInitialDelaySeconds,
+			PeriodSeconds:       startupProbePeriodSeconds,
 		}
 	}
 
 	if cr.Spec.OFEDDriver.LivenessProbe == nil {
 		cr.Spec.OFEDDriver.LivenessProbe = &mellanoxv1alpha1.PodProbeSpec{
-			InitialDelaySeconds: 30,
-			PeriodSeconds:       30,
+			InitialDelaySeconds: initialDelayStartupProbeSeconds,
+			PeriodSeconds:       defaultPeriodSeconds,
 		}
 	}
 
 	if cr.Spec.OFEDDriver.ReadinessProbe == nil {
 		cr.Spec.OFEDDriver.ReadinessProbe = &mellanoxv1alpha1.PodProbeSpec{
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       30,
+			InitialDelaySeconds: defaultInitialDelaySeconds,
+			PeriodSeconds:       defaultPeriodSeconds,
 		}
 	}
 }

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -347,7 +347,6 @@ func (s *stateSkel) deleteStateRelatedObjects(ctx context.Context, stateObjectsT
 			return false, err
 		}
 		for _, obj := range l.Items {
-			obj := obj
 			if stateObjectsToKeep.Exist(gvk, types.NamespacedName{
 				Name:      obj.GetName(),
 				Namespace: obj.GetNamespace()}) {


### PR DESCRIPTION
- Bump go version to 1.24
- Bump golangci-lint v1.64.8 to align with go version
- Update golangci.yml to align with golangci-lint v1.64.8 and go version 1.24
- Fix linter issues found after updating  golangci-lint