### PR TITLE
feat: add module dependency check config and document UNLOAD_THIRD_PARTY_RDMA_MODULES

### DIFF
--- a/docs/mofed-container-env-vars.md
+++ b/docs/mofed-container-env-vars.md
@@ -24,6 +24,7 @@ In most deployments its expected to not require setting those.
 | ENABLE_NFSRDMA |N|`"false"`| enable loading of nfs relates storage modules from mofed container|
 | RESTORE_DRIVER_ON_POD_TERMINATION |N|`"true"`| restore host drivers when container is gracefully stopped |
 | NVIDIA_NIC_DRIVERS_INVENTORY_PATH | N | `"/mnt/drivers-inventory"` | enable use of a persistent directory to store drivers' build artifacts to avoid recompilation between runs. Keep the default value or set to "" to disable. |
+| UNLOAD_THIRD_PARTY_RDMA_MODULES | N | `"false"` | When `true`, all known third-party RDMA kernel modules (from rdma-core: qedr, efa, siw, etc.) are blacklisted and unloaded before OFED driver reload. The init container will skip these modules in its dependency check when this flag is set. |
 
 In addition, the user can specify essentially any environment variables to be exposed to the MOFED container such as
 the standard `"HTTP_PROXY"`, `"HTTPS_PROXY"`, `"NO_PROXY"`
@@ -33,3 +34,23 @@ the standard `"HTTP_PROXY"`, `"HTTPS_PROXY"`, `"NO_PROXY"`
 
 > __Note__: Environment Variables Marked as Experimental should not be used in production environment, they are mainly aimed at
 > either providing special functionality or additional debug ability. Such variables can be added/removed with no notice.
+
+## Init Container Module Dependency Detection
+
+When the MOFED driver init container is enabled, it runs a module dependency check before the main driver container starts. This check detects third-party kernel modules that depend (directly or transitively) on NVIDIA MOFED RDMA/MLX5 modules.
+
+### How it works
+
+The init container reads `/proc/modules` and `/sys/module/*/holders/` on the host to build a full reverse dependency tree starting from the configured MOFED modules (e.g., `mlx5_core`, `ib_core`). It traverses the tree to find all non-MOFED modules that depend on any MOFED module, including transitive dependencies (e.g., `lustre → ko2iblnd → ib_core`).
+
+### Behavior on failure
+
+If blocking dependencies are detected, the init container exits with a non-zero exit code and logs each blocking module and what it depends on. Because this is a Kubernetes init container, the main driver container will not start until the init container succeeds. This prevents the OFED driver reload from being attempted when it would fail and leave the node in a broken state.
+
+### Resolution
+
+The init container classifies blocking dependencies into three categories:
+
+1. **Third-party RDMA modules** (e.g., `qedr`, `efa`, `siw`, `bnxt_re`): These are known rdma-core consumer modules. Set `UNLOAD_THIRD_PARTY_RDMA_MODULES="true"` in the NicClusterPolicy `ofedDriver` env vars to automatically blacklist and unload them before driver reload. Verify that no running workloads depend on these modules before enabling.
+2. **Unknown kernel modules**: Modules not recognized as third-party RDMA modules require manual intervention. Unload or blacklist them on the host before the driver container starts (e.g., `modprobe -r <module>` or via a DaemonSet).
+3. **Userspace processes**: Processes holding MOFED device files open (e.g., `/dev/infiniband/*`). Identify them with `lsof /dev/infiniband/*` or `fuser -v /dev/infiniband/*` and stop them before deploying the driver. Common culprits: `opensm`, `ibacm`, `rdma-ndd`.

