### PR TITLE
fix: update default resource limits for NIC operator

### DIFF
--- a/manifests/state-nic-configuration-operator/060-operator.yaml
+++ b/manifests/state-nic-configuration-operator/060-operator.yaml
@@ -117,8 +117,8 @@ spec:
           {{- else }}
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 1000m
+              memory: 5Gi
             requests:
               cpu: 100m
               memory: 256Mi

--- a/manifests/state-nic-configuration-operator/070-config-daemon.yaml
+++ b/manifests/state-nic-configuration-operator/070-config-daemon.yaml
@@ -63,8 +63,7 @@ spec:
           {{- else }}
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
+              memory: 5Gi
             requests:
               cpu: 100m
               memory: 512Mi


### PR DESCRIPTION
1) remove CPU limit for the config daemon
* On machines with a lot of NICs, CPU limits significantly slow down the reconciliation process (mlxconfig takes a few seconds per param since they are running in parallel). Removing the limit for CPU is generally safe.
2) bump CPU limit for the operator
* Nice to have when handling large BFBs
3) bump memory limit to 5Gi
* Containers can get killed due to OOM when processing large BFBs