### PR TITLE
feat: CI - build image on PR event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
     - "master"
     - "v*.x"
+    - "pull-request/[0-9]+"  # utilizes nvidia copy-pr-bot: https://github.com/nv-gha-runners/docs/blob/main/docs/platform/apps/copy-pr-bot/index.md
     tags:
     - "v*"
 
@@ -44,6 +45,23 @@ jobs:
           fi
         done
         echo "tags=$tags" | tee -a $GITHUB_OUTPUT
+
+        # all events reaching here are trusted:
+        # - push to master/v*.x/tags: standard ci
+        # - push to pull-request/*: copy-pr-bot is the trust gate; untrusted fork prs
+        #   require a maintainer /ok-to-test before copy-pr-bot syncs the branch
+        # - pull_request from same-repo branches: fork prs are blocked at the
+        #   self-hosted runner infrastructure level
+        push=true
+        echo "push=$push" | tee -a $GITHUB_OUTPUT
+
+        # determine if chart & bundle shall be published
+        if [[ "$push" == "true" && ("${{ github.ref_type }}" == "tag" || "${{ github.ref_name }}" == "${{ env.DEFAULT_BRANCH }}") ]]; then
+          publish=true
+        else
+          publish=false
+        fi
+        echo "publish=$publish" | tee -a $GITHUB_OUTPUT
     - uses: docker/setup-qemu-action@v4
     - uses: docker/setup-buildx-action@v4
       with:
@@ -61,14 +79,15 @@ jobs:
         file: ./Dockerfile
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.docker-tags.outputs.tags }}
-        push: true
+        push: ${{ steps.docker-tags.outputs.push }}
         build-args: |
           GOPROXY=${{ env.GOPROXY }}
     outputs:
       default_branch: ${{ env.DEFAULT_BRANCH }}  # we output this here, to use in the following job's conditioning (due to github actions environment variable scope limitations).
+      publish: ${{ steps.docker-tags.outputs.publish }}
 
   helm-package-publish:
-    if:  github.ref_type == 'tag' || github.ref_name == ${{ needs.docker-build-push.outputs.default_branch }}
+    if: needs.docker-build-push.outputs.publish == 'true'
     needs:
     - docker-build-push
     runs-on: linux-amd64-cpu4
@@ -107,6 +126,7 @@ jobs:
         APP_VERSION=$git_tag VERSION=${git_tag:1} make chart-build chart-push  # VERSION as 'v' prefix removed
 
   ocp-bundle:
+    if: needs.docker-build-push.outputs.publish == 'true'
     needs:
     - docker-build-push
     runs-on: ubuntu-24.04


### PR DESCRIPTION
this PR allows safely building network-operator images and pushing to nvstaging _from **trusted** (mellanox) 3rd party/fork PRs._

## example flow
1. submitted PR from fork: https://github.com/Mellanox/network-operator/pull/2315 (this PR - for example)
2. *copy-pr-bot* (a github app) creates "local" branch (with `pull-request/*` prefix) with copy of PR/fork code: https://github.com/Mellanox/network-operator/branches/all?query=pull-request
3. github actions CI workflow runs (on nvidia self-hosted runners) for *local* branch event: https://github.com/Mellanox/network-operator/actions/runs/24030392754
4. image pushed: https://registry.ngc.nvidia.com/orgs/nvstaging/teams/mellanox/containers/network-operator/tags (search: "0b0dbe59215a")
