### PR TITLE
fix: checkout maintenance op repo in the release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,6 +215,11 @@ jobs:
           ref: ${{ needs.determine-versions.outputs.release_branch }}
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.repository_owner }}/maintenance-operator
+          path: maintenance-operator
+          ref: ${{ needs.determine-versions.outputs.release_branch }}
+      - uses: actions/checkout@v4
+        with:
           repository: ${{ github.repository_owner }}/network-operator
           path: network-operator
       - name: Create staging branch and update component versions


### PR DESCRIPTION
otherwise we can't check for helm chart updates