--- a/manifests/state-ofed-driver/0040_ofed_init_container_config-configmap.yaml
+++ b/manifests/state-ofed-driver/0040_ofed_init_container_config-configmap.yaml
@@ -23,6 +23,13 @@ data:
       "safeDriverLoad": {
         "enable": {{ .RuntimeSpec.InitContainerConfig.SafeLoadEnable }},
         "annotation": "{{ .RuntimeSpec.InitContainerConfig.SafeLoadAnnotation }}"
+      },
+      "moduleDependencyCheck": {
+        "enable": {{ .RuntimeSpec.InitContainerConfig.ModuleDepCheckEnable }},
+        "modules": [{{ .RuntimeSpec.InitContainerConfig.ModuleDepCheckModules }}],
+        "unloadThirdPartyRdma": {{ .RuntimeSpec.InitContainerConfig.UnloadThirdPartyRDMA }},
+        "hostProcPath": "/host/proc",
+        "hostSysPath": "/host/sys"
       }
     }
 {{end}}

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -78,6 +78,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: host-sys
+              mountPath: /host/sys
+              readOnly: true
       {{- end }}
       containers:
         - image: {{ .RuntimeSpec.MOFEDImageName }}
@@ -247,6 +254,14 @@ spec:
           hostPath:
             path: /etc/modprobe.d/ib_core.conf
             type: FileOrCreate
+        - name: host-proc
+          hostPath:
+            path: /proc
+            type: Directory
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory
         {{- range .AdditionalVolumeMounts.Volumes }}
         - name: {{ .Name }}
           {{- if and .ConfigMap .ConfigMap.Items }}

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -244,6 +244,9 @@ type initContainerConfig struct {
 	InitContainerImageName string
 	SafeLoadEnable         bool
 	SafeLoadAnnotation     string
+	ModuleDepCheckEnable   bool
+	ModuleDepCheckModules  string
+	UnloadThirdPartyRDMA   bool
 }
 
 type ofedRuntimeSpec struct {
@@ -741,15 +744,38 @@ func getProviders(catalog InfoCatalog) (nodeinfo.Provider, clustertype.Provider,
 func (s *stateOFED) getInitContainerConfig(
 	cr mellanoxv1alpha1.NicPolicyCR, reqLogger logr.Logger, image string) initContainerConfig {
 	var initContCfg initContainerConfig
-	safeLoadEnable := cr.GetOFEDDriverSpec().OfedUpgradePolicy != nil &&
-		cr.GetOFEDDriverSpec().OfedUpgradePolicy.AutoUpgrade &&
-		cr.GetOFEDDriverSpec().OfedUpgradePolicy.SafeLoad
+
+	ofedDriverSpec := cr.GetOFEDDriverSpec()
+
+	safeLoadEnable := ofedDriverSpec.OfedUpgradePolicy != nil &&
+		ofedDriverSpec.OfedUpgradePolicy.AutoUpgrade &&
+		ofedDriverSpec.OfedUpgradePolicy.SafeLoad
+
+	// Extract UNLOAD_THIRD_PARTY_RDMA_MODULES from driver container env vars
+	unloadThirdPartyRDMA := false
+	if ofedDriverSpec.Env != nil {
+		for _, env := range ofedDriverSpec.Env {
+			if env.Name != "UNLOAD_THIRD_PARTY_RDMA_MODULES" {
+				continue
+			}
+			if env.Value == "true" {
+				unloadThirdPartyRDMA = true
+			}
+			break
+		}
+	}
+
 	if image != "" {
 		initContCfg = initContainerConfig{
 			InitContainerEnable:    true,
 			InitContainerImageName: image,
 			SafeLoadEnable:         safeLoadEnable,
 			SafeLoadAnnotation:     upgrade.GetUpgradeDriverWaitForSafeLoadAnnotationKey(),
+			ModuleDepCheckEnable:   true,
+			ModuleDepCheckModules: `"mlx5_core", "mlx5_ib", "ib_umad",` +
+				` "ib_uverbs", "ib_ipoib", "rdma_cm",` +
+				` "rdma_ucm", "ib_core", "ib_cm"`,
+			UnloadThirdPartyRDMA: unloadThirdPartyRDMA,
 		}
 	}
 


### PR DESCRIPTION
- Bridge UNLOAD_THIRD_PARTY_RDMA_MODULES boolean from driver
  container env vars to init container ConfigMap as
  unloadThirdPartyRdma, so the pre-flight check skips known RDMA
  modules the driver will handle
- Add moduleDependencyCheck section to init container ConfigMap
  with MOFED module list and /proc /sys volume mounts
- Document the env var and the three init container error categories
  (third-party RDMA, unknown kernel modules, userspace processes)
  in docs/mofed-container-env-vars.md