### PR TITLE
fix: add /dev mount to nic config daemon

### DIFF
--- a/deployment/network-operator/charts/nic-configuration-operator-chart/templates/config-daemon.yaml
+++ b/deployment/network-operator/charts/nic-configuration-operator-chart/templates/config-daemon.yaml
@@ -55,6 +55,9 @@ spec:
               readOnly: false
             - name: host
               mountPath: /host
+            - name: dev
+              mountPath: /dev
+              readOnly: false
             {{- if .Values.nicFirmwareStorage.pvcName }}
             - name: firmware-cache
               mountPath: /nic-firmware
@@ -70,6 +73,9 @@ spec:
         - name: host
           hostPath:
             path: /
+        - name: dev
+          hostPath:
+            path: /dev
         {{- if .Values.nicFirmwareStorage.pvcName }}
         - name: firmware-cache
           persistentVolumeClaim:

--- a/manifests/state-nic-configuration-operator/070-config-daemon.yaml
+++ b/manifests/state-nic-configuration-operator/070-config-daemon.yaml
@@ -85,6 +85,8 @@ spec:
               readOnly: false
             - name: host
               mountPath: /host
+            - name: dev
+              mountPath: /dev
           {{- if .CrSpec.NicFirmwareStorage }}
             - name: firmware-cache
               mountPath: /nic-firmware
@@ -100,6 +102,9 @@ spec:
         - name: host
           hostPath:
             path: /
+        - name: dev
+          hostPath:
+            path: /dev
         {{- if .CrSpec.NicFirmwareStorage }}
         - name: firmware-cache
           persistentVolumeClaim:


### PR DESCRIPTION
This mount is needed for access to rshim devices