### PR TITLE
fix: support custom CA certificate update on Ubuntu

### DIFF
--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -114,7 +114,7 @@ const (
 //
 //nolint:lll
 var CertConfigPathMap = map[string]string{
-	"ubuntu": "/etc/ssl/certs",
+	"ubuntu": "/usr/local/share/ca-certificates",
 	"rhcos":  "/etc/pki/ca-trust/extracted/pem",
 	"rhel":   "/etc/pki/ca-trust/extracted/pem",
 	"sles":   "/etc/ssl",

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -1265,7 +1265,7 @@ func verifyAdditionalMounts(mounts []v1.VolumeMount) {
 	cert := v1.VolumeMount{
 		Name:             "cert-cm",
 		ReadOnly:         true,
-		MountPath:        "/etc/ssl/certs/my-cert",
+		MountPath:        "/usr/local/share/ca-certificates/my-cert",
 		SubPath:          "my-cert",
 		MountPropagation: nil,
 		SubPathExpr:      "",


### PR DESCRIPTION
- Adjust mount path to /usr/local/share/ca-certificates
- Fix unit tests for cert mount validation