### PR TITLE
chore: sync NIC configuration CRDs

### DIFF
--- a/manifests/state-nic-configuration-operator/001-configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/manifests/state-nic-configuration-operator/001-configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -158,8 +158,8 @@ spec:
                         description: Specifies whether to enable PCI performance optimization
                         type: boolean
                       maxAccOutRead:
-                        description: Specifies the PCIe Max Accumulative Outstanding
-                          read bytes
+                        description: 'Deprecated: this field is ignored and no longer
+                          maps to MAX_ACC_OUT_READ.'
                         type: integer
                       maxReadRequest:
                         description: Specifies the size of a single PCI read request

--- a/manifests/state-nic-configuration-operator/002-configuration.net.nvidia.com_nicdevices.yaml
+++ b/manifests/state-nic-configuration-operator/002-configuration.net.nvidia.com_nicdevices.yaml
@@ -125,8 +125,8 @@ spec:
                               optimization
                             type: boolean
                           maxAccOutRead:
-                            description: Specifies the PCIe Max Accumulative Outstanding
-                              read bytes
+                            description: 'Deprecated: this field is ignored and no
+                              longer maps to MAX_ACC_OUT_READ.'
                             type: integer
                           maxReadRequest:
                             description: Specifies the size of a single PCI read request
@@ -483,6 +483,11 @@ spec:
                 items:
                   description: NicDevicePortSpec describes the ports of the NIC
                   properties:
+                    fwctlDevice:
+                      description: |-
+                        FwctlDevice is the fwctl character device path for this port, e.g. /dev/fwctl/fwctl0.
+                        Empty when the host does not expose a fwctl device for this PCI function.
+                      type: string
                     networkInterface:
                       description: NetworkInterface is the name of the network interface
                         for this port, e.g. eth1


### PR DESCRIPTION
## What this PR does

Syncs the vendored NIC Configuration Operator CRDs with `Mellanox/nic-configuration-operator@db9d5bdd2db1a4dc81b7c6b06ec14ec7394f4cd4` (`upstream/main` as of 2026-07-28).

The generated schema changes:
- mark `maxAccOutRead` as deprecated in the configuration template and device schemas
- expose `status.ports[].fwctlDevice` in the `NicDevice` CRD

All five vendored CRDs were compared with the source chart CRDs; the other three were already current. Network Operator copyright headers are preserved.

## Validation

- compared all five vendored CRD bodies byte-for-byte with the source chart CRDs
- parsed all five CRDs with Ruby YAML
- `git diff --check -- manifests/state-nic-configuration-operator`
- `go test ./pkg/state -count=1 -ginkgo.focus='NIC Configuration Operator Controller'`