### PR TITLE
fix: remove duplicate securityContext in sriov-network-operator deployment template

### DIFF
--- a/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/templates/operator.yaml
@@ -43,20 +43,12 @@ spec:
           image: {{ .Values.images.operator }}
           command:
             - sriov-network-operator
-          securityContext:
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
           resources:
             requests:
               cpu: 100m
               memory: 100Mi
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
The `sriov-network-operator` Deployment template had two `securityContext` entries defined for the same container. This was introduced across two separate CI/CD release commits (`v25.10.0-beta.1` and `v26.1.0-beta.1`) that each independently added a `securityContext` block.

While standard Helm silently accepts duplicate YAML mapping keys (last one wins), strict YAML parsers such as the one used by Flux's Kustomize post-renderer reject them, causing HelmRelease upgrades to fail with:

```
  yaml: unmarshal errors:
    line 72: mapping key "securityContext" already defined at line 59
```

Merge both `securityContext` blocks into a single definition, preserving all security hardening fields from both.