### PR TITLE
fix: update component to MofedStigFips and use local var in loop for setting component versions in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,7 +179,7 @@ jobs:
             echo "Checking availability of: ${image_url}"
 
             while [ $retry_count -lt $MAX_RETRIES ]; do
-              if docker manifest inspect "${DOCKER_REGISTRY}/${image}:${component_tag}" > /dev/null 2>&1; then
+              if docker manifest inspect "${image_url}" > /dev/null 2>&1; then
                 echo "Image available: ${image_url}"
                 break
               else


### PR DESCRIPTION
changes:
- fix: update component MofedStig to MofedStig**Fips** (line 300).
- fix: use separate local variable when determining component tag in release workflow (lines 250-259).
- fix: set '-stig-fips' component tag when relevant when waiting for images.
- chore: cleanup of trailing whitespace (rest of diff).