### PR TITLE
chore: update the init container patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,7 @@ release-build:
 	yq '.[].version'  hack/release.yaml | grep 'latest' && exit 1 || true
 	cd hack && $(GO) run release.go --templateDir ./templates/crs/ --outputDir ../example/crs
 	cd hack && $(GO) run release.go --templateDir ./templates/values/ --outputDir ../deployment/network-operator/
+	cd hack && $(GO) run release.go --templateDir ./templates/config/manager --outputDir ../config/manager/
 
 .PHONY: check-doca-drivers
 check-doca-drivers: $(HACKTMPDIR)

--- a/config/manager/init_container_image_name_patch.yaml
+++ b/config/manager/init_container_image_name_patch.yaml
@@ -2,4 +2,4 @@
   path: "/spec/template/spec/containers/0/env/-"
   value:
     name: OFED_INIT_CONTAINER_IMAGE
-    value: "ghcr.io/mellanox/network-operator-init-container@sha256:67e93ccf3ecb61f17597567faf0f72e1b8ddcf73c5d7440baeadcc1cb6bb811b"
+    value: "nvcr.io/nvstaging/mellanox/network-operator-init-container:network-operator-v26.4.0-beta.3"

--- a/hack/templates/config/manager/init_container_image_name_patch.template
+++ b/hack/templates/config/manager/init_container_image_name_patch.template
@@ -2,4 +2,4 @@
   path: "/spec/template/spec/containers/0/env/-"
   value:
     name: OFED_INIT_CONTAINER_IMAGE
-    value: "{{ (imageAsSha .NetworkOperatorInitContainer) }}"
+    value: "{{ if .NetworkOperatorInitContainer.Shas }}{{ imageAsSha .NetworkOperatorInitContainer }}{{ else }}{{ .NetworkOperatorInitContainer.Repository }}/{{ .NetworkOperatorInitContainer.Image }}:{{ .NetworkOperatorInitContainer.Version }}{{ end }}"


### PR DESCRIPTION
When running make release-build, updating the init container image in the patch file.

This is use in "make deploy" called in Kind-CI