### PR TITLE
fix: allow precompiled doca tag in webhook

### DIFF
--- a/api/v1alpha1/validator/nicclusterpolicy_webhook.go
+++ b/api/v1alpha1/validator/nicclusterpolicy_webhook.go
@@ -468,7 +468,7 @@ func (ofedSpec *ofedDriverSpecWrapper) validateVersion(fldPath *field.Path) fiel
 	// Perform version validation logic here
 	if !isValidOFEDVersion(ofedSpec.Version) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), ofedSpec.Version,
-			`invalid OFED version, supported formats: "23.10-0.2.2.0", "24.01-0.3.3.1-0", "doca3.1-24.01-0.3.3.1-0", "sha256:9a831bfdf85f313b1f5749b7c9b2673bb8fff18b4ff768c9242dabaa4468e449"`))
+			`invalid OFED version, supported formats: "23.10-0.2.2.0", "24.01-0.3.3.1-0", "25.01-0.6.0.0-0-6.8.0-1019-oracle-ubuntu22.04-arm64", "doca3.1-24.01-0.3.3.1-0", "doca3.1-25.07-0.9.7.0-0-5.14.0-427.87.1.el9_4.x86_64-rhcos4.18-amd64", "sha256:9a831bfdf85f313b1f5749b7c9b2673bb8fff18b4ff768c9242dabaa4468e449"`))
 	}
 	return allErrs
 }
@@ -711,9 +711,11 @@ func isValidOFEDVersion(version string) bool {
 	// Support multiple OFED version formats:
 	// 1. Old scheme: "23.10-0.2.2.0" or "23.10-0.2.2.0.1"
 	// 2. New scheme: "24.01-0.3.3.1-0"
-	// 3. DOCA prefix: "doca3.1.0-25.07-0.6.6.0-0"
-	// 4. SHA256 format: "sha256:9a831bfdf85f313b1f5749b7c9b2673bb8fff18b4ff768c9242dabaa4468e449"
-	versionPattern := `^(sha256:[a-fA-F0-9]{64}|doca\d+\.\d+\.\d+-\d+\.\d+-\d+\.\d+\.\d+\.\d+-\d+|\d+\.\d+-\d+(\.\d+)*(-\d+)?)$`
+	// 3. New scheme with kernel-specific suffix: "25.01-0.6.0.0-0-6.8.0-1019-oracle-ubuntu22.04-arm64"
+	// 4. DOCA prefix: "doca3.1.0-25.07-0.6.6.0-0"
+	// 5. DOCA prefix with kernel-specific suffix: "doca3.1-25.07-0.9.7.0-0-5.14.0-427.87.1.el9_4.x86_64-rhcos4.18-amd64"
+	// 6. SHA256 format: "sha256:9a831bfdf85f313b1f5749b7c9b2673bb8fff18b4ff768c9242dabaa4468e449"
+	versionPattern := `^(sha256:[a-fA-F0-9]{64}|doca\d+\.\d+(\.\d+)?-\d+\.\d+-\d+\.\d+\.\d+\.\d+-\d+(-[\w\.\-]+)*|\d+\.\d+-\d+(\.\d+)*(-\d+)?(-[\w\.\-]+)*)$`
 	versionRegex := regexp.MustCompile(versionPattern)
 	return versionRegex.MatchString(version)
 }

--- a/api/v1alpha1/validator/nicclusterpolicy_webhook_test.go
+++ b/api/v1alpha1/validator/nicclusterpolicy_webhook_test.go
@@ -154,6 +154,42 @@ var _ = Describe("Validate", func() {
 			_, err := validator.ValidateCreate(context.TODO(), nicClusterPolicy)
 			Expect(err).NotTo(HaveOccurred())
 		})
+		It("Valid MOFED version (with doca prefix and kernel-specific suffix)", func() {
+			validator := nicClusterPolicyValidator{}
+			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						ImageSpec: v1alpha1.ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "doca3.1-25.07-0.9.7.0-0-5.14.0-427.87.1.el9_4.x86_64-rhcos4.18-amd64",
+							ImagePullSecrets: []string{},
+						},
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(context.TODO(), nicClusterPolicy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Valid MOFED version (with doca prefix and kernel-specific suffix for Ubuntu)", func() {
+			validator := nicClusterPolicyValidator{}
+			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						ImageSpec: v1alpha1.ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "doca3.1.0-25.07-0.9.7.0-0-5.15.0-151-generic-ubuntu22.04-amd64",
+							ImagePullSecrets: []string{},
+						},
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(context.TODO(), nicClusterPolicy)
+			Expect(err).NotTo(HaveOccurred())
+		})
 		It("Valid MOFED version", func() {
 			validator := nicClusterPolicyValidator{}
 			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
@@ -164,6 +200,24 @@ var _ = Describe("Validate", func() {
 							Image:            "mofed",
 							Repository:       "ghcr.io/mellanox",
 							Version:          "24.01-0.3.3.1-0",
+							ImagePullSecrets: []string{},
+						},
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(context.TODO(), nicClusterPolicy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Valid MOFED version (with kernel-specific suffix for ARM64)", func() {
+			validator := nicClusterPolicyValidator{}
+			nicClusterPolicy := &v1alpha1.NicClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.NicClusterPolicySpec{
+					OFEDDriver: &v1alpha1.OFEDDriverSpec{
+						ImageSpec: v1alpha1.ImageSpec{
+							Image:            "mofed",
+							Repository:       "ghcr.io/mellanox",
+							Version:          "25.01-0.6.0.0-0-6.8.0-1019-oracle-ubuntu22.04-arm64",
 							ImagePullSecrets: []string{},
 						},
 					},


### PR DESCRIPTION
For example:
doca3.1-25.07-0.9.7.0-0-5.14.0-427.87.1.el9_4.x86_64-rhcos4.18-amd64 doca3.1.0-25.07-0.9.7.0-0-5.15.0-151-generic-ubuntu22.04-amd64 25.01-0.6.0.0-0-6.8.0-1019-oracle-ubuntu22.04-arm64