### PR TITLE
fix: increase default resource requirements for NIC Config Operator

### DIFF
--- a/manifests/state-nic-configuration-operator/060-operator.yaml
+++ b/manifests/state-nic-configuration-operator/060-operator.yaml
@@ -113,10 +113,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 256Mi
             requests:
-              cpu: 10m
-              memory: 64Mi
+              cpu: 100m
+              memory: 256Mi
           {{- end }}
           {{- if .CrSpec.NicFirmwareStorage }}
           volumeMounts:

--- a/manifests/state-nic-configuration-operator/070-config-daemon.yaml
+++ b/manifests/state-nic-configuration-operator/070-config-daemon.yaml
@@ -60,10 +60,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 512Mi
             requests:
-              cpu: 10m
-              memory: 64Mi
+              cpu: 100m
+              memory: 512Mi
           {{- end }}
           env:
             - name: NODE_NAME


### PR DESCRIPTION
since the last update the functionality of the operator grew and the current resource requirements are not sufficient, which may lead to OOM errors on some setups. Let's increase the default values