### PR TITLE
fix: use Docker Buildx for multi-arch CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,25 +20,42 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Determine docker tags
+      id: docker-tags
       run: |
         git_sha=$(git rev-parse --short=12 HEAD)                                  # short git commit hash
         git_tag=${{ github.ref_type == 'tag' && github.ref_name || '' }}       # git tag, if triggered by tag event
         latest=${{ github.ref_name == env.DEFAULT_BRANCH && 'latest' || '' }}  # 'latest', if branch is master
-        echo DOCKER_TAGS=""$git_sha $git_tag $latest"" | tee -a $GITHUB_ENV
+        
+        # Build comma-separated tags for docker/build-push-action
+        tags=""
+        for tag in $git_sha $git_tag $latest; do
+          if [ -n "$tag" ]; then
+            if [ -z "$tags" ]; then
+              tags="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$tag"
+            else
+              tags="$tags,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$tag"
+            fi
+          fi
+        done
+        echo "tags=$tags" | tee -a $GITHUB_OUTPUT
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-config: /etc/buildkit/buildkitd.toml
     - uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ secrets.NVCR_USERNAME }}
         password: ${{ secrets.NVCR_TOKEN }}
-    - name: Make build and push
-      env:
-        TAG: mellanox/${{ env.IMAGE_NAME }}
-        GOPROXY: ${{ secrets.GO_PROXY_URL }}
-      run: |
-        echo "Docker tags will be: $DOCKER_TAGS"
-        for docker_tag in $DOCKER_TAGS; do
-          make VERSION=$docker_tag image-build-multiarch image-push-multiarch
-        done
+    - uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.docker-tags.outputs.tags }}
+        push: true
+        build-args: |
+          GOPROXY=${{ secrets.GO_PROXY_URL || 'direct' }}
     outputs:
       default_branch: ${{ env.DEFAULT_BRANCH }}  # we output this here, to use in the following job's conditioning (due to github actions environment variable scope limitations).
 

--- a/Makefile
+++ b/Makefile
@@ -331,25 +331,15 @@ image-build-%:
 image-build-multiarch: $(addprefix image-build-,$(BUILD_ARCH))
 
 image-push-for-arch-%:
-	$(IMAGE_BUILDER) push $(CONTROLLER_IMAGE):$(VERSION)-$* 2>&1 | tee $(VERSION)-$*.push.log
-	@digest=$$(grep -o 'digest: sha256:[a-f0-9]*' $(VERSION)-$*.push.log | tail -1 | sed 's/digest: //' | awk '{print $$1}'); \
-	if [ -z "$$digest" ]; then \
-		digest=$$($(IMAGE_BUILDER) inspect $(CONTROLLER_IMAGE):$(VERSION)-$* --format '{{range .RepoDigests}}{{println .}}{{end}}' | head -n1 | cut -d@ -f2); \
-	fi; \
-	echo "$$digest" > $(VERSION)-$*.digest
+	$(IMAGE_BUILDER) tag $(CONTROLLER_IMAGE):$(VERSION)-$* $(CONTROLLER_IMAGE):$(VERSION)
+	$(IMAGE_BUILDER) push $(CONTROLLER_IMAGE):$(VERSION)
 
 .PHONY: image-push-multiarch
 image-push-multiarch: $(addprefix image-push-for-arch-,$(BUILD_ARCH))
 	$(IMAGE_BUILDER) manifest rm $(CONTROLLER_IMAGE):$(VERSION) 2>/dev/null || true
-	@set -e; \
-	digests=""; \
-	for arch in $(BUILD_ARCH); do \
-		digest=$$(cat $(VERSION)-$$arch.digest); \
-		digests="$$digests $(CONTROLLER_IMAGE)@$$digest"; \
-	done; \
-	$(IMAGE_BUILDER) manifest create $(CONTROLLER_IMAGE):$(VERSION) $$digests
-	$(IMAGE_BUILDER) manifest push  $(CONTROLLER_IMAGE):$(VERSION)
-	rm -f $(VERSION)-*.push.log $(VERSION)-*.digest
+	$(IMAGE_BUILDER) manifest create $(CONTROLLER_IMAGE):$(VERSION) \
+		$(foreach arch,$(BUILD_ARCH),$(CONTROLLER_IMAGE):$(VERSION)-$(arch))
+	$(IMAGE_BUILDER) manifest push $(CONTROLLER_IMAGE):$(VERSION)
 
 .PHONY: chart-build
 chart-build: $(HELM) ; $(info Building Helm image...)  @ ## Build Helm Chart


### PR DESCRIPTION
Use docker/build-push-action with QEMU and Buildx to handle multi-arch builds automatically, eliminating manifest creation errors.