### PR TITLE
fix: checkout ignored helm chart file on release update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -258,6 +258,7 @@ jobs:
                 if echo "$EXCLUDE_CHART_FILES" | jq -e --arg value "$REL_PATH" 'index($value) != null' > /dev/null; then
                   echo "Exclude chart file $file from update"
                   git restore --staged $file
+                  git checkout $file
                 else
                   echo "Update chart file $file"
                 fi


### PR DESCRIPTION
restoring it from staged doesn't roll back the changes