### PR TITLE
fix: bridge UNLOAD_STORAGE_MODULES to init container ConfigMap

### DIFF
--- a/manifests/state-ofed-driver/0040_ofed_init_container_config-configmap.yaml
+++ b/manifests/state-ofed-driver/0040_ofed_init_container_config-configmap.yaml
@@ -28,6 +28,7 @@ data:
         "enable": {{ .RuntimeSpec.InitContainerConfig.ModuleDepCheckEnable }},
         "modules": [{{ .RuntimeSpec.InitContainerConfig.ModuleDepCheckModules }}],
         "unloadThirdPartyRdma": {{ .RuntimeSpec.InitContainerConfig.UnloadThirdPartyRDMA }},
+        "unloadStorageModules": {{ .RuntimeSpec.InitContainerConfig.UnloadStorageModules }},
         "hostProcPath": "/host/proc",
         "hostSysPath": "/host/sys"
       }

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -247,6 +247,7 @@ type initContainerConfig struct {
 	ModuleDepCheckEnable   bool
 	ModuleDepCheckModules  string
 	UnloadThirdPartyRDMA   bool
+	UnloadStorageModules   bool
 }
 
 type ofedRuntimeSpec struct {
@@ -751,17 +752,17 @@ func (s *stateOFED) getInitContainerConfig(
 		ofedDriverSpec.OfedUpgradePolicy.AutoUpgrade &&
 		ofedDriverSpec.OfedUpgradePolicy.SafeLoad
 
-	// Extract UNLOAD_THIRD_PARTY_RDMA_MODULES from driver container env vars
+	// Extract module unload flags from driver container env vars
 	unloadThirdPartyRDMA := false
+	unloadStorageModules := false
 	if ofedDriverSpec.Env != nil {
 		for _, env := range ofedDriverSpec.Env {
-			if env.Name != "UNLOAD_THIRD_PARTY_RDMA_MODULES" {
-				continue
+			switch env.Name {
+			case "UNLOAD_THIRD_PARTY_RDMA_MODULES":
+				unloadThirdPartyRDMA = env.Value == "true"
+			case "UNLOAD_STORAGE_MODULES":
+				unloadStorageModules = env.Value == "true"
 			}
-			if env.Value == "true" {
-				unloadThirdPartyRDMA = true
-			}
-			break
 		}
 	}
 
@@ -776,6 +777,7 @@ func (s *stateOFED) getInitContainerConfig(
 				` "ib_uverbs", "ib_ipoib", "rdma_cm",` +
 				` "rdma_ucm", "ib_core", "ib_cm"`,
 			UnloadThirdPartyRDMA: unloadThirdPartyRDMA,
+			UnloadStorageModules: unloadStorageModules,
 		}
 	}
 


### PR DESCRIPTION
Extract UNLOAD_STORAGE_MODULES from the driver container env vars in getInitContainerConfig and pass it through to the init container ConfigMap as unloadStorageModules. This mirrors the existing UNLOAD_THIRD_PARTY_RDMA_MODULES bridge and allows the init container to skip known storage modules in its pre-flight dependency check when the driver is configured to handle them.

Refactors env var extraction to use a switch statement for both flags in a single loop.