### PR TITLE
fix: resolve multi-arch manifest creation with modern docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,9 +331,7 @@ image-build-%:
 image-build-multiarch: $(addprefix image-build-,$(BUILD_ARCH))
 
 image-push-for-arch-%:
-	$(IMAGE_BUILDER) tag $(CONTROLLER_IMAGE):$(VERSION)-$* $(CONTROLLER_IMAGE):$(VERSION)
-	$(IMAGE_BUILDER) push $(CONTROLLER_IMAGE):$(VERSION)
-	$(IMAGE_BUILDER) rmi $(CONTROLLER_IMAGE):$(VERSION)
+	$(IMAGE_BUILDER) push $(CONTROLLER_IMAGE):$(VERSION)-$*
 
 .PHONY: image-push-multiarch
 image-push-multiarch: $(addprefix image-push-for-arch-,$(BUILD_ARCH))


### PR DESCRIPTION
Push arch-specific tags only (VERSION-amd64, VERSION-arm64) to avoid registry auto-creating manifest lists. Then create the multi-arch manifest from individual image digests in a single command.

This fixes the "is a manifest list" error that surfaced with newer Docker/Podman versions which are stricter about manifest handling.