### PR TITLE
fix: another small fix to helm charts in release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -259,7 +259,12 @@ jobs:
               continue
             fi
 
-            CHART_LOCATION_IN_NETWORK_OPERATOR=deployment/network-operator/charts/$SOURCE_REPO
+            CHART_NAME=$(yq ".${component}.chartName" hack/release.yaml)
+            # Use SOURCE_REPO if chartName is null or empty
+            if [ "$CHART_NAME" = "null" ] || [ -z "$CHART_NAME" ]; then
+              CHART_NAME=$SOURCE_REPO
+            fi
+            CHART_LOCATION_IN_NETWORK_OPERATOR=deployment/network-operator/charts/$CHART_NAME
             rm -rf $CHART_LOCATION_IN_NETWORK_OPERATOR/*
             cp -r ../$SOURCE_REPO/$CHART_LOCATION/* $CHART_LOCATION_IN_NETWORK_OPERATOR
 

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -113,6 +113,7 @@ maintenanceOperator:
   sourceRepository: maintenance-operator
   version: network-operator-v25.7.0-beta.3
   chartLocation: deployment/maintenance-operator-chart
+  chartName: maintenance-operator-chart
 spectrumXOperator:
   image: spectrum-x-operator
   repository: nvcr.io/nvstaging/mellanox


### PR DESCRIPTION
maintenance op chart has a different name pattern in the network operator, need to account for that