### PR TITLE
fix: increase doc CI timeout

### DIFF
--- a/.github/workflows/docs-ci-trigger.yaml
+++ b/.github/workflows/docs-ci-trigger.yaml
@@ -32,7 +32,7 @@ jobs:
         IMAGE="docker://${{ env.REGISTRY }}/${{ env.REPO }}:${GIT_TAG}"
         echo "Waiting for image: $IMAGE"
 
-        MAX_RETRIES=90
+        MAX_RETRIES=180
         SLEEP_SECONDS=10
         COUNT=0
 


### PR DESCRIPTION
Image build and push job sometime take more than 20 minutes.