### PR TITLE
fix: Update rendered objects after manual changes

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -48,8 +48,6 @@ const (
 	// that network-operator pod should be skipped during the drain operation which
 	// is executed by the upgrade controller.
 	OfedDriverSkipDrainLabelSelector = "nvidia.com/ofed-driver-upgrade-drain.skip!=true"
-	// ControllerRevisionAnnotation is the key for annotations used to store revision information on Kubernetes objects.
-	ControllerRevisionAnnotation = "nvidia.network-operator.revision"
 	// ConfigHashAnnotation is the key for annotations used to store config hash on pod templates.
 	ConfigHashAnnotation = "nvidia.network-operator.config-hash"
 )

--- a/pkg/revision/revision.go
+++ b/pkg/revision/revision.go
@@ -18,11 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"strconv"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/Mellanox/network-operator/pkg/consts"
 )
 
 // ControllerRevision is the data to be stored as checkpoint
@@ -35,27 +31,6 @@ func CalculateRevision(o client.Object) (ControllerRevision, error) {
 		return 0, fmt.Errorf("failed to compute controller revision for the object: %v", err)
 	}
 	return ControllerRevision(rev), nil
-}
-
-// GetRevision returns controller revision which is saved in the object.
-// returns 0 if revision is not set for the object
-func GetRevision(o client.Object) ControllerRevision {
-	val := o.GetAnnotations()[consts.ControllerRevisionAnnotation]
-	rev, err := strconv.ParseUint(val, 10, 32)
-	if err != nil {
-		return 0
-	}
-	return ControllerRevision(rev)
-}
-
-// SetRevision saves controller revision to the object.
-func SetRevision(o client.Object, rev ControllerRevision) {
-	annotations := o.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	annotations[consts.ControllerRevisionAnnotation] = strconv.FormatUint(uint64(rev), 10)
-	o.SetAnnotations(annotations)
 }
 
 // Get returns calculated checksum for the object

--- a/pkg/revision/revision_test.go
+++ b/pkg/revision/revision_test.go
@@ -43,16 +43,4 @@ var _ = Describe("Revision", func() {
 			Expect(rev1).NotTo(Equal(rev2))
 		})
 	})
-	Context("Set/Get Revision", func() {
-		It("Should get revision set by setter", func() {
-			o := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj1", Namespace: "ns1"}}
-			testRev := revision.ControllerRevision(1000)
-			revision.SetRevision(o, testRev)
-			Expect(revision.GetRevision(o)).To(Equal(testRev))
-		})
-		It("Should return zero if revision not set", func() {
-			o := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "obj1", Namespace: "ns1"}}
-			Expect(revision.GetRevision(o)).To(Equal(revision.ControllerRevision(0)))
-		})
-	})
 })

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -229,7 +229,6 @@ func (s *stateSkel) createOrUpdateObjs(
 		if err != nil {
 			return err
 		}
-		revision.SetRevision(desiredObj, desiredRev)
 
 		alreadyExist := true
 		currentObj := desiredObj.NewEmptyInstance().(*unstructured.Unstructured)
@@ -249,7 +248,10 @@ func (s *stateSkel) createOrUpdateObjs(
 			}
 			continue
 		}
-		currRev := revision.GetRevision(currentObj)
+		currRev, err := revision.CalculateRevision(currentObj)
+		if err != nil {
+			return errors.Wrap(err, "failed to calculate current object revision")
+		}
 		if currRev != 0 && currRev == desiredRev {
 			reqLogger.V(consts.LogLevelInfo).Info("Object is already in sync")
 			continue


### PR DESCRIPTION
If user manually changes Network Operator manged objects (e.g. Multus CNI daemonset) operator should re-apply manifests.

We don't need to store object revision because it could be outdated after manual edit and Network Operator won't re-apply manifests.