### PR TITLE
fix: support env vars for NIC operator

### DIFF
--- a/api/v1alpha1/nicclusterpolicy_types.go
+++ b/api/v1alpha1/nicclusterpolicy_types.go
@@ -322,6 +322,8 @@ type NicConfigurationOperatorSpec struct {
 	Operator *ImageSpec `json:"operator"`
 	// Image information for nic-configuration-daemon
 	ConfigurationDaemon *ImageSpec `json:"configurationDaemon"`
+	// List of environment variables to set in the NIC Configuration Operator and NIC Configuration Daemon containers.
+	Env []v1.EnvVar `json:"env,omitempty"`
 	// NicFirmwareStorage contains configuration for the NIC firmware storage. If not provided, the NIC firmware storage will not be configured.
 	NicFirmwareStorage *NicFirmwareStorageSpec `json:"nicFirmwareStorage,omitempty"`
 	// LogLevel sets the verbosity level of the logs. info|debug

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -712,6 +712,13 @@ func (in *NicConfigurationOperatorSpec) DeepCopyInto(out *NicConfigurationOperat
 		*out = new(ImageSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.NicFirmwareStorage != nil {
 		in, out := &in.NicFirmwareStorage, &out.NicFirmwareStorage
 		*out = new(NicFirmwareStorageSpec)

--- a/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
+++ b/config/crd/bases/mellanox.com_nicclusterpolicies.yaml
@@ -526,6 +526,127 @@ spec:
                     - repository
                     - version
                     type: object
+                  env:
+                    description: List of environment variables to set in the NIC Configuration
+                      Operator and NIC Configuration Daemon containers.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   logLevel:
                     default: info
                     description: LogLevel sets the verbosity level of the logs. info|debug

--- a/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
+++ b/deployment/network-operator/crds/mellanox.com_nicclusterpolicies.yaml
@@ -526,6 +526,127 @@ spec:
                     - repository
                     - version
                     type: object
+                  env:
+                    description: List of environment variables to set in the NIC Configuration
+                      Operator and NIC Configuration Daemon containers.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   logLevel:
                     default: info
                     description: LogLevel sets the verbosity level of the logs. info|debug

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.yaml
@@ -108,6 +108,11 @@ spec:
       image: nic-configuration-operator-daemon
       repository: nvcr.io/nvstaging/mellanox
       version: network-operator-v25.10.0-beta.5
+    # Uncomment to explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration.
+    # Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.
+    # env:
+    # - name: "FW_RESET_AFTER_CONFIG_UPDATE"
+    #   value: "true"
     nicFirmwareStorage:
       create: true
       pvcName: nic-fw-storage-pvc

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
@@ -120,6 +120,11 @@ spec:
       image: nic-configuration-operator-daemon
       repository: nvcr.io/nvstaging/mellanox
       version: network-operator-v25.10.0-beta.5
+    # Uncomment to explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration.
+    # Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.
+    # env:
+    # - name: "FW_RESET_AFTER_CONFIG_UPDATE"
+    #   value: "true"
     nicFirmwareStorage:
       create: true
       pvcName: nic-fw-storage-pvc

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full-ocp.template
@@ -108,6 +108,11 @@ spec:
       image: {{ .NicConfigurationConfigDaemon.Image }}
       repository: {{ .NicConfigurationConfigDaemon.Repository }}
       version: {{ .NicConfigurationConfigDaemon.Version }}
+    # Uncomment to explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration.
+    # Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.
+    # env:
+    # - name: "FW_RESET_AFTER_CONFIG_UPDATE"
+    #   value: "true"
     nicFirmwareStorage:
       create: true
       pvcName: nic-fw-storage-pvc

--- a/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.template
+++ b/hack/templates/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.template
@@ -120,6 +120,11 @@ spec:
       image: {{ .NicConfigurationConfigDaemon.Image }}
       repository: {{ .NicConfigurationConfigDaemon.Repository }}
       version: {{ .NicConfigurationConfigDaemon.Version }}
+    # Uncomment to explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration.
+    # Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.
+    # env:
+    # - name: "FW_RESET_AFTER_CONFIG_UPDATE"
+    #   value: "true"
     nicFirmwareStorage:
       create: true
       pvcName: nic-fw-storage-pvc

--- a/manifests/state-nic-configuration-operator/060-operator.yaml
+++ b/manifests/state-nic-configuration-operator/060-operator.yaml
@@ -85,6 +85,11 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ .CrSpec.LogLevel }}
+            {{- if .CrSpec.Env }}
+            {{- range .CrSpec.Env }}
+              {{ . | yaml | nindentPrefix 14 "- " }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/manifests/state-nic-configuration-operator/070-config-daemon.yaml
+++ b/manifests/state-nic-configuration-operator/070-config-daemon.yaml
@@ -80,6 +80,11 @@ spec:
                   fieldPath: metadata.namespace
             - name: LOG_LEVEL
               value: {{ .CrSpec.LogLevel }}
+            {{- if .CrSpec.Env }}
+            {{- range .CrSpec.Env }}
+              {{ . | yaml | nindentPrefix 14 "- " }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: sys
               mountPath: /sys


### PR DESCRIPTION
We need that for the DGX use case to support mlxfwreset before rebooting the node