### PR TITLE
ci: add pre-GA artifacts for GA releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,22 @@ jobs:
 
         APP_VERSION=$git_tag VERSION=${git_tag:1} make chart-build chart-push  # VERSION as 'v' prefix removed
 
+    - name: Make pre-GA package and push (`git_tag-pre-ga` as chart version)
+      if: github.ref_type == 'tag' && !contains(github.ref_name, '-')
+      run: |
+        git_tag=${{ github.ref_name }}
+
+        # Patch values.yaml to point to nvstaging repositories
+        sed -i \
+          -e 's|nvcr.io/nvidia/mellanox|nvcr.io/nvstaging/mellanox|g' \
+          -e 's|nvcr.io/nvidia/cloud-native|nvcr.io/nvstaging/mellanox|g' \
+          deployment/network-operator/values.yaml
+
+        APP_VERSION=$git_tag VERSION=${git_tag:1}-pre-ga make chart-build chart-push
+
+        # Restore values.yaml so subsequent steps see the original production values
+        git checkout -- deployment/network-operator/values.yaml
+
   ocp-bundle:
     if: needs.docker-build-push.outputs.publish == 'true'
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -325,9 +325,18 @@ jobs:
           make release-build
           make generate-sosreport-maps
 
+          # Generate release-nvstaging.yaml for GA releases (no rc/beta suffix)
+          if ! echo "$APP_VERSION" | grep -q '-'; then
+            sed \
+              -e 's|nvcr.io/nvidia/mellanox|nvcr.io/nvstaging/mellanox|g' \
+              -e 's|nvcr.io/nvidia/cloud-native|nvcr.io/nvstaging/mellanox|g' \
+              hack/release.yaml > hack/release-nvstaging.yaml
+          fi
+
           if ! git diff --color --unified=0 --exit-code; then
             git add deployment/network-operator/
             git add hack/release.yaml
+            git add hack/release-nvstaging.yaml
             git add scripts/sosreport/network-operator-sosreport.sh
             git add scripts/sosreport/kubectl-netop_sosreport
             git commit -sam "cicd: release Network Operator $APP_VERSION"

