### PR TITLE
fix: hack workaround to trigger mirror gitlab ci on git *tags*

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,13 +3,23 @@ stages:
 
 trigger-jenkins-nspect-on-tag:
   stage: trigger-jenkins-nspect-on-tag
-  image: curlimages/curl:8.5.0
   rules:
-    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|v[0-9.]+\.x)$/'  # runs on master and release *branch* commits (since gitlab pull-*mirrors* cannot trigger tag pipelines)
   tags:
     - os/linux
     - type/docker
+  image: alpine
   variables:  # additional variables defined at the gitlab group scope
     JENKINS_JOB_NAME: nspect-automation
+  # check if a git tag is associated with current commit and if yes, triggers nspect jenkins job with it
   script:
-    - curl -fsSLX POST -u "$SVC_CLOUD_ORCH_CI_USERNAME:$SVC_CLOUD_ORCH_CI_JENKINS_TOKEN" "$BLOSSOM_JENKINS_URL/job/$JENKINS_JOB_NAME/buildWithParameters?GIT_TAG=$CI_COMMIT_TAG"
+    - apk add --no-cache git
+    - git fetch --tags upstream
+    - GIT_TAG=$(git describe --tags --exact-match HEAD || true)
+    - |
+      if [ -n "$GIT_TAG" ]; then
+        apk add --no-cache curl
+        curl -fsSLX POST -u "$SVC_CLOUD_ORCH_CI_USERNAME:$SVC_CLOUD_ORCH_CI_JENKINS_TOKEN" "$BLOSSOM_JENKINS_URL/job/$JENKINS_JOB_NAME/buildWithParameters?GIT_TAG=$GIT_TAG"
+      else
+        echo "No tag found for this commit. Exiting."
+      fi


### PR DESCRIPTION
since gitlab pull-*mirrors* cannot trigger tag pipelines, this gitlab CI mirror pipeline will now run on branch triggers (_master_ and _release_ branch only) and if the branch commit has a matching git tag, then it will trigger the [internal] nspect automation jenkins pipeline.