### PR TITLE
feat: manage nvidia.com/operator.nic-configuration.wait label

### DIFF
--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -176,6 +176,9 @@ sriov-network-operator:
     configDaemonNodeSelector:
       beta.kubernetes.io/os: "linux"
       network.nvidia.com/operator.mofed.wait: "false"
+      # Enable when using together with NIC Configuration Operator to wait until
+      # all required FW parameters are successfully applied before configuring SR-IOV
+      # network.nvidia.com/operator.nic-configuration.wait: "false"
 
 # Maintenance Operator chart related values.
 maintenance-operator-chart:

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -176,6 +176,9 @@ sriov-network-operator:
     configDaemonNodeSelector:
       beta.kubernetes.io/os: "linux"
       network.nvidia.com/operator.mofed.wait: "false"
+      # Enable when using together with NIC Configuration Operator to wait until
+      # all required FW parameters are successfully applied before configuring SR-IOV
+      # network.nvidia.com/operator.nic-configuration.wait: "false"
 
 # Maintenance Operator chart related values.
 maintenance-operator-chart:

--- a/manifests/state-nic-configuration-operator/070-config-daemon.yaml
+++ b/manifests/state-nic-configuration-operator/070-config-daemon.yaml
@@ -14,6 +14,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: nic-configuration-daemon
       labels:
+        nvidia.com/nic-configuration-daemon: ""
         app.kubernetes.io/name: nic-configuration-daemon
     spec:
       serviceAccountName: nic-configuration-operator

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -34,6 +34,8 @@ const (
 	NicClusterPolicyResourceName = "nic-cluster-policy"
 	// OfedDriverLabel is the label key for ofed driver Pods and DaemonSets.
 	OfedDriverLabel = "nvidia.com/ofed-driver"
+	// NicConfigurationDaemonLabel is the label key for nic-configuration-daemon Pods and DaemonSets.
+	NicConfigurationDaemonLabel = "nvidia.com/nic-configuration-daemon"
 	// StateLabel is the label key describing which state the operator created a Kubernetes object from.
 	StateLabel = "nvidia.network-operator.state"
 	// DefaultCniBinDirectory is the default location of the CNI binaries on a host.

--- a/pkg/nodeinfo/attributes.go
+++ b/pkg/nodeinfo/attributes.go
@@ -32,6 +32,7 @@ const (
 	NodeLabelMlnxNIC          = "feature.node.kubernetes.io/pci-15b3.present"
 	NodeLabelNvGPU            = "nvidia.com/gpu.present"
 	NodeLabelWaitOFED         = "network.nvidia.com/operator.mofed.wait"
+	NodeLabelWaitNicConfig    = "network.nvidia.com/operator.nic-configuration.wait"
 	NodeLabelCudaVersionMajor = "nvidia.com/cuda.driver.major"
 	NodeLabelOSTreeVersion    = "feature.node.kubernetes.io/system-os_release.OSTREE_VERSION"
 )


### PR DESCRIPTION
When NIC Configuration Operator is disabled, manage the label similar to how the mofed.wait label is managed