### PR TITLE
ci: sync Dependabot config to release branches for owned components

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,15 @@ jobs:
           # tag for components
           TAG="network-operator-${APP_VERSION}"
           echo "component_tag=${TAG}" >> $GITHUB_OUTPUT
+
+          # whether to sync Dependabot config to the release branch: rc/ga only,
+          # never beta (betas are cut from master, the LTS branch is only real at rc)
+          if echo "$APP_VERSION" | grep -q 'beta'; then
+            SYNC_DEPENDABOT=false
+          else
+            SYNC_DEPENDABOT=true
+          fi
+          echo "sync_dependabot=${SYNC_DEPENDABOT}" >> $GITHUB_OUTPUT
       - id: set-chart-version
         run: |
           CHART_VERSION=$(echo ${APP_VERSION#v})
@@ -79,6 +88,7 @@ jobs:
       docker_registry_managed_components: ${{ steps.determine-docker-registry.outputs.docker_registry_managed_components }}
       docker_registry_staging: nvcr.io/nvstaging/mellanox
       release_branch: ${{ steps.set-version.outputs.release_branch }}
+      sync_dependabot: ${{ steps.set-version.outputs.sync_dependabot }}
 
   get-managed-components:
     needs: determine-versions
@@ -93,8 +103,22 @@ jobs:
           repos=$(yq -o=json 'to_entries | map(select(.value.sourceRepository != null and .value.sourceRepository != "NVIDIA/k8s-launch-kit") | .value.sourceRepository)' hack/release.yaml | jq -c 'unique')
           echo "Managed repositories: $repos"
           echo "managed_repos=$(echo $repos)" >> $GITHUB_OUTPUT
+      - id: set-dependabot-repos
+        run: |
+          # Repos whose dependabot.yaml we own (dependabotSyncManaged: true).
+          # Components keyed by sourceRepository; deduped to one entry per repo.
+          sync=$(yq -o=json 'to_entries | map(select(.value.dependabotSyncManaged == true and .value.sourceRepository != null) | .value.sourceRepository) | unique' hack/release.yaml | jq -c .)
+          # Mofed has no sourceRepository; its image is built from doca-driver-build
+          # (added to the matrix via include), so map its flag to that repo.
+          if [ "$(yq '.Mofed.dependabotSyncManaged // false' hack/release.yaml)" = "true" ] || \
+             [ "$(yq '.MofedStigFips.dependabotSyncManaged // false' hack/release.yaml)" = "true" ]; then
+            sync=$(echo "$sync" | jq -c '. + ["doca-driver-build"] | unique')
+          fi
+          echo "Dependabot-managed repositories: $sync"
+          echo "dependabot_managed_repos=$(echo $sync)" >> $GITHUB_OUTPUT
     outputs:
       managed_repos: ${{ steps.set-components.outputs.managed_repos }}
+      dependabot_managed_repos: ${{ steps.set-dependabot-repos.outputs.dependabot_managed_repos }}
 
   create-tags-for-components:
     runs-on: ubuntu-24.04
@@ -117,7 +141,7 @@ jobs:
           repository: ${{ github.repository_owner }}/${{ matrix.repo }}
           path: ${{ matrix.repo }}
           fetch-depth: 0
-      - name: Create tag to trigger PR that update image tags in network-operator values
+      - name: Ensure release branch exists
         run: |
           cd ${{ matrix.repo }}
           git config user.name  nvidia-ci-cd
@@ -133,6 +157,71 @@ jobs:
             git checkout -b $RELEASE_BRANCH
             git push -u origin $RELEASE_BRANCH
           fi
+
+      # Add a target-branch Dependabot entry for the new release branch on the
+      # component's default branch, so LTS branches receive version (security
+      # patch) updates. Runs only for owned configs (dependabot_managed_repos)
+      # on rc/ga (sync_dependabot). Non-blocking: a failure here must never hold
+      # up the release tag. Must run BEFORE the tag is cut.
+      - name: Sync Dependabot config for the new release branch
+        if: >-
+          needs.determine-versions.outputs.sync_dependabot == 'true' &&
+          contains(fromJson(needs.get-managed-components.outputs.dependabot_managed_repos), matrix.repo)
+        continue-on-error: true
+        run: |
+          cd ${{ matrix.repo }}
+          DEFAULT_BRANCH=$(gh repo view ${{ github.repository_owner }}/${{ matrix.repo }} --json defaultBranchRef -q .defaultBranchRef.name)
+          git checkout "$DEFAULT_BRANCH"
+          git pull origin "$DEFAULT_BRANCH"
+
+          CONFIG=.github/dependabot.yaml
+          [ -f "$CONFIG" ] || CONFIG=.github/dependabot.yml
+          if [ ! -f "$CONFIG" ]; then
+            echo "::warning::${{ matrix.repo }} is dependabotSyncManaged but has no $CONFIG; $RELEASE_BRANCH left uncovered"
+            exit 0
+          fi
+
+          # (1) already merged into the config on the default branch
+          if yq -e '.updates[] | select(.["target-branch"] == strenv(RELEASE_BRANCH))' "$CONFIG" >/dev/null 2>&1; then
+            echo "$RELEASE_BRANCH already present in $CONFIG; nothing to do"
+            exit 0
+          fi
+          # (2) a sync PR is already open from a prior rc.N run
+          if [ -n "$(gh pr list --repo ${{ github.repository_owner }}/${{ matrix.repo }} --head dependabot-sync-$RELEASE_BRANCH --state open --json number -q '.[].number')" ]; then
+            echo "dependabot-sync PR for $RELEASE_BRANCH already open; nothing to do"
+            exit 0
+          fi
+
+          # Clone every default-branch update entry, retarget it to the release
+          # branch, and restrict the LTS branch to patch-only bumps.
+          yq -i '.updates += [
+            .updates[] | select(has("target-branch") | not)
+            | . + {
+                "target-branch": strenv(RELEASE_BRANCH),
+                "ignore": ((.ignore // []) + [{"dependency-name": "*", "update-types": ["version-update:semver-major", "version-update:semver-minor"]}])
+              }
+          ]' "$CONFIG"
+
+          git checkout -b dependabot-sync-$RELEASE_BRANCH
+          git commit -sam "ci: add Dependabot config for $RELEASE_BRANCH"
+          # --force-with-lease: re-cut the CI-owned sync branch if a prior PR was
+          # closed without merging and left the remote branch behind. The lease
+          # (checkout uses fetch-depth: 0, so the remote-tracking ref exists)
+          # still refuses to clobber genuine concurrent pushes.
+          git push --force-with-lease -u origin dependabot-sync-$RELEASE_BRANCH
+          gh pr create \
+            --repo ${{ github.repository_owner }}/${{ matrix.repo }} \
+            --base "$DEFAULT_BRANCH" \
+            --head dependabot-sync-$RELEASE_BRANCH \
+            --title "ci: Dependabot config for $RELEASE_BRANCH" \
+            --body "Adds version updates for the \`$RELEASE_BRANCH\` release branch (patch-only). Auto-opened by the network-operator [*${{ github.job }}* job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) when the branch was cut."
+
+      # Cut the tag LAST, after the Dependabot PR has been raised. Step above
+      # switched to the default branch, so re-checkout the release branch here.
+      - name: Create release tag
+        run: |
+          cd ${{ matrix.repo }}
+          git checkout $RELEASE_BRANCH
 
           echo "Checking if tag already exists: $COMPONENT_TAG"
           if git ls-remote --tags origin | grep -q "refs/tags/$COMPONENT_TAG$"; then

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -1,3 +1,10 @@
+# dependabotSyncManaged: true marks components whose .github/dependabot.yaml we
+# own (the source repo is not a fork, or it is a fork but upstream ships no
+# dependabot config). For those, the Release workflow adds a target-branch
+# Dependabot entry to the component's default branch when a release branch is
+# cut (RC/GA only). Do NOT set it on forks whose dependabot config is synced
+# from upstream, or on repos with no dependabot config. See the create-tags-for-
+# components job in .github/workflows/release.yaml.
 NetworkOperator:
   image: network-operator
   repository: nvcr.io/nvstaging/mellanox
@@ -9,6 +16,7 @@ NetworkOperatorInitContainer:
   sourceRepository: network-operator-init-container
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 SriovNetworkOperator:
   image: sriov-network-operator
   repository: nvcr.io/nvstaging/mellanox
@@ -51,16 +59,19 @@ Mofed:
   image: doca-driver
   repository: nvcr.io/nvstaging/mellanox
   version: doca3.5.0-26.07-0.0.9.0-0
+  dependabotSyncManaged: true
 MofedStigFips:
   image: doca-driver-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   version: doca3.5.0-26.07-0.0.9.0-0
+  dependabotSyncManaged: true
 RdmaSharedDevicePlugin:
   image: k8s-rdma-shared-dev-plugin
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: k8s-rdma-shared-dev-plugin
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 SriovDevicePlugin:
   image: sriov-network-device-plugin
   repository: nvcr.io/nvstaging/mellanox
@@ -73,12 +84,14 @@ IbKubernetes:
   sourceRepository: ib-kubernetes
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 CniPlugins:
   image: plugins
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: k8snetworkplumbingwg-plugins
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 Multus:
   image: multus-cni
   repository: nvcr.io/nvstaging/mellanox
@@ -91,18 +104,21 @@ Ipoib:
   sourceRepository: ipoib-cni
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 nvIpam:
   image: nvidia-k8s-ipam
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nvidia-k8s-ipam
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 nicFeatureDiscovery:
   image: nic-feature-discovery
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nic-feature-discovery
   version: network-operator-v26.4.0-beta.9
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 docaTelemetryService:
   image: doca_telemetry
   repository: nvcr.io/nvidia/doca
@@ -125,36 +141,42 @@ nicConfigurationOperator:
   sourceRepository: nic-configuration-operator
   version: network-operator-v26.4.0-beta.9
   nSpectScope: general
+  dependabotSyncManaged: true
 nicConfigurationConfigDaemon:
   image: nic-configuration-operator-daemon
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nic-configuration-operator
   version: network-operator-v26.4.0-beta.9
   nSpectScope: general
+  dependabotSyncManaged: true
 nicConfigurationOperatorStigFipsUbuntu:
   image: nic-configuration-operator-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nic-configuration-operator
   version: network-operator-v26.4.0-beta.9-stig-fips-ubuntu
   nSpectScope: fedramp
+  dependabotSyncManaged: true
 nicConfigurationConfigDaemonStigFipsUbuntu:
   image: nic-configuration-operator-daemon-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nic-configuration-operator
   version: network-operator-v26.4.0-beta.9-stig-fips-ubuntu
   nSpectScope: fedramp
+  dependabotSyncManaged: true
 nicConfigurationOperatorStigFipsRhel:
   image: nic-configuration-operator-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nic-configuration-operator
   version: network-operator-v26.4.0-beta.9-stig-fips-rhel
   nSpectScope: fedramp
+  dependabotSyncManaged: true
 nicConfigurationConfigDaemonStigFipsRhel:
   image: nic-configuration-operator-daemon-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: nic-configuration-operator
   version: network-operator-v26.4.0-beta.9-stig-fips-rhel
   nSpectScope: fedramp
+  dependabotSyncManaged: true
 maintenanceOperator:
   image: maintenance-operator
   repository: nvcr.io/nvstaging/mellanox
@@ -163,24 +185,28 @@ maintenanceOperator:
   chartLocation: deployment/maintenance-operator-chart
   chartName: maintenance-operator-chart
   nSpectScope: gov-ready
+  dependabotSyncManaged: true
 spectrumXOperator:
   image: spectrum-x-operator
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: spectrum-x-operator
   version: network-operator-v26.4.0-beta.9
   nSpectScope: general
+  dependabotSyncManaged: true
 spectrumXOperatorStigFipsRhel:
   image: spectrum-x-operator-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: spectrum-x-operator
   version: network-operator-v26.4.0-beta.9-stig-fips-rhel
   nSpectScope: fedramp
+  dependabotSyncManaged: true
 spectrumXOperatorStigFipsUbuntu:
   image: spectrum-x-operator-stig-fips
   repository: nvcr.io/nvstaging/mellanox
   sourceRepository: spectrum-x-operator
   version: network-operator-v26.4.0-beta.9-stig-fips-ubuntu
   nSpectScope: fedramp
+  dependabotSyncManaged: true
 xPlaneService:
   image: xplane
   repository: nvcr.io/nvstaging/doca


### PR DESCRIPTION
## What

Make the Release workflow keep Dependabot working on LTS release branches
(`network-operator-<MAJOR.MINOR>.x`) of the component repos.

## Why

Dependabot only acts on a repo's **default branch** unless a config entry
explicitly sets `target-branch`. So once we cut a release branch in a
component repo, that branch got **zero** dependency updates — security and
patch bumps never reached our LTS lines.

## How

When `create-tags-for-components` cuts a release branch in a component
repo, it now also opens a PR on that repo's **default branch** adding a
`target-branch` Dependabot entry for the new branch. The entry is a clone
of each existing default-branch update entry, retargeted and restricted to
**patch-only** bumps (major/minor ignored) to keep stable branches quiet.

Opt-in is **per component**, via a new `dependabotSyncManaged` flag in
`hack/release.yaml`. Only repos whose Dependabot config we own are touched
— forks whose config is synced from upstream, and repos with no config,
are excluded. Classification (derived by inspecting each source repo):

| Category | Repos |
|---|---|
| **Ours (flagged)** | network-operator-init-container, k8s-rdma-shared-dev-plugin, ib-kubernetes, ipoib-cni, nvidia-k8s-ipam, nic-feature-discovery, nic-configuration-operator, maintenance-operator, spectrum-x-operator, doca-driver-build, k8snetworkplumbingwg-plugins\* |
| **Upstream-managed (skip)** | sriov-network-operator, sriov-cni, ib-sriov-cni, sriov-network-device-plugin, ovs-cni, rdma-cni, node-feature-discovery, dra-driver-sriov |
| **No dependabot (skip)** | multus-cni |

\* `k8snetworkplumbingwg-plugins` is a fork, but upstream ships no
dependabot config and we added our own — so it's ours. A blanket
"skip all forks" rule would wrongly exclude it; the per-component marker
is authoritative.

### Workflow changes

- `determine-versions`: new `sync_dependabot` output — `true` for rc/ga,
  `false` for beta (betas come off `master`; the LTS branch is only real
  at rc).
- `get-managed-components`: new `dependabot_managed_repos` output, derived
  from the markers (Mofed maps to the `doca-driver-build` matrix include).
- `create-tags-for-components`: the single tag step is split into three
  ordered steps — **ensure branch → sync Dependabot → cut tag** — so the
  **tag is cut after** the Dependabot PR is raised. The sync step is gated
  on `sync_dependabot` + marker membership, **non-blocking**
  (`continue-on-error: true`) so housekeeping never holds up a release,
  and **idempotent**: skips when the branch is already in the config or a
  `dependabot-sync` PR is already open (covers rc.1/rc.2/ga re-runs).

## Scope note

This enables Dependabot **version updates** on LTS branches. Alert-driven
**security updates** remain default-branch-only — a GitHub limitation no
config can change.

## Validation

- `yq`/`jq` derivation of `dependabot_managed_repos` produces exactly the
  11 expected repos.
- The clone-retarget transform was run against `ib-kubernetes`'s real
  `dependabot.yaml`: 3 originals preserved, 3 retargeted clones added, the
  `gomod` clone keeps its controller-runtime/k8s ignores and gains the
  patch-only block; the idempotency check fires on re-run.
- `actionlint` passes clean on the workflow.