--- a/hack/release-nvstaging.yaml
+++ b/hack/release-nvstaging.yaml
@@ -1,0 +1,206 @@
+NetworkOperator:
+  image: network-operator
+  repository: nvcr.io/nvstaging/mellanox
+  version: v26.4.0-beta.9
+  nSpectScope: gov-ready
+NetworkOperatorInitContainer:
+  image: network-operator-init-container
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: network-operator-init-container
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+SriovNetworkOperator:
+  image: sriov-network-operator
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: sriov-network-operator
+  version: network-operator-v26.4.0-beta.9
+  chartLocation: deployment/sriov-network-operator-chart
+  excludeChartFiles: ["Chart.yaml", "crds/k8s.cni.cncf.io_networkattachmentdefinitions_crd.yaml"]
+  nSpectScope: gov-ready
+SriovNetworkOperatorWebhook:
+  image: sriov-network-operator-webhook
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: sriov-network-operator
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+SriovConfigDaemon:
+  image: sriov-network-operator-config-daemon
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: sriov-network-operator
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: general
+SriovConfigDaemonStigFips:
+  image: sriov-network-operator-config-daemon-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: sriov-network-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips
+  nSpectScope: fedramp
+SriovCni:
+  image: sriov-cni
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: sriov-cni
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+SriovIbCni:
+  image: ib-sriov-cni
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: ib-sriov-cni
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+Mofed:
+  image: doca-driver
+  repository: nvcr.io/nvstaging/mellanox
+  version: doca3.5.0-26.07-0.0.9.0-0
+MofedStigFips:
+  image: doca-driver-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  version: doca3.5.0-26.07-0.0.9.0-0
+RdmaSharedDevicePlugin:
+  image: k8s-rdma-shared-dev-plugin
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: k8s-rdma-shared-dev-plugin
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+SriovDevicePlugin:
+  image: sriov-network-device-plugin
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: sriov-network-device-plugin
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+IbKubernetes:
+  image: ib-kubernetes
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: ib-kubernetes
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+CniPlugins:
+  image: plugins
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: k8snetworkplumbingwg-plugins
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+Multus:
+  image: multus-cni
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: multus-cni
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+Ipoib:
+  image: ipoib-cni
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: ipoib-cni
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+nvIpam:
+  image: nvidia-k8s-ipam
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nvidia-k8s-ipam
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+nicFeatureDiscovery:
+  image: nic-feature-discovery
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-feature-discovery
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+docaTelemetryService:
+  image: doca_telemetry
+  repository: nvcr.io/nvidia/doca
+  version: 1.25.5-doca3.4.0-host
+ovsCni:
+  image: ovs-cni-plugin
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: ovs-cni
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+rdmaCni:
+  image: rdma-cni
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: rdma-cni
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready
+nicConfigurationOperator:
+  image: nic-configuration-operator
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-configuration-operator
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: general
+nicConfigurationConfigDaemon:
+  image: nic-configuration-operator-daemon
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-configuration-operator
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: general
+nicConfigurationOperatorStigFipsUbuntu:
+  image: nic-configuration-operator-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-configuration-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips-ubuntu
+  nSpectScope: fedramp
+nicConfigurationConfigDaemonStigFipsUbuntu:
+  image: nic-configuration-operator-daemon-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-configuration-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips-ubuntu
+  nSpectScope: fedramp
+nicConfigurationOperatorStigFipsRhel:
+  image: nic-configuration-operator-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-configuration-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips-rhel
+  nSpectScope: fedramp
+nicConfigurationConfigDaemonStigFipsRhel:
+  image: nic-configuration-operator-daemon-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: nic-configuration-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips-rhel
+  nSpectScope: fedramp
+maintenanceOperator:
+  image: maintenance-operator
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: maintenance-operator
+  version: network-operator-v26.4.0-beta.9
+  chartLocation: deployment/maintenance-operator-chart
+  chartName: maintenance-operator-chart
+  nSpectScope: gov-ready
+spectrumXOperator:
+  image: spectrum-x-operator
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: spectrum-x-operator
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: general
+spectrumXOperatorStigFipsRhel:
+  image: spectrum-x-operator-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: spectrum-x-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips-rhel
+  nSpectScope: fedramp
+spectrumXOperatorStigFipsUbuntu:
+  image: spectrum-x-operator-stig-fips
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: spectrum-x-operator
+  version: network-operator-v26.4.0-beta.9-stig-fips-ubuntu
+  nSpectScope: fedramp
+xPlaneService:
+  image: xplane
+  repository: nvcr.io/nvstaging/doca
+  version: 3.4.0005
+nodeFeatureDiscovery:
+  image: node-feature-discovery
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: node-feature-discovery
+  version: network-operator-v26.4.0-beta.9
+  chartLocation: deployment/helm/node-feature-discovery
+  nSpectScope: gov-ready
+k8sLaunchKit:
+  image: k8s-launch-kit
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: NVIDIA/k8s-launch-kit
+  version: v26.4.0
+  nSpectScope: general
+DraDriverSriov:
+  image: dra-driver-sriov
+  repository: nvcr.io/nvstaging/mellanox
+  sourceRepository: dra-driver-sriov
+  version: network-operator-v26.4.0-beta.9
+  nSpectScope: gov-ready


### PR DESCRIPTION
On GA releases, generate hack/release-nvstaging.yaml (a copy of hack/release.yaml with repositories pointing to nvcr.io/nvstaging/mellanox) and commit it alongside release.yaml in the release PR, making it available at the GA tag for QA use.

Also add a pre-GA Helm chart build in the helm-package-publish job, triggered only on GA tags, that patches values.yaml to use nvstaging repositories and publishes the chart with version <VERSION>-pre-ga (e.g. 26.4.0-pre-ga).