### PR TITLE
fix: correct multi-arch manifest creation for docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,19 +330,16 @@ image-build-%:
 .PHONY: image-build-multiarch
 image-build-multiarch: $(addprefix image-build-,$(BUILD_ARCH))
 
-DOCKER_MANIFEST_CREATE_ARGS?="--amend"
-image-manifest-for-arch: $(addprefix image-push-for-arch-,$(BUILD_ARCH))
-	$(IMAGE_BUILDER) manifest create $(DOCKER_MANIFEST_CREATE_ARGS)  $(CONTROLLER_IMAGE):$(VERSION) $(shell $(IMAGE_BUILDER) inspect --format='{{index .RepoDigests 0}}' $(CONTROLLER_IMAGE):$(VERSION)-$(ARCH))
-
 image-push-for-arch-%:
-	$(IMAGE_BUILDER) tag $(CONTROLLER_IMAGE):$(VERSION)-$(ARCH) $(CONTROLLER_IMAGE):$(VERSION)
+	$(IMAGE_BUILDER) tag $(CONTROLLER_IMAGE):$(VERSION)-$* $(CONTROLLER_IMAGE):$(VERSION)
 	$(IMAGE_BUILDER) push $(CONTROLLER_IMAGE):$(VERSION)
-
-image-manifest-for-arch-%:
-	$(MAKE) ARCH=$* image-manifest-for-arch
+	$(IMAGE_BUILDER) rmi $(CONTROLLER_IMAGE):$(VERSION)
 
 .PHONY: image-push-multiarch
-image-push-multiarch: $(addprefix image-manifest-for-arch-,$(BUILD_ARCH))
+image-push-multiarch: $(addprefix image-push-for-arch-,$(BUILD_ARCH))
+	$(IMAGE_BUILDER) manifest rm $(CONTROLLER_IMAGE):$(VERSION) 2>/dev/null || true
+	$(IMAGE_BUILDER) manifest create $(CONTROLLER_IMAGE):$(VERSION) \
+		$(foreach arch,$(BUILD_ARCH),$(shell $(IMAGE_BUILDER) inspect --format='{{index .RepoDigests 0}}' $(CONTROLLER_IMAGE):$(VERSION)-$(arch)))
 	$(IMAGE_BUILDER) manifest push  $(CONTROLLER_IMAGE):$(VERSION)
 
 .PHONY: chart-build


### PR DESCRIPTION
Fixed two issues in the multi-arch build process:
1. image-push-for-arch-% now uses $* instead of $(ARCH) to correctly reference the matched architecture pattern
2. Simplified manifest creation to push all architectures first, then create the manifest once with all digests in a single command

This resolves the "is a manifest list" error that occurred when newer Docker/Podman versions tried to add a manifest list to itself.