### PR TITLE
feat: rhcos os-version change no longer requires an annotation for OCP catalog bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ IMAGE_NAME?=network-operator
 CONTROLLER_IMAGE=$(REGISTRY)/$(IMAGE_NAME)
 IMAGE_BUILD_OPTS?=
 BUNDLE_IMG?=network-operator-bundle:$(VERSION)
-BUNDLE_OCP_VERSIONS?=v4.15-v4.18
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 BUILD_ARCH= amd64 arm64
@@ -404,7 +403,7 @@ bundle: $(OPERATOR_SDK) $(KUSTOMIZE) manifests ## Generate bundle manifests and 
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(TAG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	git checkout -- config/manager/kustomization.yaml
-	GO=$(GO) BUNDLE_OCP_VERSIONS=$(BUNDLE_OCP_VERSIONS) TAG=$(TAG) hack/scripts/ocp-bundle-postprocess.sh
+	GO=$(GO) TAG=$(TAG) hack/scripts/ocp-bundle-postprocess.sh
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -13,4 +13,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.15-v4.18

--- a/hack/scripts/ocp-bundle-postprocess.sh
+++ b/hack/scripts/ocp-bundle-postprocess.sh
@@ -35,5 +35,3 @@ rm hack/related_images.yaml
 # Escape the tag annotation value for sed
 ESCAPED_TAG=$(printf '%s\n' "$TAG" | sed -e 's/[]\/$*.^[]/\\&/g')
 sed -i "0,/annotations:/s/annotations:/annotations:\n    containerImage: $ESCAPED_TAG/" bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
-# Add OpenShift versions in metadata/annotations.yaml
-echo "  com.redhat.openshift.versions: $BUNDLE_OCP_VERSIONS" >> bundle/metadata/annotations.yaml


### PR DESCRIPTION
As discussed on RH Slack with @rollandf.