### PR TITLE
fix: skip k8s-launch-kit when tagging components for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,12 +86,12 @@ jobs:
       - id: set-components
         run: |
           # Extract unique sourceRepository names for tagging
-          repos=$(yq -o=json 'to_entries | map(select(.value.sourceRepository != null) | .value.sourceRepository)' hack/release.yaml | jq -c 'unique')
+          repos=$(yq -o=json 'to_entries | map(select(.value.sourceRepository != null and .value.sourceRepository != "NVIDIA/k8s-launch-kit") | .value.sourceRepository)' hack/release.yaml | jq -c 'unique')
           echo "Managed repositories: $repos"
           echo "managed_repos=$(echo $repos)" >> $GITHUB_OUTPUT
 
           # Extract image names with repository for components that have sourceRepository
-          images=$(yq 'to_entries | map(select(.value.sourceRepository != null) | .value.image) | join(" ")' hack/release.yaml)
+          images=$(yq 'to_entries | map(select(.value.sourceRepository != null and .value.sourceRepository != "NVIDIA/k8s-launch-kit") | .value.image) | join(" ")' hack/release.yaml)
           echo "Managed images: $images"
           echo "managed_images=$images" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
this fix prevents unwanted behavior due to adding the `sourceRepository` field to the k8s-launch-kit component.