### PR TITLE
fix: permissions issue with gitlab CI mirror triggering jenkins

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 trigger-jenkins-nspect-on-tag:
   stage: trigger-jenkins-nspect-on-tag
-  image: curlimages/curl:8.5.0
+  image: alpine:3.23
   rules:
     - if: $CI_COMMIT_TAG
   tags:
@@ -15,7 +15,7 @@ trigger-jenkins-nspect-on-tag:
     SLEEP_INTERVAL: 120s
   script:
     # init
-    - apk add --no-cache jq yq
+    - apk add --no-cache curl jq yq
     - retry_counter=0
     - gh_workflow_name=$(yq ".name" .github/workflows/ci.yaml)
     # await github actions CI completion


### PR DESCRIPTION
_curl_ image does not run as `root`, preventing ability to `apk add` additional required packages (see error in gitlab CI job id `262420278`).
this PR should solve that bug.