### PR TITLE
[DNM] helm: add noPrimaryCNI value to bootstrap operator without primary CNI

### DIFF
--- a/deployment/network-operator/templates/_helpers.tpl
+++ b/deployment/network-operator/templates/_helpers.tpl
@@ -67,6 +67,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Returns operator tolerations. When noPrimaryCNI is enabled, automatically
+appends the node.kubernetes.io/network-unavailable:NoSchedule toleration so
+the operator and its hook jobs can be scheduled before any CNI plugin is present.
+*/}}
+{{- define "network-operator.operator.tolerations" -}}
+{{- $tolerations := .Values.operator.tolerations | default list }}
+{{- if .Values.noPrimaryCNI }}
+{{- $noCNIToleration := dict "key" "node.kubernetes.io/network-unavailable" "operator" "Exists" "effect" "NoSchedule" }}
+{{- $tolerations = append $tolerations $noCNIToleration }}
+{{- end }}
+{{- if $tolerations }}
+{{- toYaml $tolerations }}
+{{- end }}
+{{- end }}
+
+{{/*
 imagePullSecrets helpers
 */}}
 {{- define "network-operator.operator.imagePullSecrets" }}

--- a/deployment/network-operator/templates/keep-ncp-hook.yaml
+++ b/deployment/network-operator/templates/keep-ncp-hook.yaml
@@ -69,9 +69,13 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.operator.tolerations }}
-      tolerations:
-      {{- toYaml . | nindent 8 }}
+      {{- $tolerations := include "network-operator.operator.tolerations" . | trim }}
+      {{- if $tolerations }}
+      tolerations:{{- $tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.noPrimaryCNI }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}-hooks-keep-ncp-sa
       imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -43,9 +43,13 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.operator.tolerations }}
-      tolerations:
-      {{- toYaml . | nindent 8 }}
+      {{- $tolerations := include "network-operator.operator.tolerations" . | trim }}
+      {{- if $tolerations }}
+      tolerations:{{- $tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.noPrimaryCNI }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}
       imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}

--- a/deployment/network-operator/templates/upgrade-crd-hook.yaml
+++ b/deployment/network-operator/templates/upgrade-crd-hook.yaml
@@ -70,9 +70,13 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.operator.tolerations }}
-      tolerations:
-      {{- toYaml . | nindent 8 }}
+      {{- $tolerations := include "network-operator.operator.tolerations" . | trim }}
+      {{- if $tolerations }}
+      tolerations:{{- $tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.noPrimaryCNI }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}-hooks-sa
       imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -326,6 +326,12 @@ operator:
 # Network Operator images.
 imagePullSecrets: []
 
+# -- Set to true when installing on a cluster with no primary CNI running.
+# Enables hostNetwork and adds the node.kubernetes.io/network-unavailable
+# toleration on the operator deployment and hook jobs, allowing them to
+# bootstrap before any CNI plugin is present.
+noPrimaryCNI: false
+
 # @ignore
 test:
   pf: ens2f0

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -326,6 +326,12 @@ operator:
 # Network Operator images.
 imagePullSecrets: []
 
+# -- Set to true when installing on a cluster with no primary CNI running.
+# Enables hostNetwork and adds the node.kubernetes.io/network-unavailable
+# toleration on the operator deployment and hook jobs, allowing them to
+# bootstrap before any CNI plugin is present.
+noPrimaryCNI: false
+
 # @ignore
 test:
   pf: ens2f0


### PR DESCRIPTION
When no primary CNI is running on the cluster, the operator and its pre-install hook jobs (keep-ncp, upgrade-crd) cannot start due to the node.kubernetes.io/network-unavailable:NoSchedule taint and the absence of a CNI plugin to create pod sandboxes.

Setting noPrimaryCNI=true enables hostNetwork on the operator deployment and hook jobs, and automatically adds the network-unavailable toleration via a new operator.tolerations helper in _helpers.tpl — allowing the operator to bootstrap before any CNI plugin is present.