### PR TITLE
fix: remove OFED driver validation init container from device plugin DS

### DIFF
--- a/manifests/state-rdma-shared-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/state-rdma-shared-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -40,14 +40,6 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
-{{if .DeployInitContainer}}
-      initContainers:
-        - name: ofed-driver-validation
-          image: {{ imagePath .CrSpec.Repository .CrSpec.Image .CrSpec.Version }}
-          imagePullPolicy: IfNotPresent
-          command: [ 'sh', '-c' ]
-          args: [ "until lsmod | grep mlx5_core; do echo waiting for OFED drivers to be loaded; sleep 30; done" ]
-{{end}}
       {{- if .CrSpec.ImagePullSecrets }}
       imagePullSecrets:
       {{- range .CrSpec.ImagePullSecrets }}

--- a/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yaml
+++ b/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yaml
@@ -59,14 +59,6 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-{{- if .DeployInitContainer}}
-      initContainers:
-        - name: ofed-driver-validation
-          image: {{ imagePath .CrSpec.ImageSpec.Repository .CrSpec.ImageSpec.Image .CrSpec.ImageSpec.Version }}
-          imagePullPolicy: IfNotPresent
-          command: ['sh', '-c']
-          args: ["until lsmod | grep mlx5_core; do echo waiting for OFED drivers to be loaded; sleep 30; done"]
-{{- end}}
       containers:
         - name: kube-sriovdp
           image: {{ imagePath .CrSpec.ImageSpec.Repository .CrSpec.ImageSpec.Image .CrSpec.ImageSpec.Version }}

--- a/pkg/state/state_ib_kubernetes.go
+++ b/pkg/state/state_ib_kubernetes.go
@@ -72,7 +72,6 @@ type IBKubernetesManifestRenderData struct {
 	NodeAffinity                *v1.NodeAffinity
 	DeploymentNodeAffinity      *v1.NodeAffinity
 	DeploymentTolerations       []v1.Toleration
-	DeployInitContainer         bool
 	RuntimeSpec                 *IBKubernetesSpec
 }
 
@@ -162,7 +161,6 @@ func (s *stateIBKubernetes) GetManifestObjects(
 		NodeAffinity:                cr.Spec.NodeAffinity,
 		DeploymentNodeAffinity:      cr.Spec.DeploymentNodeAffinity,
 		DeploymentTolerations:       cr.Spec.DeploymentTolerations,
-		DeployInitContainer:         cr.Spec.OFEDDriver != nil,
 		RuntimeSpec: &IBKubernetesSpec{
 			runtimeSpec:        runtimeSpec{config.FromEnv().State.NetworkOperatorResourceNamespace},
 			IsOpenshift:        clusterInfo.IsOpenshift(),

--- a/pkg/state/state_rdma_shared_device_plugin.go
+++ b/pkg/state/state_rdma_shared_device_plugin.go
@@ -66,14 +66,13 @@ type stateRDMASharedDevicePluginSpec struct {
 	ContainerResources ContainerResourcesMap
 }
 type stateRDMASharedDevicePluginManifestRenderData struct {
-	CrSpec              *mellanoxv1alpha1.DevicePluginSpec
-	Tolerations         []v1.Toleration
-	NodeAffinity        *v1.NodeAffinity
-	NodeSelector        map[string]string
-	DSOwner             string
-	NameSuffix          string
-	DeployInitContainer bool
-	RuntimeSpec         *stateRDMASharedDevicePluginSpec
+	CrSpec       *mellanoxv1alpha1.DevicePluginSpec
+	Tolerations  []v1.Toleration
+	NodeAffinity *v1.NodeAffinity
+	NodeSelector map[string]string
+	DSOwner      string
+	NameSuffix   string
+	RuntimeSpec  *stateRDMASharedDevicePluginSpec
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -162,13 +161,12 @@ func (s *stateRDMASharedDevicePlugin) GetManifestObjects(
 	}
 
 	renderData := &stateRDMASharedDevicePluginManifestRenderData{
-		CrSpec:              cr.GetRdmaSharedDevicePluginSpec(),
-		Tolerations:         cr.GetTolerations(),
-		NodeAffinity:        cr.GetNodeAffinity(),
-		NodeSelector:        cr.GetNodeSelector(),
-		DSOwner:             dsOwnerValue(cr),
-		NameSuffix:          nameSuffix(cr),
-		DeployInitContainer: cr.GetOFEDDriverSpec() != nil,
+		CrSpec:       cr.GetRdmaSharedDevicePluginSpec(),
+		Tolerations:  cr.GetTolerations(),
+		NodeAffinity: cr.GetNodeAffinity(),
+		NodeSelector: cr.GetNodeSelector(),
+		DSOwner:      dsOwnerValue(cr),
+		NameSuffix:   nameSuffix(cr),
 		RuntimeSpec: &stateRDMASharedDevicePluginSpec{
 			runtimeSpec:        runtimeSpec{config.FromEnv().State.NetworkOperatorResourceNamespace},
 			IsOpenshift:        clusterInfo.IsOpenshift(),

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -68,14 +68,13 @@ type sriovDpRuntimeSpec struct {
 }
 
 type sriovDpManifestRenderData struct {
-	CrSpec              *mellanoxv1alpha1.DevicePluginSpec
-	Tolerations         []v1.Toleration
-	NodeAffinity        *v1.NodeAffinity
-	NodeSelector        map[string]string
-	DSOwner             string
-	NameSuffix          string
-	DeployInitContainer bool
-	RuntimeSpec         *sriovDpRuntimeSpec
+	CrSpec       *mellanoxv1alpha1.DevicePluginSpec
+	Tolerations  []v1.Toleration
+	NodeAffinity *v1.NodeAffinity
+	NodeSelector map[string]string
+	DSOwner      string
+	NameSuffix   string
+	RuntimeSpec  *sriovDpRuntimeSpec
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -164,13 +163,12 @@ func (s *stateSriovDp) GetManifestObjects(
 	}
 
 	renderData := &sriovDpManifestRenderData{
-		CrSpec:              cr.GetSriovDevicePluginSpec(),
-		Tolerations:         cr.GetTolerations(),
-		NodeAffinity:        cr.GetNodeAffinity(),
-		NodeSelector:        cr.GetNodeSelector(),
-		DSOwner:             dsOwnerValue(cr),
-		NameSuffix:          nameSuffix(cr),
-		DeployInitContainer: cr.GetOFEDDriverSpec() != nil,
+		CrSpec:       cr.GetSriovDevicePluginSpec(),
+		Tolerations:  cr.GetTolerations(),
+		NodeAffinity: cr.GetNodeAffinity(),
+		NodeSelector: cr.GetNodeSelector(),
+		DSOwner:      dsOwnerValue(cr),
+		NameSuffix:   nameSuffix(cr),
 		RuntimeSpec: &sriovDpRuntimeSpec{
 			runtimeSpec:        runtimeSpec{config.FromEnv().State.NetworkOperatorResourceNamespace},
 			IsOpenshift:        clusterInfo.IsOpenshift(),


### PR DESCRIPTION
Remove the ofed-driver-validation init container and DeployInitContainer render field from SR-IOV device plugin, RDMA shared device plugin, and IB Kubernetes states.