### PR TITLE
cicd: fix git add of release-nvstaging.yaml for RC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -494,7 +494,9 @@ jobs:
           if ! git diff --color --unified=0 --exit-code; then
             git add deployment/network-operator/
             git add hack/release.yaml
-            git add hack/release-nvstaging.yaml
+            if ! echo "$APP_VERSION" | grep -q '-'; then
+              git add hack/release-nvstaging.yaml
+            fi
             git add scripts/sosreport/network-operator-sosreport.sh
             git add scripts/sosreport/kubectl-netop_sosreport
             git commit -sam "cicd: release Network Operator $APP_VERSION"


### PR DESCRIPTION
The file hack/release-nvstaging.yaml is only generated for GA releases (versions without a '-' suffix), but was unconditionally staged with `git add`, causing the create-release-pr job to fail with exit code 128 for RC/beta releases. Guard the `git add` with the same condition used to generate the file.