### PR TITLE
fix: Driver re-build after OCP kernel change

### DIFF
--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -177,11 +177,11 @@ spec:
           command: [bash, -xc]
           args:
             - |
-              until [ -f /mnt/shared-doca-driver-toolkit/dtk_start_compile ]; do
+              until [ -f /mnt/shared-doca-driver-toolkit/{{ .RuntimeSpec.Kernel }}/dtk_start_compile ]; do
                 echo Waiting for mofed-container container to prepare the shared directory
                 sleep 3
               done
-              exec /mnt/shared-doca-driver-toolkit/dtk_nic_driver_build.sh
+              exec /mnt/shared-doca-driver-toolkit/{{ .RuntimeSpec.Kernel }}/dtk_nic_driver_build.sh
           env:
             - name: DTK_OCP_NIC_SHARED_DIR
               value: "/mnt/shared-doca-driver-toolkit"


### PR DESCRIPTION
We need to store driver build in kernel-speciffic directory to not re-load it after kernel was changed.

Related to: https://github.com/Mellanox/doca-driver-build/pull/166