### PR TITLE
chore: support GA releases in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,17 +78,6 @@ jobs:
       run: |
         git_tag=${{ github.ref_name }}
 
-        # If this is a GA release (no hyphen in tag), update necessary files
-        if ! echo $git_tag | grep -q "-"; then
-          # Update files for GA release
-          echo "Updating files for GA release $git_tag"
-          yq -i '.NetworkOperator.repository = "nvcr.io/nvidia/cloud-native"' hack/release.yaml
-          yq -i '.SriovNetworkOperator.repository = "nvcr.io/nvidia/mellanox"' hack/release.yaml
-          yq -i '.SriovNetworkOperatorWebhook.repository = "nvcr.io/nvidia/mellanox"' hack/release.yaml
-          yq -i '.SriovConfigDaemon.repository = "nvcr.io/nvidia/mellanox"' hack/release.yaml
-          make release-build
-        fi
-
         APP_VERSION=$git_tag VERSION=${git_tag:1} make chart-build chart-push  # VERSION as 'v' prefix removed
 
   ocp-bundle:

--- a/.github/workflows/release-pr-checker.yaml
+++ b/.github/workflows/release-pr-checker.yaml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Wait for CI checks
+        # We skip the checks for GA release PRs, as they refer to not yet available images and will fail the CI.
+        # All the functionality was tested with the previous release candidate, so these checks are not mandatory.
+        if: (!startsWith(github.head_ref, 'staging')) || contains(github.head_ref, 'beta') || contains(github.head_ref, 'rc')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -114,6 +117,18 @@ jobs:
               $PRERELEASE_FLAG
 
             echo "Successfully created GitHub release: $VERSION"
+
+            # Find and close related GitHub issue
+            echo "Searching for GitHub issue with version: $VERSION"
+            ISSUE_NUMBER=$(gh issue list --search "$VERSION in:title" --state open --json number --jq '.[0].number' || echo "")
+            
+            if [ -n "$ISSUE_NUMBER" ] && [ "$ISSUE_NUMBER" != "null" ]; then
+              echo "Found issue #$ISSUE_NUMBER for version $VERSION. Closing it..."
+              gh issue close "$ISSUE_NUMBER" --comment "Closed automatically after releasing $VERSION"
+              echo "Successfully closed issue #$ISSUE_NUMBER"
+            else
+              echo "No open issue found for version $VERSION"
+            fi
           else
             echo "Not creating release - source branch is not staging-*"
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,15 @@ jobs:
           fi
           echo "base_branch=${base_branch}" >> $GITHUB_OUTPUT
           echo BASE_BRANCH=$base_branch | tee -a $GITHUB_ENV
+      - id: determine-docker-registry
+        run: |
+          if echo $APP_VERSION | grep -q '-'; then
+            echo "docker_registry_network_operator=nvcr.io/nvstaging/mellanox" >> $GITHUB_OUTPUT
+            echo "docker_registry_managed_components=nvcr.io/nvstaging/mellanox" >> $GITHUB_OUTPUT
+          else
+            echo "docker_registry_network_operator=nvcr.io/nvidia/cloud-native" >> $GITHUB_OUTPUT
+            echo "docker_registry_managed_components=nvcr.io/nvidia/mellanox" >> $GITHUB_OUTPUT
+          fi
       - name: Verify release branch exists if "rc" version
         run: |
           if echo $APP_VERSION | grep -q 'rc'; then
@@ -64,7 +73,9 @@ jobs:
       base_branch: ${{ steps.determine-base-branch.outputs.base_branch }}
       chart_version: ${{ steps.set-chart-version.outputs.chart_version }}
       component_tag: ${{ steps.set-version.outputs.component_tag }}
-      docker_registry: nvcr.io/nvstaging/mellanox
+      docker_registry_network_operator: ${{ steps.determine-docker-registry.outputs.docker_registry_network_operator }}
+      docker_registry_managed_components: ${{ steps.determine-docker-registry.outputs.docker_registry_managed_components }}
+      docker_registry_staging: nvcr.io/nvstaging/mellanox
       release_branch: ${{ steps.set-version.outputs.release_branch }}
 
   get-managed-components:
@@ -137,7 +148,7 @@ jobs:
     needs: [determine-versions, get-managed-components, create-tags-for-components]
     env:
       COMPONENT_TAG: ${{ needs.determine-versions.outputs.component_tag }}
-      DOCKER_REGISTRY: ${{ needs.determine-versions.outputs.docker_registry }}
+      DOCKER_REGISTRY: ${{ needs.determine-versions.outputs.docker_registry_staging }}
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -188,7 +199,8 @@ jobs:
       APP_VERSION: ${{ needs.determine-versions.outputs.app_version }}
       BASE_BRANCH: ${{ needs.determine-versions.outputs.base_branch }}
       CHART_VERSION: ${{ needs.determine-versions.outputs.chart_version }}
-      DOCKER_REGISTRY: ${{ needs.determine-versions.outputs.docker_registry }}
+      DOCKER_REGISTRY_NETWORK_OPERATOR: ${{ needs.determine-versions.outputs.docker_registry_network_operator }}
+      DOCKER_REGISTRY_MANAGED_COMPONENTS: ${{ needs.determine-versions.outputs.docker_registry_managed_components }}
       COMPONENT_TAG: ${{ needs.determine-versions.outputs.component_tag }}
     steps:
       - uses: actions/checkout@v4
@@ -216,6 +228,7 @@ jobs:
 
           # Update Network Operator version
           yq -i '.NetworkOperator.version = "${{ env.APP_VERSION }}"' hack/release.yaml
+          yq -i '.NetworkOperator.repository = "${{ env.DOCKER_REGISTRY_NETWORK_OPERATOR }}"' hack/release.yaml
           
           # Update components with sourceRepository to use new registry and version
           for component in $(yq 'keys | .[]' hack/release.yaml); do
@@ -227,13 +240,12 @@ jobs:
             fi
             
             echo "Updating component: $component"
-            echo "  Setting repository to: $DOCKER_REGISTRY"
+            echo "  Setting repository to: $DOCKER_REGISTRY_MANAGED_COMPONENTS"
             echo "  Setting version to: $COMPONENT_TAG"
             
             # Update repository and version for components with sourceRepository
-            yq -i ".${component}.repository = \"$DOCKER_REGISTRY\"" hack/release.yaml
+            yq -i ".${component}.repository = \"$DOCKER_REGISTRY_MANAGED_COMPONENTS\"" hack/release.yaml
             yq -i ".${component}.version = \"$COMPONENT_TAG\"" hack/release.yaml
-
 
             # Pull the component's helm chart
             CHART_LOCATION=$(yq ".${component}.chartLocation" hack/release.yaml)

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -112,6 +112,7 @@ maintenanceOperator:
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: maintenance-operator
   version: network-operator-v25.7.0-beta.3
+  chartLocation: deployment/maintenance-operator-chart
 spectrumXOperator:
   image: spectrum-x-operator
   repository: nvcr.io/nvstaging/mellanox


### PR DESCRIPTION
when creating a GA release, update image references to ngc public and skip the CI checks.

Also add support for maintenance operator helm chart