### PR TITLE
feat: adding shared-requestor support in upgrade-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Mellanox/maintenance-operator/api v0.2.2
-	github.com/NVIDIA/k8s-operator-libs v0.0.0-20250512170135-63bc7baf3f6f
+	github.com/NVIDIA/k8s-operator-libs v0.0.0-20250708070119-9dc24ccc10ee
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/containers/image/v5 v5.35.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Mellanox/maintenance-operator/api v0.2.2 h1:7bl/txeHv49NdubQ72AqC7tLXa9oJrZuqk27TG5CybM=
 github.com/Mellanox/maintenance-operator/api v0.2.2/go.mod h1:pkd4TxjMFItohSXT0D1JhXB/E3d8jE5asBzxNATwT2s=
-github.com/NVIDIA/k8s-operator-libs v0.0.0-20250512170135-63bc7baf3f6f h1:nU6yhJjS7eSVWBxnUvF+RIEdTPG1zWKG2Xgy4FJ7JjU=
-github.com/NVIDIA/k8s-operator-libs v0.0.0-20250512170135-63bc7baf3f6f/go.mod h1:B5g1bFq39qbuVK62pz0m93Qy3CCjeutfNICSl7SFoYo=
+github.com/NVIDIA/k8s-operator-libs v0.0.0-20250708070119-9dc24ccc10ee h1:IW3URIejZ85qDFoMXV1EzuHjjerGd8h0I5BvLGiuqa0=
+github.com/NVIDIA/k8s-operator-libs v0.0.0-20250708070119-9dc24ccc10ee/go.mod h1:8skFe7Dyub0FRpk5ysCM88ysFqJpIcw/4ZqLBWcevw8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/main.go
+++ b/main.go
@@ -245,14 +245,12 @@ func setupUpgradeController(mgr ctrl.Manager, migrationChan chan struct{}) error
 		setupLog.Error(err, "unable to create new ClusterUpdateStateManager", "controller", "Upgrade")
 		return err
 	}
-	requestorPredicate := upgrade.NewConditionChangedPredicate(setupLog,
-		requestorOpts.MaintenanceOPRequestorID)
 	if err = (&controllers.UpgradeReconciler{
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		StateManager: clusterUpdateStateManager,
 		MigrationCh:  migrationChan,
-	}).SetupWithManager(mgr, requestorPredicate); err != nil {
+	}).SetupWithManager(setupLog, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Upgrade")
 		return err
 	}


### PR DESCRIPTION
Network-Operator adaptations for k8s-operator-lib changes, supporting [shared-requestor ](https://github.com/NVIDIA/k8s-operator-libs/blob/main/docs/automatic-ofed-upgrade.md#shared-requestor)flow
