### PR TITLE
fix: retry DOCA registry tag fetch on reconcile after transient errors

### DIFF
--- a/pkg/docadriverimages/doca_drivers.go
+++ b/pkg/docadriverimages/doca_drivers.go
@@ -19,8 +19,12 @@ package docadriverimages
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,13 +32,14 @@ import (
 	"github.com/Mellanox/network-operator/pkg/config"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -71,6 +76,8 @@ type provider struct {
 	ctx           context.Context
 	mu            sync.Mutex
 	lastError     error // tracks the last error from tag retrieval
+	// tagLister overrides remote.List when set (used in unit tests).
+	tagLister func(name.Repository, ...remote.Option) ([]string, error)
 }
 
 // TagExists returns true if DOCA driver image with provided tag exists
@@ -96,13 +103,25 @@ func (p *provider) SetImageSpec(spec *mellanoxv1alpha1.ImageSpec) {
 		p.mu.Unlock()
 		return
 	}
-	if reflect.DeepEqual(p.docaImageSpec, spec) {
-		p.mu.Unlock()
-		return
+	specChanged := p.docaImageSpec == nil || !reflect.DeepEqual(p.docaImageSpec, spec)
+	if specChanged {
+		p.docaImageSpec = spec
 	}
-	p.docaImageSpec = spec
+	lastErr := p.lastError
+	shouldRefresh := specChanged || (lastErr != nil && isRetryableRegistryError(lastErr))
+	retrying := !specChanged && shouldRefresh
 	p.mu.Unlock()
-	p.retrieveTags()
+	if shouldRefresh {
+		if retrying {
+			log.FromContext(p.ctx).Info("retrying DOCA driver image tag fetch after transient error",
+				"repo", spec.Repository, "image", spec.Image, "error", lastErr)
+		}
+		p.retrieveTags()
+	} else if !specChanged {
+		log.FromContext(p.ctx).Info("DOCA tag refresh skipped on reconcile",
+			"repo", spec.Repository, "image", spec.Image,
+			"hasLastError", lastErr != nil, "retryable", isRetryableRegistryError(lastErr), "lastError", lastErr)
+	}
 }
 
 func (p *provider) retrieveTags() {
@@ -120,7 +139,7 @@ func (p *provider) retrieveTags() {
 			Name:      name,
 			Namespace: config.FromEnv().State.NetworkOperatorResourceNamespace,
 		}, secret)
-		if errors.IsNotFound(err) {
+		if apiErrors.IsNotFound(err) {
 			continue
 		} else if err != nil {
 			logger.Error(err, "failed to get pull secret")
@@ -142,12 +161,93 @@ func (p *provider) retrieveTags() {
 		p.lastError = fmt.Errorf("failed to create repo: %w", err)
 		return
 	}
-	tags, err := remote.List(repo, remote.WithAuthFromKeychain(auth))
+	var tags []string
+	listOpts := []remote.Option{remote.WithAuthFromKeychain(auth)}
+	if p.tagLister != nil {
+		tags, err = p.tagLister(repo, listOpts...)
+	} else {
+		tags, err = remote.List(repo, listOpts...)
+	}
 	if err != nil {
-		logger.Error(err, "failed to list tags")
+		retryable := isRetryableRegistryError(fmt.Errorf("failed to list tags: %w", err))
+		logger.Info("failed to list DOCA driver image tags", "repo", p.docaImageSpec.Repository,
+			"image", p.docaImageSpec.Image, "retryable", retryable, "error", err)
 		p.lastError = fmt.Errorf("failed to list tags: %w", err)
 		return
 	}
 	p.tags = tags
 	p.lastError = nil // clear error on successful tag retrieval
+}
+
+func isRetryableRegistryError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var transportErr *transport.Error
+	if errors.As(err, &transportErr) {
+		if isNonRetryableTransportError(transportErr) {
+			return false
+		}
+		if transportErr.Temporary() {
+			return true
+		}
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	if strings.Contains(errMsg, "failed to create repo") ||
+		strings.Contains(errMsg, "failed to create registry auth from secrets") {
+		return false
+	}
+
+	// Treat tag-list failures as retryable unless classified non-retryable above
+	// (covers timeouts, DNS, TLS, and other network errors with varying wrappers).
+	if strings.Contains(errMsg, "failed to list tags") {
+		return true
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	if apiErrors.IsTimeout(err) || apiErrors.IsServerTimeout(err) ||
+		apiErrors.IsServiceUnavailable(err) || apiErrors.IsInternalError(err) {
+		return true
+	}
+
+	if strings.Contains(errMsg, "i/o timeout") ||
+		strings.Contains(errMsg, "connection refused") ||
+		strings.Contains(errMsg, "connection reset") ||
+		strings.Contains(errMsg, "no such host") ||
+		strings.Contains(errMsg, "server misbehaving") ||
+		strings.Contains(errMsg, "temporary failure in name resolution") ||
+		strings.Contains(errMsg, "tls:") {
+		return true
+	}
+
+	return false
+}
+
+func isNonRetryableTransportError(err *transport.Error) bool {
+	switch err.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	}
+	for _, d := range err.Errors {
+		switch d.Code {
+		case transport.UnauthorizedErrorCode, transport.DeniedErrorCode, transport.NameUnknownErrorCode:
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/docadriverimages/doca_drivers_test.go
+++ b/pkg/docadriverimages/doca_drivers_test.go
@@ -1,0 +1,196 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docadriverimages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
+)
+
+func TestDocaDriverImages(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "docadriverimages Suite")
+}
+
+var _ = Describe("isRetryableRegistryError", func() {
+	It("returns false for nil error", func() {
+		Expect(isRetryableRegistryError(nil)).To(BeFalse())
+	})
+
+	It("returns true for dial tcp i/o timeout", func() {
+		err := fmt.Errorf(`failed to list tags: Get "https://registry:443/v2/": dial tcp 10.0.0.1:443: i/o timeout`)
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns true for transport 503 errors", func() {
+		err := &transport.Error{StatusCode: http.StatusServiceUnavailable}
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns true for transport 429 errors", func() {
+		err := &transport.Error{StatusCode: http.StatusTooManyRequests}
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns false for transport 401 errors", func() {
+		err := &transport.Error{
+			StatusCode: http.StatusUnauthorized,
+			Errors:     []transport.Diagnostic{{Code: transport.UnauthorizedErrorCode}},
+		}
+		Expect(isRetryableRegistryError(err)).To(BeFalse())
+	})
+
+	It("returns false for transport 403 errors", func() {
+		err := &transport.Error{
+			StatusCode: http.StatusForbidden,
+			Errors:     []transport.Diagnostic{{Code: transport.DeniedErrorCode}},
+		}
+		Expect(isRetryableRegistryError(err)).To(BeFalse())
+	})
+
+	It("returns false for transport 404 NAME_UNKNOWN errors", func() {
+		err := &transport.Error{
+			StatusCode: http.StatusNotFound,
+			Errors:     []transport.Diagnostic{{Code: transport.NameUnknownErrorCode}},
+		}
+		Expect(isRetryableRegistryError(err)).To(BeFalse())
+	})
+
+	It("returns true for net timeout errors", func() {
+		err := &net.DNSError{IsTimeout: true}
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns true for exact acme.io no such host error from cluster", func() {
+		err := fmt.Errorf("failed to list tags: Get %q: dial tcp: lookup acme.io on 10.96.0.10:53: no such host",
+			"https://acme.io/v2/")
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns false for invalid repository name errors", func() {
+		err := fmt.Errorf("failed to create repo: invalid reference")
+		Expect(isRetryableRegistryError(err)).To(BeFalse())
+	})
+
+	It("returns true for no such host wrapped in failed to list tags", func() {
+		err := fmt.Errorf("failed to list tags: %w",
+			fmt.Errorf(`Get "https://acme.io/v2/": dial tcp: lookup acme.io: no such host`))
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns true for generic failed to list tags network error", func() {
+		err := fmt.Errorf("failed to list tags: %w", errors.New("unexpected EOF"))
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+
+	It("returns true for DNS server misbehaving", func() {
+		err := fmt.Errorf("failed to list tags: %w",
+			&net.DNSError{Name: "acme.io", Err: "server misbehaving", IsTimeout: false})
+		Expect(isRetryableRegistryError(err)).To(BeTrue())
+	})
+})
+
+var _ = Describe("SetImageSpec retry behavior", func() {
+	var (
+		ctx  context.Context
+		spec *mellanoxv1alpha1.ImageSpec
+		p    *provider
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		spec = &mellanoxv1alpha1.ImageSpec{
+			Image:      "mofed",
+			Repository: "nvcr.io/mellanox",
+			Version:    "23.10-0.5.5.0",
+		}
+	})
+
+	It("retries fetch when spec is unchanged and last error is retryable", func() {
+		callCount := 0
+		p = &provider{
+			ctx:           ctx,
+			docaImageSpec: spec,
+			tags:          []string{},
+			lastError: fmt.Errorf("failed to list tags: %w",
+				fmt.Errorf(`Get "https://registry:443/v2/": dial tcp 10.0.0.1:443: i/o timeout`)),
+			tagLister: func(_ name.Repository, _ ...remote.Option) ([]string, error) {
+				callCount++
+				return []string{"tag1"}, nil
+			},
+		}
+
+		p.SetImageSpec(spec)
+
+		Expect(callCount).To(Equal(1))
+		Expect(p.lastError).To(BeNil())
+		Expect(p.tags).To(Equal([]string{"tag1"}))
+	})
+
+	It("does not fetch when spec is unchanged and last fetch succeeded", func() {
+		callCount := 0
+		p = &provider{
+			ctx:           ctx,
+			docaImageSpec: spec,
+			tags:          []string{"existing-tag"},
+			lastError:     nil,
+			tagLister: func(_ name.Repository, _ ...remote.Option) ([]string, error) {
+				callCount++
+				return nil, nil
+			},
+		}
+
+		p.SetImageSpec(spec)
+
+		Expect(callCount).To(Equal(0))
+		Expect(p.tags).To(Equal([]string{"existing-tag"}))
+	})
+
+	It("does not fetch when spec is unchanged and last error is non-retryable", func() {
+		callCount := 0
+		p = &provider{
+			ctx:           ctx,
+			docaImageSpec: spec,
+			tags:          []string{},
+			lastError: fmt.Errorf("failed to list tags: %w", &transport.Error{
+				StatusCode: http.StatusUnauthorized,
+				Errors:     []transport.Diagnostic{{Code: transport.UnauthorizedErrorCode}},
+			}),
+			tagLister: func(_ name.Repository, _ ...remote.Option) ([]string, error) {
+				callCount++
+				return nil, nil
+			},
+		}
+
+		p.SetImageSpec(spec)
+
+		Expect(callCount).To(Equal(0))
+		Expect(p.lastError).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
When the initial registry list failed (e.g. i/o timeout during node restart), NicClusterPolicy could stay in state-OFED error until the next background poll (DOCA_DRIVER_IMAGE_POLL_TIME_MINUTES, default 30m). Retry tag listing on each reconcile while the last error is retryable, without increasing steady-state registry load after a successful fetch.