### PR TITLE
fix: relax kubeVersion constraint to support pre-release suffixes

### DIFF
--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-operator
 version: 26.1.0-beta.7
-kubeVersion: '>= 1.21.0'
+kubeVersion: '>= 1.21.0-0'
 appVersion: v26.1.0-beta.7
 description: Nvidia network operator
 type: application


### PR DESCRIPTION
## Summary
- Append `-0` to the Helm chart `kubeVersion` constraint (`>= 1.21.0` → `>= 1.21.0-0`) so it accepts Kubernetes versions with pre-release suffixes

## Problem
Kubernetes distributions like EKS append pre-release metadata to the version string (e.g. `v1.34.3-eks-ac2d5a0`). Per the [semver spec](https://semver.org/#spec-item-11), pre-release versions have lower precedence than the release version, so Helm's `>= 1.21.0` constraint rejects `1.34.3-eks-ac2d5a0` even though the cluster version clearly satisfies the requirement.

```
Error: chart requires kubeVersion: >= 1.21.0 which is incompatible with Kubernetes v1.34.3-eks-ac2d5a0
```

## Fix
Appending `-0` to the constraint includes pre-release versions in the comparison. This is the standard Helm convention — the bundled `sriov-network-operator` sub-chart already uses `>= 1.16.0-0`.

Reference: https://helm.sh/docs/topics/charts/#the-apiversion-field

## Test plan
- [x] Verified `helm install` succeeds on EKS v1.34.3-eks-ac2d5a0 with patched chart
- [x] No change in behavior for standard Kubernetes versions (e.g. v1.32.0)