### PR TITLE
fix: do not wait for stig images during release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,7 +170,7 @@ jobs:
 
           for image in "${IMAGE_ARRAY[@]}"; do
             if [[ "$image" == *stig-fips ]]; then
-              component_tag="${COMPONENT_TAG}-stig-fips"
+              continue
             else
               component_tag="${COMPONENT_TAG}"
             fi


### PR DESCRIPTION
STIG FIPS images are now built on gitlab asynchronously, do not block the pipeline for them here