### PR TITLE
feat: mount /dev/infiniband in OFED driver container

### DIFF
--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -127,6 +127,8 @@ spec:
               mountPath: /mnt/drivers-inventory
             - name: host-ib-core
               mountPath: /etc/modprobe.d/ib_core.conf
+            - name: dev-infiniband
+              mountPath: /dev/infiniband
             {{- if.AdditionalVolumeMounts.VolumeMounts }}
             {{- range .AdditionalVolumeMounts.VolumeMounts }}
             - name: {{ .Name }}
@@ -254,6 +256,10 @@ spec:
           hostPath:
             path: /etc/modprobe.d/ib_core.conf
             type: FileOrCreate
+        - name: dev-infiniband
+          hostPath:
+            path: /dev/infiniband
+            type: DirectoryOrCreate
         - name: host-proc
           hostPath:
             path: /proc


### PR DESCRIPTION
Allow DOCA's openibd script to analyze IB device usage (e.g. via lsof) during driver restarts by mounting the host's /dev/infiniband directory into the mofed-container. Uses DirectoryOrCreate to handle nodes where the directory doesn't exist yet.