### PR TITLE
ci: use workflow metadata for Dependabot sync

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.determine-versions.outputs.base_branch }}
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-source
       - name: Validate downstreamFork consistency across entries sharing a sourceRepository
         run: |
           inconsistent=$(yq -o=json '.' hack/release.yaml | jq -c 'to_entries
@@ -126,12 +130,16 @@ jobs:
       - id: set-dependabot-repos
         run: |
           # Repos whose dependabot.yaml we own (dependabotSyncManaged: true).
+          # This ownership metadata is workflow policy, so read it from the
+          # workflow commit rather than the release branch. Older release
+          # branches may not carry the marker fields.
+          release_metadata=workflow-source/hack/release.yaml
           # Components keyed by sourceRepository; deduped to one entry per repo.
-          sync=$(yq -o=json '.' hack/release.yaml | jq -c 'to_entries | map(select(.value.dependabotSyncManaged == true and .value.sourceRepository != null) | .value.sourceRepository) | unique')
+          sync=$(yq -o=json '.' "$release_metadata" | jq -c 'to_entries | map(select(.value.dependabotSyncManaged == true and .value.sourceRepository != null) | .value.sourceRepository) | unique')
           # Mofed has no sourceRepository; its image is built from doca-driver-build
           # (added to the matrix via include), so map its flag to that repo.
-          if [ "$(yq '.Mofed.dependabotSyncManaged // false' hack/release.yaml)" = "true" ] || \
-             [ "$(yq '.MofedStigFips.dependabotSyncManaged // false' hack/release.yaml)" = "true" ]; then
+          if [ "$(yq '.Mofed.dependabotSyncManaged // false' "$release_metadata")" = "true" ] || \
+             [ "$(yq '.MofedStigFips.dependabotSyncManaged // false' "$release_metadata")" = "true" ]; then
             sync=$(echo "$sync" | jq -c '. + ["doca-driver-build"] | unique')
           fi
           echo "Dependabot-managed repositories: $sync"


### PR DESCRIPTION
## Summary
- Check out the workflow commit separately in `get-managed-components`.
- Read `dependabotSyncManaged` ownership metadata from that workflow source instead of the release branch.
- Keep release component and downstream-fork metadata sourced from the release branch.

## Root cause
For RC releases, `get-managed-components` checks out `base_branch` such as `v26.1.x`. Older release branches do not contain the newer `dependabotSyncManaged` markers, so `dependabot_managed_repos` becomes `[]` and the Dependabot sync step is skipped for every matrix repo even though `sync_dependabot` is true.

## Validation
- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/release.yaml"); puts "yaml ok"'`\n- `ruby -ryaml -e 'doc=YAML.load_file(".github/workflows/release.yaml"); step=doc["jobs"]["get-managed-components"]["steps"].find{|s| s["id"] == "set-dependabot-repos"}; print step["run"]' | bash -n`\n- `git diff --check -- .github/workflows/release.yaml`