### PR TITLE
chore: Update Maintenance OP Helm sub-chart

### DIFF
--- a/deployment/network-operator/charts/maintenance-operator-chart/README.md
+++ b/deployment/network-operator/charts/maintenance-operator-chart/README.md
@@ -26,6 +26,7 @@ Maintenance Operator Helm Chart
 | operator.serviceAccount.annotations | object | `{}` | set annotations for the operator service account |
 | operator.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | toleration for the operator |
 | operatorConfig | object | `{"logLevel":"info","maxNodeMaintenanceTimeSeconds":null,"maxParallelOperations":null,"maxUnavailable":null}` | operator configuration values. fields here correspond to fields in MaintenanceOperatorConfig CR |
+| operatorConfig.deploy | bool | `false` | deploy operatorConfig custom resource |
 | operatorConfig.logLevel | string | `"info"` | log level configuration |
 | operatorConfig.maxNodeMaintenanceTimeSeconds | string | `nil` | max time for node maintenance |
 | operatorConfig.maxParallelOperations | string | `nil` | max number of parallel operations |

--- a/deployment/network-operator/charts/maintenance-operator-chart/crds/maintenance.nvidia.com_maintenanceoperatorconfigs.yaml
+++ b/deployment/network-operator/charts/maintenance-operator-chart/crds/maintenance.nvidia.com_maintenanceoperatorconfigs.yaml
@@ -50,12 +50,12 @@ spec:
                 - error
                 type: string
               maxNodeMaintenanceTimeSeconds:
-                default: 1600
+                default: 3600
                 description: |-
                   MaxNodeMaintenanceTimeSeconds is the time from when a NodeMaintenance is marked as ready (phase: Ready)
                   until the NodeMaintenance is considered stale and removed by the operator.
                   should be less than idle time for any autoscaler that is running.
-                  default to 30m (1600 seconds)
+                  default to 60m (3600 seconds)
                 format: int32
                 minimum: 0
                 type: integer

--- a/deployment/network-operator/charts/maintenance-operator-chart/templates/deployment.yaml
+++ b/deployment/network-operator/charts/maintenance-operator-chart/templates/deployment.yaml
@@ -27,7 +27,12 @@ spec:
       tolerations: {{- toYaml .Values.operator.tolerations | nindent 8 }}
       nodeSelector: {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       affinity: {{- toYaml .Values.operator.affinity | nindent 8 }}
-      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "maintenance-operator.fullname" . }}-controller-manager

--- a/deployment/network-operator/charts/maintenance-operator-chart/templates/operatorconfig.yaml
+++ b/deployment/network-operator/charts/maintenance-operator-chart/templates/operatorconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operatorConfig.deploy }}
 apiVersion: maintenance.nvidia.com/v1alpha1
 kind: MaintenanceOperatorConfig
 metadata:
@@ -18,4 +19,5 @@ spec:
 {{- end }}
 {{- if .Values.operatorConfig.maxNodeMaintenanceTimeSeconds }}
   maxNodeMaintenanceTimeSeconds: {{ .Values.operatorConfig.maxNodeMaintenanceTimeSeconds }}
+{{- end }}
 {{- end }}

--- a/deployment/network-operator/charts/maintenance-operator-chart/values.yaml
+++ b/deployment/network-operator/charts/maintenance-operator-chart/values.yaml
@@ -79,6 +79,8 @@ operator:
 
 # -- operator configuration values. fields here correspond to fields in MaintenanceOperatorConfig CR
 operatorConfig:
+  # -- deploy operatorConfig CR with the below values
+  deploy: false
   # -- log level configuration
   logLevel: info
   # operatorConfig.maxParallelOperations -- max number of parallel operations

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -197,6 +197,11 @@ nic-configuration-operator-chart:
 
 # Maintenance Operator chart related values.
 maintenance-operator-chart:
+  # -- Deploy MaintenanceOperatorConfig.
+  # Maintenance Operator might be already deployed on the cluster, in that case no need to deploy MaintenanceOperatorConfig.
+  operatorConfig:
+    # -- deploy MaintenanceOperatorConfig CR
+    deploy: false
   operator:
     image:
       repository: nvcr.io/nvstaging/mellanox

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -197,6 +197,11 @@ nic-configuration-operator-chart:
 
 # Maintenance Operator chart related values.
 maintenance-operator-chart:
+  # -- Deploy MaintenanceOperatorConfig.
+  # Maintenance Operator might be already deployed on the cluster, in that case no need to deploy MaintenanceOperatorConfig.
+  operatorConfig:
+    # -- deploy MaintenanceOperatorConfig CR
+    deploy: false
   operator:
     image:
       repository: {{ .MaintenanceOperator.Repository }}


### PR DESCRIPTION
`maintenanceoperatorconfigs` can be deployed by other k8s operators, utilizing Maintennace OP. Using the following change we can control whether to deploy this object or not.

* Update maintenance OP Helm sub-chart.
* Add support in values.yaml to control 'maintenanceoperatorconfigs' deployment