### PR TITLE
fix: set mofed.wait labels on startup when no NicClusterPolicy exists

### DIFF
--- a/controllers/nicclusterpolicy_controller.go
+++ b/controllers/nicclusterpolicy_controller.go
@@ -361,6 +361,27 @@ func (r *NicClusterPolicyReconciler) SetupWithManager(mgr ctrl.Manager, setupLog
 		builder.WithPredicates(nodeEventPredicates), // Wrap predicates for WatchesOption
 	)
 
+	// Watch Node create events filtered to Mellanox NIC nodes so that:
+	// (a) cache population at startup fires a reconcile for each existing Mellanox NIC node, and
+	// (b) newly joining nodes that already carry the Mellanox NIC label trigger a reconcile.
+	// Nodes without the label at creation time (NFD not yet run) are covered by the update
+	// watch above via MlnxLabelChangedPredicate when NFD later adds the label.
+	// This ensures mofed.wait labels are initialized via handleMOFEDWaitLabelsNoConfig
+	// even when no NicClusterPolicy exists (e.g. only SRIOV operator is deployed).
+	bld = bld.Watches(
+		&corev1.Node{},
+		handler.Funcs{
+			CreateFunc: func(_ context.Context, _ event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+					Name: consts.NicClusterPolicyResourceName,
+				}})
+			},
+		},
+		builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			return obj.GetLabels()[nodeinfo.NodeLabelMlnxNIC] == "true"
+		})),
+	)
+
 	bld = watchStateSources(bld, mgr, setupLog, stateManager, &mellanoxv1alpha1.NicClusterPolicy{})
 
 	// Watch NicNodePolicy changes so we recalculate NNP-managed node exclusions for mofed.wait.

--- a/controllers/nicclusterpolicy_controller_test.go
+++ b/controllers/nicclusterpolicy_controller_test.go
@@ -227,6 +227,33 @@ var _ = Describe("NicClusterPolicyReconciler Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+	Context("When no NicClusterPolicy exists", func() {
+		It("should set mofed.wait=false on Mellanox NIC nodes at startup without any NCP CR", func() {
+			By("Creating a node with a Mellanox NIC label but no mofed.wait label")
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-ncp-mlnx-node",
+					Labels: map[string]string{
+						nodeinfo.NodeLabelMlnxNIC: "true",
+					},
+					Annotations: make(map[string]string),
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(context.TODO(), node) }()
+
+			By("Verifying mofed.wait=false is set without any NicClusterPolicy CR")
+			Eventually(func() string {
+				n := &corev1.Node{}
+				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: node.Name}, n)
+				if err != nil {
+					return ""
+				}
+				return n.Labels[nodeinfo.NodeLabelWaitOFED]
+			}, timeout*3, interval).Should(Equal("false"))
+		})
+	})
+
 	Context("When NicClusterPolicy CR is deleted", func() {
 		It("should set mofed.wait and nic-configuration.wait to false", func() {
 			By("Create Node")


### PR DESCRIPTION
Watch Node create events in NicClusterPolicyReconciler without predicate filtering so that cache population at startup enqueues a reconcile for every existing node. This ensures handleMOFEDWaitLabelsNoConfig runs and sets mofed.wait=false on Mellanox NIC nodes even when no NicClusterPolicy CR is present (e.g. only the SRIOV operator is deployed), preventing dependent DaemonSets from being stuck at DESIRED=0.