### PR TITLE
feat: add STIG compliance adjustments to hack/release files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -289,8 +289,9 @@ jobs:
           done
 
           # Special handling for Mofed component (update registry only, not version, for all releases)
-          echo "Updating Mofed component registry for release"
-          yq -i '.Mofed.repository = "${{ env.DOCKER_REGISTRY_MANAGED_COMPONENTS }}"' hack/release.yaml
+          echo "Updating Mofed components registry for release"
+          yq -i     '.Mofed.repository = "${{ env.DOCKER_REGISTRY_MANAGED_COMPONENTS }}"' hack/release.yaml
+          yq -i '.MofedStig.repository = "${{ env.DOCKER_REGISTRY_MANAGED_COMPONENTS }}"' hack/release.yaml
 
           # Update chart versions
           yq -i '.version = "${{ env.CHART_VERSION }}"'  deployment/network-operator/Chart.yaml

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -38,6 +38,10 @@ Mofed:
   image: doca-driver
   repository: nvcr.io/nvstaging/mellanox
   version: doca3.2.0-25.10-1.0.0.0-0
+MofedStig:
+  image: doca-driver-stig
+  repository: nvcr.io/nvstaging/mellanox
+  version: doca3.2.0-25.10-1.0.0.0-0
 RdmaSharedDevicePlugin:
   image: k8s-rdma-shared-dev-plugin
   repository: nvcr.io/nvstaging/mellanox


### PR DESCRIPTION
this PR is coupled with https://github.com/Mellanox/doca-driver-build/pull/163 and with the merge request in our internal CI (so should be merged at the ‘same’ time).