### PR TITLE
fix: shorten NicNodePolicy requestorID to fit 63-byte NodeMaintenance…

### DIFF
--- a/api/v1alpha1/nicnodepolicy_types.go
+++ b/api/v1alpha1/nicnodepolicy_types.go
@@ -24,6 +24,9 @@ import (
 const (
 	// NicNodePolicyCRDName is used for the CRD Kind.
 	NicNodePolicyCRDName = "NicNodePolicy"
+	// NicNodePolicyShortName is the abbreviated form used in labels and requestorIDs
+	// to keep values within Kubernetes length limits.
+	NicNodePolicyShortName = "nnp"
 )
 
 // NicNodePolicySpec defines the desired state of NIC drivers and device plugin

--- a/controllers/mofed_wait_labels_test.go
+++ b/controllers/mofed_wait_labels_test.go
@@ -74,7 +74,7 @@ var _ = Describe("NicNodePolicy mofed.wait label management", func() {
 			defer func() { _ = k8sClient.Delete(ctx, nnp) }()
 
 			By("Simulating a ready OFED pod owned by this NNP")
-			dsOwner := mellanoxv1alpha1.NicNodePolicyCRDName + "-" + nnp.Name
+			dsOwner := mellanoxv1alpha1.NicNodePolicyShortName + "-" + nnp.Name
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mofed-wait-test-pod",

--- a/controllers/nicnodepolicy_controller.go
+++ b/controllers/nicnodepolicy_controller.go
@@ -132,7 +132,7 @@ func (r *NicNodePolicyReconciler) handleMOFEDWaitLabels(
 	if instance.Spec.OFEDDriver == nil {
 		return nil
 	}
-	dsOwner := mellanoxv1alpha1.NicNodePolicyCRDName + "-" + instance.Name
+	dsOwner := mellanoxv1alpha1.NicNodePolicyShortName + "-" + instance.Name
 	return handleOFEDWaitLabelsForPods(ctx, r.Client, map[string]string{
 		consts.OfedDriverLabel: "",
 		consts.DSOwnerLabel:    dsOwner,
@@ -143,7 +143,7 @@ func (r *NicNodePolicyReconciler) handleMOFEDWaitLabels(
 // If OFED pods owned by this NNP are still terminating, sets mofed.wait=true and requeues.
 func (r *NicNodePolicyReconciler) handleDeletion(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)
-	dsOwner := mellanoxv1alpha1.NicNodePolicyCRDName + "-" + req.Name
+	dsOwner := mellanoxv1alpha1.NicNodePolicyShortName + "-" + req.Name
 
 	pods := &corev1.PodList{}
 	if err := r.Client.List(ctx, pods, client.MatchingLabels{

--- a/controllers/upgrade_controller.go
+++ b/controllers/upgrade_controller.go
@@ -56,7 +56,7 @@ type UpgradeReconciler struct {
 	MigrationCh  chan struct{}
 
 	// NodePolicyStateManagers holds per-NicNodePolicy upgrade state managers.
-	// Keyed by "NicNodePolicy-<name>".
+	// Keyed by "nnp-<name>".
 	NodePolicyStateManagers map[string]upgrade.ClusterUpgradeStateManager
 
 	// newStateManagerFn creates a ClusterUpgradeStateManager for a given requestor ID.
@@ -65,6 +65,9 @@ type UpgradeReconciler struct {
 }
 
 const plannedRequeueInterval = time.Minute * 2
+
+// nicNodePolicyRequestorPrefix is the short prefix used in requestorIDs for NicNodePolicy upgrades.
+const nicNodePolicyRequestorPrefix = mellanoxv1alpha1.NicNodePolicyShortName
 
 // UpgradeStateAnnotation is kept for backwards cleanup TODO: drop in 2 releases
 const UpgradeStateAnnotation = "nvidia.com/ofed-upgrade-state"
@@ -177,7 +180,7 @@ func (r *UpgradeReconciler) reconcileNodePolicyUpgrades(ctx context.Context,
 
 	for i := range nodePolicyList.Items {
 		np := &nodePolicyList.Items[i]
-		policyKey := mellanoxv1alpha1.NicNodePolicyCRDName + "-" + np.Name
+		policyKey := nicNodePolicyRequestorPrefix + "-" + np.Name
 
 		if np.Spec.OFEDDriver == nil ||
 			np.Spec.OFEDDriver.OfedUpgradePolicy == nil ||
@@ -233,15 +236,15 @@ func (r *UpgradeReconciler) reconcileNodePolicyUpgrades(ctx context.Context,
 	}
 
 	// Clean up stale state managers for deleted policies
-	for key := range r.NodePolicyStateManagers {
-		if !activePolicyKeys[key] {
-			if err := r.cleanupNodePolicyUpgradeResources(ctx, key); err != nil {
+	for policyKey := range r.NodePolicyStateManagers {
+		if !activePolicyKeys[policyKey] {
+			if err := r.cleanupNodePolicyUpgradeResources(ctx, policyKey); err != nil {
 				reqLogger.V(consts.LogLevelError).Error(err,
-					"Failed to clean up upgrade resources for deleted policy", "policy", key)
+					"Failed to clean up upgrade resources for deleted policy", "policy", policyKey)
 				needsRequeue = true
 				continue // keep manager in map, retry next reconcile
 			}
-			delete(r.NodePolicyStateManagers, key)
+			delete(r.NodePolicyStateManagers, policyKey)
 		}
 	}
 
@@ -250,19 +253,18 @@ func (r *UpgradeReconciler) reconcileNodePolicyUpgrades(ctx context.Context,
 
 // getOrCreateNodePolicyStateManager creates a new ClusterUpgradeStateManager for a NicNodePolicy.
 func (r *UpgradeReconciler) getOrCreateNodePolicyStateManager(
-	policyKey string) (upgrade.ClusterUpgradeStateManager, error) {
+	requestorKey string) (upgrade.ClusterUpgradeStateManager, error) {
 	if r.newStateManagerFn != nil {
-		return r.newStateManagerFn(policyKey)
+		return r.newStateManagerFn(requestorKey)
 	}
-	return newNodePolicyStateManager(policyKey)
+	return newNodePolicyStateManager(requestorKey)
 }
 
 // newNodePolicyStateManager creates a ClusterUpgradeStateManager with a policy-specific requestor ID.
-func newNodePolicyStateManager(policyKey string) (upgrade.ClusterUpgradeStateManager, error) {
-	upgradeLogger := ctrl.Log.WithName("controllers").WithName("Upgrade").WithName(policyKey)
+func newNodePolicyStateManager(requestorKey string) (upgrade.ClusterUpgradeStateManager, error) {
+	upgradeLogger := ctrl.Log.WithName("controllers").WithName("Upgrade").WithName(requestorKey)
 	requestorOpts := upgrade.GetRequestorOptsFromEnvs()
-	// Create a policy-specific requestor ID
-	requestorOpts.MaintenanceOPRequestorID = requestorOpts.MaintenanceOPRequestorID + "-" + policyKey
+	requestorOpts.MaintenanceOPRequestorID = requestorOpts.MaintenanceOPRequestorID + "-" + requestorKey
 	return upgrade.NewClusterUpgradeStateManager(
 		upgradeLogger,
 		ctrl.GetConfigOrDie(),
@@ -429,6 +431,7 @@ func (r *UpgradeReconciler) cleanupNodeMaintenanceObjects(ctx context.Context) e
 
 // cleanupNodePolicyUpgradeResources cleans up upgrade state labels and NodeMaintenance objects
 // for a specific NicNodePolicy that has been deleted or had its upgrade policy disabled.
+// policyKey is "nnp-<name>", used for both ds-owner label matching and requestorID matching.
 func (r *UpgradeReconciler) cleanupNodePolicyUpgradeResources(ctx context.Context, policyKey string) error {
 	reqLogger := log.FromContext(ctx)
 	reqLogger.V(consts.LogLevelInfo).Info("Cleaning up upgrade resources for NicNodePolicy", "policy", policyKey)

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -281,7 +281,7 @@ operator:
     # enable upgrade controller requestor
     useRequestor: false
     # upgrade controller requestor ID to be used in nodeMaintenance objects
-    requestorID: "nvidia.network-operator-driver-upgrade-controller"
+    requestorID: "nvidia.doca-driver-upgrade"
     # nodeMaintenance name prefix to be used by upgrade-controller (default is "")
     nodeMaintenanceNamePrefix: "network-operator"
     # enable drain controller requestor

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -281,7 +281,7 @@ operator:
     # enable upgrade controller requestor
     useRequestor: false
     # upgrade controller requestor ID to be used in nodeMaintenance objects
-    requestorID: "nvidia.network-operator-driver-upgrade-controller"
+    requestorID: "nvidia.doca-driver-upgrade"
     # nodeMaintenance name prefix to be used by upgrade-controller (default is "")
     nodeMaintenanceNamePrefix: "network-operator"
     # enable drain controller requestor

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -72,12 +72,13 @@ func (s *stateSkel) Description() string {
 
 // dsOwnerValue returns the ds-owner label value for the given CR.
 // For NicClusterPolicy, it returns just the CRD name (preserving backwards compatibility).
-// For other CR types (e.g. NicNodePolicy), it includes the CR name to allow multiple instances.
+// For NicNodePolicy, it returns "nnp-<name>" to allow multiple instances while keeping
+// the label value short enough to fit within Kubernetes limits.
 func dsOwnerValue(cr mellanoxv1alpha1.NicPolicyCR) string {
 	if cr.GetCRDName() == mellanoxv1alpha1.NicClusterPolicyCRDName {
 		return cr.GetCRDName()
 	}
-	return cr.GetCRDName() + "-" + cr.GetName()
+	return mellanoxv1alpha1.NicNodePolicyShortName + "-" + cr.GetName()
 }
 
 // nameSuffix returns the resource name suffix for the given CR.


### PR DESCRIPTION
… limit

The upgrade controller constructs a requestorID by concatenating the base ID with the policy kind and name, which exceeded the 63-byte limit enforced by the maintenance-operator CRD. This caused NodeMaintenance creation to fail during OFED upgrades.

- Shorten default MAINTENANCE_OPERATOR_REQUESTOR_ID to "nvidia.doca-driver-upgrade"
- Use abbreviated "nnp" prefix instead of "NicNodePolicy" in ds-owner labels and requestorIDs
- Add NicNodePolicyShortName constant for consistent usage across controllers