### PR TITLE
fix: allow non-zero PCI domain in NicSelector PCI address validation

### DIFF
--- a/manifests/state-nic-configuration-operator/001-configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/manifests/state-nic-configuration-operator/001-configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -68,7 +68,7 @@ spec:
                   pciAddresses:
                     description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
                     items:
-                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      pattern: ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
                       type: string
                     type: array
                   serialNumbers:

--- a/manifests/state-nic-configuration-operator/004-configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/manifests/state-nic-configuration-operator/004-configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -69,7 +69,7 @@ spec:
                   pciAddresses:
                     description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
                     items:
-                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      pattern: ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
                       type: string
                     type: array
                   serialNumbers:


### PR DESCRIPTION
The kubebuilder validation pattern for pciAddresses hardcoded domain 0000, silently rejecting valid PCI addresses on systems with multiple PCI host bridges or PCIe switches (e.g., 0001:03:00.0). Relax the domain segment from literal "0000" to [0-9a-fA-F]{4}.