### PR TITLE
fix: inspect arch-specific tag in multi-arch manifest creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ image-build-multiarch: $(addprefix image-build-,$(BUILD_ARCH))
 
 DOCKER_MANIFEST_CREATE_ARGS?="--amend"
 image-manifest-for-arch: $(addprefix image-push-for-arch-,$(BUILD_ARCH))
-	$(IMAGE_BUILDER) manifest create $(DOCKER_MANIFEST_CREATE_ARGS)  $(CONTROLLER_IMAGE):$(VERSION) $(shell $(IMAGE_BUILDER) inspect --format='{{index .RepoDigests 0}}' $(CONTROLLER_IMAGE):$(VERSION))
+	$(IMAGE_BUILDER) manifest create $(DOCKER_MANIFEST_CREATE_ARGS)  $(CONTROLLER_IMAGE):$(VERSION) $(shell $(IMAGE_BUILDER) inspect --format='{{index .RepoDigests 0}}' $(CONTROLLER_IMAGE):$(VERSION)-$(ARCH))
 
 image-push-for-arch-%:
 	$(IMAGE_BUILDER) tag $(CONTROLLER_IMAGE):$(VERSION)-$(ARCH) $(CONTROLLER_IMAGE):$(VERSION)


### PR DESCRIPTION
Changed docker inspect to use $(VERSION)-$(ARCH) instead of $(VERSION) to avoid "is a manifest list" error when building multiple architectures. The generic tag becomes a manifest list after the first arch is built, causing subsequent builds to fail with newer Docker versions.