### PR TITLE
ofed-driver: Adjust mount path for Ubuntu system CA certificates

### DIFF
--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -114,7 +114,7 @@ const (
 //
 //nolint:lll
 var CertConfigPathMap = map[string]string{
-	"ubuntu": "/etc/ssl/certs",
+	"ubuntu": "/usr/local/share/ca-certificates",
 	"rhcos":  "/etc/pki/ca-trust/extracted/pem",
 	"rhel":   "/etc/pki/ca-trust/extracted/pem",
 	"sles":   "/etc/ssl",

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -1265,7 +1265,7 @@ func verifyAdditionalMounts(mounts []v1.VolumeMount) {
 	cert := v1.VolumeMount{
 		Name:             "cert-cm",
 		ReadOnly:         true,
-		MountPath:        "/etc/ssl/certs/my-cert",
+		MountPath:        "/usr/local/share/ca-certificates/my-cert",
 		SubPath:          "my-cert",
 		MountPropagation: nil,
 		SubPathExpr:      "",


### PR DESCRIPTION
This PR adds a postStart lifecycle hook in the MOFED container to run update-ca-certificates (Ubuntu/Debian) or update-ca-trust (RHEL/SLES), ensuring system trust store picks up any mounted CA certs.

Tested on: Ubuntu 24.04

This avoids the need to rebuild the image just to inject CA certs.