### PR TITLE
fix: improve sosreport component diagnostics

### DIFF
--- a/scripts/sosreport/README.md
+++ b/scripts/sosreport/README.md
@@ -40,8 +40,12 @@ kubectl netop-sosreport --help
 ### Features
 
 - **Automatic Detection**: Auto-detects the Network Operator namespace
-- **Comprehensive Collection**: Gathers CRDs, workloads, logs, and diagnostic data
+- **Comprehensive Collection**: Gathers CRDs, workloads, logs, and diagnostic data from every known component
+- **Helm Release Discovery**: Finds chart and sub-chart workloads by release label so optional or newly added components are not omitted
 - **Graceful Error Handling**: Continues collection even if some resources fail
+- **Capability-Aware Diagnostics**: Records unavailable optional tools as skipped instead of collection failures
+- **All Container Logs**: Collects current and previous logs from regular, init, and ephemeral containers
+- **SR-IOV Operator Coverage**: Collects resources and container logs from bundled and standalone deployments
 - **Configurable**: Multiple options to customize the collection behavior
 - **Platform Aware**: Detects OpenShift vs vanilla Kubernetes
 
@@ -52,9 +56,9 @@ The collection script automatically generates a self-contained HTML report (`rep
 **Features:**
 - Executive dashboard with overall NicClusterPolicy status, node count, pod health, and error summary
 - NicClusterPolicy applied states table with color-coded status badges
-- Component health grid showing all 22 components with desired/ready replicas, pod counts, and restart counts
+- Component health grid showing discovered components with desired/ready replicas, pod counts, and restart counts
 - Per-component detail panels with workload YAML, pod status, and log viewers with error/warning highlighting
-- OFED diagnostics per node (lsmod, ibstat, ibv_devinfo, mst status, dmesg, ip link/addr)
+- OFED diagnostics per node (RDMA, devlink, sysfs, kernel, network, and optional legacy tools)
 - Node overview with summary table, resource allocation, and labels
 - Events timeline with warning highlighting
 - CRD inventory with definitions and instances
@@ -80,7 +84,7 @@ python3 generate-report.py ./network-operator-sosreport-20260218-143000/ --templ
 ### What's Collected
 
 #### Custom Resources
-- NicClusterPolicy, MacVlanNetwork, HostDeviceNetwork, IPoIBNetwork
+- NicClusterPolicy, NicNodePolicy, MacVlanNetwork, HostDeviceNetwork, IPoIBNetwork
 - IPPools, CIDRPools (NV-IPAM)
 - NICDevice, NICConfigurationTemplate, NICFirmwareResource, etc.
 - NetworkAttachmentDefinitions (Multus)
@@ -93,7 +97,7 @@ python3 generate-report.py ./network-operator-sosreport-20260218-143000/ --templ
 - Events in operator namespace
 - Webhook configurations
 
-#### Component Workloads (15 components)
+#### Component Workloads
 - OFED Driver
 - NIC Feature Discovery
 - SR-IOV Device Plugin
@@ -106,11 +110,24 @@ python3 generate-report.py ./network-operator-sosreport-20260218-143000/ --templ
 - NIC Configuration Operator (Daemon and Controller)
 - DOCA Telemetry Service
 - Spectrum-X Operator
+- Node Feature Discovery (Master, Worker, Garbage Collector, and optional Topology Updater)
+- SR-IOV Network Operator controller, config daemon, webhook, resource injector,
+  device plugin, metrics exporter, and DRA driver (when deployed by Network Operator)
+- Maintenance Operator (when deployed by Network Operator)
+
+The collector also discovers every workload carrying the Network Operator Helm
+release's `app.kubernetes.io/instance` label. This release-scoped fallback
+captures optional and future parent-chart or sub-chart components without
+collecting unrelated pods when the operator shares a namespace. A complete
+release inventory is stored under `operator/helm-release/`, including
+Deployments, DaemonSets, StatefulSets, ReplicaSets, Jobs, CronJobs,
+PodDisruptionBudgets, and NetworkPolicies that are present during collection.
 
 For each component:
-- DaemonSet/Deployment specifications
+- Workload specifications (including DaemonSets, Deployments, StatefulSets,
+  ReplicaSets, Jobs, CronJobs, and standalone Pods)
 - All pod details and status
-- Current and previous logs (if restarted)
+- Current and previous logs from every regular, init, and ephemeral container
 - Related ConfigMaps and Services
 
 #### Node Information
@@ -120,13 +137,21 @@ For each component:
 - Node-specific labels (feature.node.kubernetes.io/*)
 
 #### Diagnostic Commands (from OFED pods)
+
+Portable diagnostics used by current MOFED/DOCA driver containers:
+
 - `lsmod | grep mlx` - Loaded Mellanox modules
-- `ibstat` - InfiniBand device status
-- `ibv_devinfo` - RDMA device information
-- `mst status` - Mellanox Software Tools status
+- `rdma dev show` and `rdma link show` - RDMA devices and links
+- `devlink dev show`, `devlink dev info`, and `devlink port show` - devlink inventory
+- InfiniBand sysfs attributes - device, port, state, firmware, and GUID data
 - Kernel version
 - Recent dmesg output
 - Network interface information
+
+The collector also runs `ibstat`, `ibv_devinfo`, and `mst status` when those
+optional legacy tools are installed. An unavailable command is recorded as
+`SKIPPED` in the node's `diagnostic_status.txt`; it is not written as an error
+to `collection-errors.log`. Command execution failures are still reported.
 
 #### Cluster-Wide Resources
 - Kubernetes version
@@ -158,9 +183,9 @@ For each component:
 # Skip diagnostic commands for faster collection
 # This skips executing commands inside OFED pods:
 #   - lsmod | grep mlx (loaded Mellanox kernel modules)
-#   - ibstat (InfiniBand device status)
-#   - ibv_devinfo (RDMA device information)
-#   - mst status (Mellanox Software Tools status)
+#   - rdma and devlink inventory
+#   - InfiniBand sysfs attributes
+#   - ibstat, ibv_devinfo, and mst status (when installed)
 #   - dmesg (kernel messages)
 #   - ip link/addr (network interface information)
 ./network-operator-sosreport.sh --skip-diagnostics
@@ -185,7 +210,8 @@ Options:
   --no-compress              Don't create tarball, leave as directory
   --log-lines N              Number of log lines to collect per pod (default: 5000)
   --skip-diagnostics         Skip running diagnostic commands in OFED pods
-                             (lsmod, ibstat, ibv_devinfo, mst, dmesg, ip commands)
+                             (lsmod, rdma, devlink, sysfs, optional legacy tools,
+                             dmesg, and ip commands)
                              Use this for faster collection when driver-level diagnostics are not needed
   --skip-report              Skip HTML report generation
   --kubectl-path PATH        Path to kubectl binary (default: kubectl from PATH)
@@ -221,22 +247,28 @@ network-operator-sosreport-<timestamp>/
 │   ├── events.yaml                   # Namespace events
 │   ├── validatingwebhookconfigurations.yaml
 │   ├── mutatingwebhookconfigurations.yaml
+│   ├── helm-release/                 # Complete parent/sub-chart resource inventory
+│   │   ├── workloads/                # Deployments, DaemonSets, Jobs, etc.
+│   │   ├── poddisruptionbudgets.yaml
+│   │   └── networkpolicies.yaml
 │   └── components/
 │       ├── network-operator/         # Operator controller
 │       │   ├── deployment.yaml
 │       │   └── pods/
 │       │       ├── <pod-name>.yaml
-│       │       ├── <pod-name>.log
-│       │       └── <pod-name>-previous.log
+│       │       ├── <pod-name>-<container>.log
+│       │       ├── <pod-name>-init-<container>.log
+│       │       ├── <pod-name>-ephemeral-<container>.log
+│       │       └── *-previous.log
 │       ├── ofed-driver/
 │       │   ├── daemonset.yaml
 │       │   ├── pods/
-│       │   └── diagnostics/          # Host commands output
+│       │   └── diagnostics/          # Command output and per-node status
 │       ├── rdma-shared-dp-ds/
 │       ├── sriov-device-plugin/
 │       ├── nv-ipam-node/
 │       ├── nv-ipam-controller/
-│       └── ...                       # All components
+│       └── ...                       # Known and Helm-discovered components
 ├── nodes/
 │   ├── all-nodes.yaml                # All nodes with full details
 │   ├── nodes-summary.txt             # Node summary table
@@ -245,7 +277,12 @@ network-operator-sosreport-<timestamp>/
 ├── network/
 │   └── services.yaml
 ├── related-operators/
-│   └── sriov-network-operator/       # If present
+│   └── sriov-network-operator/       # Standalone deployment, if present
+│       └── <namespace>/
+│           ├── deployments.yaml
+│           ├── daemonsets.yaml
+│           ├── events.yaml
+│           └── pods/                 # Pod YAML plus current/previous container logs
 ├── diagnostic-summary.txt            # Quick summary and issues
 ├── report.html                       # Interactive HTML report
 └── collection-errors.log             # Any errors during collection

--- a/scripts/sosreport/generate-maps.sh
+++ b/scripts/sosreport/generate-maps.sh
@@ -42,6 +42,19 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+# Convert one YAML label line into a kubectl selector. Preserve NameSuffix as a
+# marker so the collector can expand it to the base NicClusterPolicy value and
+# all current NicNodePolicy-suffixed values. Other templates are removed.
+format_label_selector() {
+    echo "$1" | sed -E \
+        -e 's/^[[:space:]]+//' \
+        -e 's/[[:space:]]*\{\{[[:space:]]*\.NameSuffix[[:space:]]*\}\}/__NAME_SUFFIX__/g' \
+        -e 's/[[:space:]]*\{\{.*$//' \
+        -e 's/:[[:space:]]*/=/' \
+        -e 's/"//g' \
+        -e 's/[[:space:]]+$//'
+}
+
 # Extract CRD names from manifests
 extract_crds() {
     local crds=()
@@ -95,25 +108,30 @@ extract_components() {
                 fi
 
                 # Extract component name from metadata.name in the manifest
-                comp_name=$(grep -A2 "^metadata:" "$manifest" 2>/dev/null | grep "name:" | head -1 | awk '{print $2}')
+                comp_name=$(grep -A2 "^metadata:" "$manifest" 2>/dev/null | grep "name:" | head -1 | awk '{print $2}' | sed 's/{{.*//')
                 # Fallback to directory name if metadata.name not found
                 [ -z "$comp_name" ] && comp_name=$(basename "$state_dir" | sed 's/state-//')
 
                 # Skip if already found for this component
                 [ -n "${components[$comp_name]}" ] && continue
 
-                # Extract labels from matchLabels section, skip lines with Go templates
-                # Try to find a stable label (one without {{ }})
+                # Extract labels from the matchLabels area. NameSuffix values
+                # retain a marker that is expanded by the collector at runtime.
                 local labels
-                labels=$(grep -A10 "matchLabels:" "$manifest" 2>/dev/null | grep -v "matchLabels:" | grep -v "^--$" | grep -v "{{" | head -5)
+                labels=$(grep -A12 "matchLabels:" "$manifest" 2>/dev/null \
+                    | grep -E '^[[:space:]]+[[:alnum:]_.\/-]+:' \
+                    | grep -vE '^[[:space:]]+(matchLabels|template|metadata|labels|spec):' \
+                    | head -10)
 
-                # Get first non-template label
-                label=$(echo "$labels" | head -1 | sed 's/^ *//' | sed 's/: */=/' | tr -d ' ' | sed 's/=""$/=/')
+                # Get the first label, preserving a runtime marker for
+                # NicNodePolicy suffixes.
+                label=$(format_label_selector "$(echo "$labels" | head -1)")
 
-                # If the manifest has Go templates and we found nvidia.com label, prefer it
-                if grep -q "{{" "$manifest" 2>/dev/null; then
+                # The OFED app label is entirely runtime-generated, so prefer
+                # its stable presence label when it is available.
+                if echo "$labels" | grep -q "nvidia.com/ofed-driver"; then
                     local nvidia_label
-                    nvidia_label=$(echo "$labels" | grep "nvidia.com" | head -1 | sed 's/^ *//' | sed 's/: */=/' | tr -d ' ' | sed 's/=""$/=/')
+                    nvidia_label=$(format_label_selector "$(echo "$labels" | grep "nvidia.com/ofed-driver" | head -1)")
                     [ -n "$nvidia_label" ] && label="$nvidia_label"
                 fi
 
@@ -183,7 +201,7 @@ generate_crds_section() {
 generate_components_section() {
     echo "    # [GENERATED-COMPONENTS-START] - Auto-generated, do not edit manually"
     echo "    # Generated at: $TIMESTAMP"
-    echo "    # Component definitions: name, label, type"
+    echo "    # Component definitions: name, workload label, type, optional pod label"
     echo "    declare -A components=("
 
     echo "        # Main Network Operator components"
@@ -198,11 +216,16 @@ generate_components_section() {
     echo "        [\"nfd-master\"]=\"app.kubernetes.io/name=node-feature-discovery,app.kubernetes.io/component=master|deployment\""
     echo "        [\"nfd-worker\"]=\"app.kubernetes.io/name=node-feature-discovery,app.kubernetes.io/component=worker|daemonset\""
     echo "        [\"nfd-gc\"]=\"app.kubernetes.io/name=node-feature-discovery,app.kubernetes.io/component=gc|deployment\""
+    echo "        [\"nfd-topology-updater\"]=\"app.kubernetes.io/name=node-feature-discovery,role=topology-updater|daemonset\""
 
     echo "        # SR-IOV Network Operator (sub-chart)"
-    echo "        [\"sriov-network-operator\"]=\"app=sriov-network-operator|deployment\""
+    echo "        [\"sriov-network-operator\"]=\"app.kubernetes.io/name=sriov-network-operator|deployment|name=sriov-network-operator\""
     echo "        [\"sriov-network-config-daemon\"]=\"app=sriov-network-config-daemon|daemonset\""
-    echo "        [\"sriov-network-resources-injector\"]=\"app=network-resources-injector|deployment\""
+    echo "        [\"sriov-network-resources-injector\"]=\"app=network-resources-injector|daemonset\""
+    echo "        [\"sriov-network-operator-webhook\"]=\"app=operator-webhook|daemonset\""
+    echo "        [\"sriov-network-device-plugin\"]=\"app=sriov-device-plugin|daemonset\""
+    echo "        [\"sriov-network-metrics-exporter\"]=\"app=sriov-network-metrics-exporter|daemonset\""
+    echo "        [\"sriov-dra-driver\"]=\"app=sriov-dra-driver|daemonset\""
 
     echo "        # Maintenance Operator (sub-chart)"
     echo "        [\"maintenance-operator\"]=\"app.kubernetes.io/name=maintenance-operator|deployment\""
@@ -303,6 +326,7 @@ update_maps() {
 
     mv "${temp_file}.2" "$SCRIPT_FILE"
     rm -f "$temp_file"
+    chmod +x "$SCRIPT_FILE"
 
     local crd_count
     crd_count=$(extract_crds | wc -l)
@@ -311,7 +335,7 @@ update_maps() {
 
     log_info "Updated: $SCRIPT_FILE"
     log_info "  - CRDs: $crd_count (from manifests) + 12 (sub-charts)"
-    log_info "  - Components: $component_count (from manifests) + 7 (sub-charts)"
+    log_info "  - Components: $component_count (from manifests) + 11 (sub-charts)"
 }
 
 # Main

--- a/scripts/sosreport/generate-report.py
+++ b/scripts/sosreport/generate-report.py
@@ -509,14 +509,20 @@ def render_components(report_dir):
             # Determine workload type
             workload_type = "unknown"
             workload_file = ""
-            ds_file = os.path.join(comp_path, "daemonset.yaml")
-            dep_file = os.path.join(comp_path, "deployment.yaml")
-            if os.path.isfile(ds_file):
-                workload_type = "DaemonSet"
-                workload_file = ds_file
-            elif os.path.isfile(dep_file):
-                workload_type = "Deployment"
-                workload_file = dep_file
+            workload_files = [
+                ("DaemonSet", os.path.join(comp_path, "daemonset.yaml")),
+                ("Deployment", os.path.join(comp_path, "deployment.yaml")),
+                ("StatefulSet", os.path.join(comp_path, "statefulset.yaml")),
+                ("ReplicaSet", os.path.join(comp_path, "replicaset.yaml")),
+                ("Job", os.path.join(comp_path, "job.yaml")),
+                ("CronJob", os.path.join(comp_path, "cronjob.yaml")),
+                ("Pod", os.path.join(comp_path, "pod.yaml")),
+            ]
+            for candidate_type, candidate_file in workload_files:
+                if os.path.isfile(candidate_file):
+                    workload_type = candidate_type
+                    workload_file = candidate_file
+                    break
 
             # Extract replica counts
             desired = "-"
@@ -526,6 +532,12 @@ def render_components(report_dir):
                 if workload_type == "DaemonSet":
                     desired = extract_yaml_field(wf_content, "desiredNumberScheduled") or "-"
                     ready_count = extract_yaml_field(wf_content, "numberReady") or "-"
+                elif workload_type == "Job":
+                    desired = extract_yaml_field(wf_content, "completions") or "1"
+                    ready_count = extract_yaml_field(wf_content, "succeeded") or "0"
+                elif workload_type in ("CronJob", "Pod"):
+                    desired = "-"
+                    ready_count = "-"
                 else:
                     desired = extract_yaml_field(wf_content, "replicas") or "-"
                     ready_count = extract_yaml_field(wf_content, "readyReplicas") or "-"
@@ -597,7 +609,7 @@ def render_components(report_dir):
             parts.append('<div class="comp-row-detail">\n')
 
             # Workload YAML files
-            for wf in [ds_file, dep_file]:
+            for _, wf in workload_files:
                 if os.path.isfile(wf):
                     parts.append(collapsible(
                         os.path.basename(wf),
@@ -632,16 +644,46 @@ def render_components(report_dir):
                         "yaml-block",
                     ))
 
-                    # Pod logs
-                    log_file = os.path.join(pods_dir, f"{pod_name}.log")
-                    if os.path.isfile(log_file) and os.path.getsize(log_file) > 0:
+                    # Pod logs. Current collections store one file per
+                    # container; retain support for the historical
+                    # single-container filename when rendering older archives.
+                    pod_logs = sorted(set(
+                        glob.glob(os.path.join(pods_dir, f"{pod_name}.log"))
+                        + glob.glob(os.path.join(pods_dir, f"{pod_name}-*.log"))
+                    ))
+                    for log_file in pod_logs:
+                        if not os.path.isfile(log_file) or os.path.getsize(log_file) == 0:
+                            continue
+
+                        log_basename = os.path.basename(log_file)
+                        is_previous = log_basename.endswith("-previous.log")
+
+                        suffix = log_basename[len(pod_name):]
+                        if suffix.endswith(".log"):
+                            suffix = suffix[:-4]
+                        if suffix.endswith("-previous"):
+                            suffix = suffix[:-9]
+                        container_name = suffix[1:] if suffix.startswith("-") else suffix
+                        container_type = "Container"
+                        if container_name.startswith("init-"):
+                            container_type = "Init Container"
+                            container_name = container_name[len("init-"):]
+                        elif container_name.startswith("ephemeral-"):
+                            container_type = "Ephemeral Container"
+                            container_name = container_name[len("ephemeral-"):]
+
+                        log_kind = "Previous " if is_previous else ""
+                        log_kind += f"{container_type} Logs"
+                        if container_name:
+                            log_kind += f" ({container_name})"
+
                         log_content = read_file(log_file)
                         escaped_log = highlight_logs(html.escape(log_content))
                         log_lines = len(log_content.split("\n"))
                         parts.append('<details class="collapsible">\n')
                         parts.append(
-                            f'<summary>Logs <span class="line-count">'
-                            f"{log_lines} lines</span></summary>\n"
+                            f'<summary>{html.escape(log_kind)} '
+                            f'<span class="line-count">{log_lines} lines</span></summary>\n'
                         )
                         parts.append(
                             f'<div class="collapsible-content">'
@@ -649,26 +691,31 @@ def render_components(report_dir):
                         )
                         parts.append("</details>\n")
 
-                    # Previous logs
-                    prev_log = os.path.join(pods_dir, f"{pod_name}-previous.log")
-                    if os.path.isfile(prev_log) and os.path.getsize(prev_log) > 0:
-                        prev_content = read_file(prev_log)
-                        escaped_prev = highlight_logs(html.escape(prev_content))
-                        prev_lines = len(prev_content.split("\n"))
-                        parts.append('<details class="collapsible">\n')
-                        parts.append(
-                            f'<summary>Previous Logs <span class="line-count">'
-                            f"{prev_lines} lines</span></summary>\n"
-                        )
-                        parts.append(
-                            f'<div class="collapsible-content">'
-                            f"<pre><code>{escaped_prev}</code></pre></div>\n"
-                        )
-                        parts.append("</details>\n")
-
                     parts.append("</div>\n")
 
             parts.append("</div></details>\n")
+
+        # Preserve a release-wide inventory in addition to the per-component
+        # view. This includes chart workloads with no current pods (for example
+        # scaled-down controllers or completed Helm hook Jobs).
+        release_dir = os.path.join(report_dir, "operator", "helm-release")
+        if os.path.isdir(release_dir):
+            parts.append("<h3>Helm Release Artifacts</h3>\n")
+            release_files = []
+            for root, _, filenames in os.walk(release_dir):
+                for filename in filenames:
+                    if filename.endswith((".yaml", ".yml", ".txt")):
+                        release_files.append(os.path.join(root, filename))
+
+            for release_file in sorted(release_files):
+                if os.path.getsize(release_file) == 0:
+                    continue
+                relative_name = os.path.relpath(release_file, release_dir)
+                parts.append(collapsible(
+                    html.escape(relative_name),
+                    file_content_escaped(release_file),
+                    "yaml-block",
+                ))
 
     parts.append("""\
 </div>
@@ -704,8 +751,10 @@ def render_diagnostics(report_dir):
     else:
         # Group files by node name
         known_commands = [
-            "lsmod", "ibstat", "ibv_devinfo", "mst_status",
-            "kernel_version", "dmesg", "ip_link", "ip_addr",
+            "diagnostic_status", "lsmod", "ibstat", "ibv_devinfo", "mst_status",
+            "rdma_dev", "rdma_link", "devlink_dev", "devlink_info",
+            "devlink_port", "infiniband_sysfs", "kernel_version", "dmesg",
+            "ip_link", "ip_addr",
         ]
         seen_nodes = []
         seen_set = set()
@@ -744,12 +793,21 @@ def render_diagnostics(report_dir):
 
                 # Each diagnostic command as a collapsible
                 display_commands = [
-                    "lsmod", "ibstat", "ibv_devinfo", "mst_status",
-                    "dmesg", "ip_link", "ip_addr",
+                    "diagnostic_status", "lsmod", "ibstat", "ibv_devinfo",
+                    "mst_status", "rdma_dev", "rdma_link", "devlink_dev",
+                    "devlink_info", "devlink_port", "infiniband_sysfs",
+                    "kernel_version", "dmesg", "ip_link", "ip_addr",
                 ]
                 display_names = {
+                    "diagnostic_status": "Diagnostic command status",
                     "lsmod": "lsmod | grep mlx",
                     "mst_status": "mst status",
+                    "rdma_dev": "rdma dev show",
+                    "rdma_link": "rdma link show",
+                    "devlink_dev": "devlink dev show",
+                    "devlink_info": "devlink dev info",
+                    "devlink_port": "devlink port show",
+                    "infiniband_sysfs": "InfiniBand sysfs state",
                     "kernel_version": "Kernel Version",
                     "ip_link": "ip link show",
                     "ip_addr": "ip addr show",
@@ -1204,17 +1262,27 @@ def render_related_operators(report_dir):
         for op_path in sorted_dirs(related_dir):
             op_name = os.path.basename(op_path)
             parts.append(f"<h4>{html.escape(op_name)}</h4>\n")
-            # Collect .yaml and .txt files
-            files = sorted(
-                glob.glob(os.path.join(op_path, "*.yaml"))
-                + glob.glob(os.path.join(op_path, "*.txt"))
-            )
+            # Related operators may have one directory per discovered
+            # namespace and nested pod logs. Render the full tree so
+            # standalone SR-IOV logs are visible in the HTML report.
+            files = []
+            for root, _, filenames in os.walk(op_path):
+                for filename in filenames:
+                    if filename.endswith((".yaml", ".yml", ".txt", ".log")):
+                        files.append(os.path.join(root, filename))
+
+            files.sort()
             for f in files:
                 if not os.path.isfile(f) or os.path.getsize(f) == 0:
                     continue
+
+                relative_name = os.path.relpath(f, op_path)
+                content = file_content_escaped(f)
+                if f.endswith(".log"):
+                    content = highlight_logs(content)
                 parts.append(collapsible(
-                    html.escape(os.path.basename(f)),
-                    file_content_escaped(f),
+                    html.escape(relative_name),
+                    content,
                     "yaml-block",
                 ))
 
@@ -1402,7 +1470,7 @@ def main():
         "SECTION_RBAC": render_rbac(report_dir),
         "SECTION_NETWORK": render_network(report_dir),
         "SECTION_CONFIG": render_config(report_dir),
-        "SECTION_RELATED_OPERATORS": render_related_operators(report_dir),
+        "SECTION_RELATED": render_related_operators(report_dir),
         "SECTION_ERRORS": render_errors(report_dir),
     }
 

--- a/scripts/sosreport/kubectl-netop_sosreport
+++ b/scripts/sosreport/kubectl-netop_sosreport
@@ -41,6 +41,15 @@ VERBOSE=false
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 ERROR_LOG=""
 NODE_SELECTOR=""
+HELM_RELEASE_SELECTOR=""
+HELM_RELEASE_DISCOVERED=false
+RESOLVED_COMPONENT_SELECTOR=""
+
+# Track pods and dynamically discovered components so the Helm release
+# catch-all does not duplicate artifacts already collected by a known
+# component selector.
+declare -A COLLECTED_PODS=()
+declare -A DISCOVERED_COMPONENTS=()
 
 # Collection statistics
 declare -A STATS=(
@@ -52,6 +61,8 @@ declare -A STATS=(
     [component_pods]=0
     [nodes]=0
     [diagnostic_commands]=0
+    [diagnostic_skipped]=0
+    [diagnostic_failed]=0
     [errors]=0
     [warnings]=0
 )
@@ -81,7 +92,7 @@ Options:
   --output-dir PATH          Output directory (default: ./network-operator-sosreport-<timestamp>)
   --no-compress              Don't create tarball, leave as directory
   --log-lines N              Number of log lines to collect per pod (default: 5000)
-  --skip-diagnostics         Skip running diagnostic commands in OFED pods (lsmod, ibstat, ibv_devinfo, mst, dmesg, ip)
+  --skip-diagnostics         Skip running diagnostic commands in OFED pods (lsmod, RDMA/devlink, dmesg, ip, and optional legacy tools)
   --skip-report              Skip HTML report generation
   --node-selector SELECTOR   Only collect from nodes matching label selector (default: all nodes)
                              Example: feature.node.kubernetes.io/pci-15b3.present=true
@@ -259,7 +270,7 @@ collect_resource() {
         local line_count
         line_count=$(wc -l < "$temp_file")
         local has_items
-        has_items=$(grep -c "^  - " "$temp_file" 2>/dev/null || echo 0)
+        has_items=$(grep -c "^  - " "$temp_file" 2>/dev/null || true)
 
         # Detect empty YAML structures
         local is_empty=false
@@ -411,7 +422,7 @@ collect_crd_definitions() {
     local crd_dir="$OUTPUT_DIR/crds/definitions"
 
     # [GENERATED-CRDS-START] - Auto-generated, do not edit manually
-    # Generated at: 2026-07-27T12:50:26Z
+    # Generated at: 2026-07-31T11:23:32Z
     # All CRDs we want to collect
     local all_crds=(
         # Main Network Operator CRDs
@@ -496,6 +507,7 @@ collect_crd_instances() {
     # Collect all CR types
     # Main Network Operator CRs
     collect_cr_instances "nicclusterpolicies.mellanox.com" "nicclusterpolicies"
+    collect_cr_instances "nicnodepolicies.mellanox.com" "nicnodepolicies"
     collect_cr_instances "macvlannetworks.mellanox.com" "macvlannetworks"
     collect_cr_instances "hostdevicenetworks.mellanox.com" "hostdevicenetworks"
     collect_cr_instances "ipoibnetworks.mellanox.com" "ipoibnetworks"
@@ -550,26 +562,7 @@ collect_operator_resources() {
     local pods
     pods=$("$KUBECTL_BIN" get pods -n "$OPERATOR_NAMESPACE" -l app.kubernetes.io/name=network-operator -o name 2>/dev/null)
 
-    for pod in $pods; do
-        local pod_name
-        pod_name=$(basename "$pod")
-        log_info "  Collecting operator pod: $pod_name"
-
-        collect_resource "$controller_dir/pods/${pod_name}.yaml" get -n "$OPERATOR_NAMESPACE" "$pod" -o yaml
-
-        # Pod logs
-        mkdir -p "$controller_dir/pods"
-        if "$KUBECTL_BIN" logs -n "$OPERATOR_NAMESPACE" "$pod" --tail="$LOG_LINES" > "$controller_dir/pods/${pod_name}.log" 2>> "$ERROR_LOG"; then
-            STATS[operator_pods]=$((STATS[operator_pods] + 1))
-        fi
-
-        # Previous logs if pod restarted
-        if "$KUBECTL_BIN" logs -n "$OPERATOR_NAMESPACE" "$pod" --previous --tail="$LOG_LINES" > "$controller_dir/pods/${pod_name}-previous.log" 2>/dev/null; then
-            log_info "    Collected previous logs"
-        else
-            rm -f "$controller_dir/pods/${pod_name}-previous.log"
-        fi
-    done
+    collect_pods_and_logs "$OPERATOR_NAMESPACE" "$controller_dir/pods" "$pods" "operator_pods"
 
     # ConfigMaps
     collect_resource "$operator_dir/configmaps.yaml" get configmaps -n "$OPERATOR_NAMESPACE" -o yaml
@@ -585,6 +578,17 @@ collect_operator_resources() {
     collect_resource "$operator_dir/rbac/clusterroles.yaml" get clusterroles -l app.kubernetes.io/name=network-operator -o yaml
     collect_resource "$operator_dir/rbac/clusterrolebindings.yaml" get clusterrolebindings -l app.kubernetes.io/name=network-operator -o yaml
 
+    # The parent chart and all enabled sub-charts share the Helm release label.
+    # Collect their cluster-scoped RBAC even when the component uses a different
+    # app.kubernetes.io/name value.
+    detect_helm_release_selector
+    if [ -n "$HELM_RELEASE_SELECTOR" ]; then
+        collect_resource "$operator_dir/rbac/helm-release-clusterroles.yaml" \
+            get clusterroles -l "$HELM_RELEASE_SELECTOR" -o yaml
+        collect_resource "$operator_dir/rbac/helm-release-clusterrolebindings.yaml" \
+            get clusterrolebindings -l "$HELM_RELEASE_SELECTOR" -o yaml
+    fi
+
     # Events
     collect_resource "$operator_dir/events.yaml" get events -n "$OPERATOR_NAMESPACE" --sort-by='.lastTimestamp' -o yaml
 
@@ -595,11 +599,324 @@ collect_operator_resources() {
     log_success "Operator resources collection completed"
 }
 
+# Collect current and previous logs for one container.
+collect_container_logs() {
+    local namespace="$1"
+    local pod="$2"
+    local pod_name="$3"
+    local pods_dir="$4"
+    local container="$5"
+    local container_type="$6"
+
+    local file_prefix=""
+    local type_description="container"
+    case "$container_type" in
+        init)
+            file_prefix="init-"
+            type_description="init container"
+            ;;
+        ephemeral)
+            file_prefix="ephemeral-"
+            type_description="ephemeral container"
+            ;;
+    esac
+
+    mkdir -p "$pods_dir"
+
+    local current_log="$pods_dir/${pod_name}-${file_prefix}${container}.log"
+    local log_error_file
+    log_error_file=$(mktemp)
+    if "$KUBECTL_BIN" logs -n "$namespace" "$pod" -c "$container" --tail="$LOG_LINES" > "$current_log" 2> "$log_error_file"; then
+        log_info "      Collected logs for $type_description: $container"
+    else
+        rm -f "$current_log"
+        log_warn "Failed to collect logs for $namespace/$pod_name $type_description $container"
+        sed 's/^/  /' "$log_error_file" >> "$ERROR_LOG"
+    fi
+    rm -f "$log_error_file"
+
+    # Previous logs are optional because most containers have not restarted.
+    local previous_log="$pods_dir/${pod_name}-${file_prefix}${container}-previous.log"
+    if "$KUBECTL_BIN" logs -n "$namespace" "$pod" -c "$container" --previous --tail="$LOG_LINES" > "$previous_log" 2>/dev/null; then
+        log_info "      Collected previous logs for $type_description: $container"
+    else
+        rm -f "$previous_log"
+    fi
+}
+
+# Collect pod specifications and logs for regular, init, and ephemeral containers.
+collect_pods_and_logs() {
+    local namespace="$1"
+    local pods_dir="$2"
+    local pods="$3"
+    local stats_key="${4:-component_pods}"
+
+    # Get list of selected nodes if node selector is specified
+    local selected_nodes=""
+    if [ -n "$NODE_SELECTOR" ]; then
+        selected_nodes=$("$KUBECTL_BIN" get nodes -l "$NODE_SELECTOR" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+        if [ -z "$selected_nodes" ]; then
+            log_info "    No pods match the requested node selector"
+            return 0
+        fi
+    fi
+
+    for pod in $pods; do
+        local pod_name
+        pod_name=$(basename "$pod")
+        local pod_key="$namespace/$pod_name"
+
+        if [ -n "${COLLECTED_PODS[$pod_key]:-}" ]; then
+            log_info "    Pod already collected: $pod_key"
+            continue
+        fi
+
+        # Skip pod if node selector is set and pod is not on selected node
+        if [ -n "$NODE_SELECTOR" ]; then
+            local pod_node
+            pod_node=$("$KUBECTL_BIN" get -n "$namespace" "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+            if ! echo "$selected_nodes" | grep -qw "$pod_node"; then
+                log_info "    Skipping pod $pod_name (not on selected node)"
+                COLLECTED_PODS["$pod_key"]="skipped"
+                continue
+            fi
+        fi
+
+        collect_resource "$pods_dir/${pod_name}.yaml" get -n "$namespace" "$pod" -o yaml
+
+        local container_type
+        for container_type in regular init ephemeral; do
+            local containers=""
+            case "$container_type" in
+                regular)
+                    containers=$("$KUBECTL_BIN" get -n "$namespace" "$pod" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null)
+                    ;;
+                init)
+                    containers=$("$KUBECTL_BIN" get -n "$namespace" "$pod" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null)
+                    ;;
+                ephemeral)
+                    containers=$("$KUBECTL_BIN" get -n "$namespace" "$pod" -o jsonpath='{.spec.ephemeralContainers[*].name}' 2>/dev/null)
+                    ;;
+            esac
+
+            local container
+            for container in $containers; do
+                collect_container_logs "$namespace" "$pod" "$pod_name" "$pods_dir" "$container" "$container_type"
+            done
+        done
+
+        COLLECTED_PODS["$pod_key"]="collected"
+        if [ "$stats_key" = "operator_pods" ]; then
+            STATS[operator_pods]=$((STATS[operator_pods] + 1))
+        else
+            STATS[component_pods]=$((STATS[component_pods] + 1))
+        fi
+    done
+}
+
+# Discover the Helm release that owns the Network Operator deployment. Parent
+# and sub-chart workloads all inherit app.kubernetes.io/instance, which gives
+# the collector a future-proof catch-all without collecting unrelated pods in
+# a shared namespace.
+detect_helm_release_selector() {
+    if [ "$HELM_RELEASE_DISCOVERED" = true ]; then
+        return 0
+    fi
+    HELM_RELEASE_DISCOVERED=true
+
+    local release_name
+    release_name=$("$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" \
+        -l app.kubernetes.io/name=network-operator \
+        -o jsonpath='{.items[0].metadata.labels.app\.kubernetes\.io/instance}' 2>/dev/null)
+
+    if [ -z "$release_name" ]; then
+        release_name=$("$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" \
+            -l app.kubernetes.io/name=network-operator \
+            -o jsonpath='{.items[0].metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null)
+    fi
+
+    # nameOverride can change app.kubernetes.io/name. In that case, identify
+    # the parent deployment by its network-operator Helm chart label.
+    if [ -z "$release_name" ]; then
+        release_name=$("$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" \
+            -o jsonpath='{range .items[*]}{.metadata.labels.helm\.sh/chart}{"|"}{.metadata.labels.app\.kubernetes\.io/instance}{"|"}{.metadata.annotations.meta\.helm\.sh/release-name}{"\n"}{end}' 2>/dev/null \
+            | awk -F'|' '$1 ~ /^network-operator-/ { if ($2 != "") print $2; else print $3; exit }')
+    fi
+
+    if [ -n "$release_name" ]; then
+        HELM_RELEASE_SELECTOR="app.kubernetes.io/instance=$release_name"
+        log_info "Detected Network Operator Helm release: $release_name"
+    else
+        log_info "Network Operator Helm release label not found"
+    fi
+}
+
+# Resolve a pod's controlling workload. ReplicaSets are folded into their
+# parent Deployment so a rollout does not appear as a separate component.
+resolve_pod_workload() {
+    local namespace="$1"
+    local pod="$2"
+
+    local owner_kind
+    local owner_name
+    owner_kind=$("$KUBECTL_BIN" get -n "$namespace" "$pod" \
+        -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null)
+    owner_name=$("$KUBECTL_BIN" get -n "$namespace" "$pod" \
+        -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null)
+
+    if [ "$owner_kind" = "ReplicaSet" ] && [ -n "$owner_name" ]; then
+        local parent_kind
+        local parent_name
+        parent_kind=$("$KUBECTL_BIN" get replicaset -n "$namespace" "$owner_name" \
+            -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null)
+        parent_name=$("$KUBECTL_BIN" get replicaset -n "$namespace" "$owner_name" \
+            -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null)
+        if [ "$parent_kind" = "Deployment" ] && [ -n "$parent_name" ]; then
+            owner_kind="$parent_kind"
+            owner_name="$parent_name"
+        fi
+    fi
+
+    if [ -z "$owner_kind" ] || [ -z "$owner_name" ]; then
+        owner_kind="Pod"
+        owner_name=$(basename "$pod")
+    fi
+
+    printf '%s|%s\n' "$(printf '%s' "$owner_kind" | tr '[:upper:]' '[:lower:]')" "$owner_name"
+}
+
+# Collect all resources and pods owned by the Network Operator Helm release.
+# Known components retain their stable report names; any chart workload missing
+# from the generated map is added dynamically using its controlling workload.
+collect_helm_release_components() {
+    detect_helm_release_selector
+    if [ -z "$HELM_RELEASE_SELECTOR" ]; then
+        return 0
+    fi
+
+    log_info "Collecting complete Helm release workload inventory..."
+    local release_dir="$OUTPUT_DIR/operator/helm-release"
+    local resource_type
+    for resource_type in deployments daemonsets statefulsets replicasets jobs cronjobs; do
+        collect_resource "$release_dir/workloads/${resource_type}.yaml" \
+            get "$resource_type" -n "$OPERATOR_NAMESPACE" -l "$HELM_RELEASE_SELECTOR" -o yaml || true
+    done
+    collect_resource "$release_dir/poddisruptionbudgets.yaml" \
+        get poddisruptionbudgets -n "$OPERATOR_NAMESPACE" -l "$HELM_RELEASE_SELECTOR" -o yaml || true
+    collect_resource "$release_dir/networkpolicies.yaml" \
+        get networkpolicies -n "$OPERATOR_NAMESPACE" -l "$HELM_RELEASE_SELECTOR" -o yaml || true
+
+    local pods
+    pods=$("$KUBECTL_BIN" get pods -n "$OPERATOR_NAMESPACE" -l "$HELM_RELEASE_SELECTOR" -o name 2>/dev/null)
+    local pod
+    for pod in $pods; do
+        local pod_name
+        pod_name=$(basename "$pod")
+        if [ -n "${COLLECTED_PODS[$OPERATOR_NAMESPACE/$pod_name]:-}" ]; then
+            continue
+        fi
+
+        local workload
+        local workload_type
+        local workload_name
+        workload=$(resolve_pod_workload "$OPERATOR_NAMESPACE" "$pod")
+        IFS='|' read -r workload_type workload_name <<< "$workload"
+
+        local component_dir="$OUTPUT_DIR/operator/components/$workload_name"
+        if [ -z "${DISCOVERED_COMPONENTS[$component_dir]:-}" ]; then
+            log_info "  Discovered Helm component: $workload_name ($workload_type)"
+            DISCOVERED_COMPONENTS["$component_dir"]="true"
+            STATS[components_found]=$((STATS[components_found] + 1))
+
+            collect_resource "$component_dir/${workload_type}.yaml" \
+                get "$workload_type" -n "$OPERATOR_NAMESPACE" "$workload_name" -o yaml
+        fi
+
+        collect_pods_and_logs "$OPERATOR_NAMESPACE" "$component_dir/pods" "$pod"
+    done
+}
+
+# Expand a generated NameSuffix marker into one selector that matches every
+# deployed base or suffixed workload. Discover values from workload and pod
+# labels instead of requiring permission to list NicNodePolicy objects.
+resolve_component_selector() {
+    local selector="$1"
+    local namespace="${2:-$OPERATOR_NAMESPACE}"
+    local resource_type="${3:-both}"
+    local suffix_marker="__NAME_SUFFIX__"
+
+    if [[ "$selector" != *"$suffix_marker"* ]]; then
+        RESOLVED_COMPONENT_SELECTOR="$selector"
+        return 0
+    fi
+
+    local label_key="${selector%%=*}"
+    local base_value="${selector#*=}"
+    base_value="${base_value//$suffix_marker/}"
+
+    local label_jsonpath_key="${label_key//./\\.}"
+    local label_jsonpath="{range .items[*]}{.metadata.labels.${label_jsonpath_key}}{\"\\n\"}{end}"
+    local resources=(pods)
+    case "$resource_type" in
+        daemonset)
+            resources=(daemonsets pods)
+            ;;
+        deployment)
+            resources=(deployments pods)
+            ;;
+        both)
+            resources=(daemonsets deployments pods)
+            ;;
+    esac
+
+    local values="$base_value"
+    local -A seen_values=(["$base_value"]="true")
+    local resource
+    for resource in "${resources[@]}"; do
+        local discovered_values
+        local discovery_error_file
+        discovery_error_file=$(mktemp)
+        if ! discovered_values=$("$KUBECTL_BIN" get "$resource" -n "$namespace" \
+            -l "$label_key" -o "jsonpath=$label_jsonpath" 2> "$discovery_error_file"); then
+            log_warn "Failed to discover suffix values for label $label_key from $namespace/$resource"
+            sed 's/^/  /' "$discovery_error_file" >> "$ERROR_LOG"
+        fi
+        rm -f "$discovery_error_file"
+
+        local discovered_value
+        for discovered_value in $discovered_values; do
+            if [[ "$discovered_value" != "$base_value" && "$discovered_value" != "$base_value"-* ]]; then
+                continue
+            fi
+            if [ -z "${seen_values[$discovered_value]:-}" ]; then
+                values="${values},${discovered_value}"
+                seen_values["$discovered_value"]="true"
+            fi
+        done
+    done
+
+    RESOLVED_COMPONENT_SELECTOR="$label_key in ($values)"
+}
+
 # Collect component workloads
 collect_component() {
     local component_name="$1"
-    local label_selector="$2"
+    local raw_label_selector="$2"
     local resource_type="$3"  # daemonset, deployment, or both
+    local raw_pod_label_selector="${4:-$raw_label_selector}"
+    local namespace="${5:-$OPERATOR_NAMESPACE}"
+    local components_dir="${6:-$OUTPUT_DIR/operator/components}"
+
+    local label_selector
+    resolve_component_selector "$raw_label_selector" "$namespace" "$resource_type"
+    label_selector="$RESOLVED_COMPONENT_SELECTOR"
+    local pod_label_selector
+    if [ "$raw_pod_label_selector" = "$raw_label_selector" ]; then
+        pod_label_selector="$label_selector"
+    else
+        resolve_component_selector "$raw_pod_label_selector" "$namespace" "$resource_type"
+        pod_label_selector="$RESOLVED_COMPONENT_SELECTOR"
+    fi
 
     log_info "Checking component: $component_name"
 
@@ -607,13 +924,13 @@ collect_component() {
     local exists=false
 
     if [ "$resource_type" = "daemonset" ] || [ "$resource_type" = "both" ]; then
-        if "$KUBECTL_BIN" get daemonsets -n "$OPERATOR_NAMESPACE" -l "$label_selector" --no-headers 2>/dev/null | grep -q .; then
+        if "$KUBECTL_BIN" get daemonsets -n "$namespace" -l "$label_selector" --no-headers 2>/dev/null | grep -q .; then
             exists=true
         fi
     fi
 
     if [ "$resource_type" = "deployment" ] || [ "$resource_type" = "both" ]; then
-        if "$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" -l "$label_selector" --no-headers 2>/dev/null | grep -q .; then
+        if "$KUBECTL_BIN" get deployments -n "$namespace" -l "$label_selector" --no-headers 2>/dev/null | grep -q .; then
             exists=true
         fi
     fi
@@ -627,65 +944,26 @@ collect_component() {
     log_info "  Collecting component: $component_name"
     STATS[components_found]=$((STATS[components_found] + 1))
 
-    local component_dir="$OUTPUT_DIR/operator/components/$component_name"
+    local component_dir="$components_dir/$component_name"
+    DISCOVERED_COMPONENTS["$component_dir"]="true"
 
     # Collect DaemonSet or Deployment
     if [ "$resource_type" = "daemonset" ] || [ "$resource_type" = "both" ]; then
-        collect_resource "$component_dir/daemonset.yaml" get daemonsets -n "$OPERATOR_NAMESPACE" -l "$label_selector" -o yaml
+        collect_resource "$component_dir/daemonset.yaml" get daemonsets -n "$namespace" -l "$label_selector" -o yaml
     fi
 
     if [ "$resource_type" = "deployment" ] || [ "$resource_type" = "both" ]; then
-        collect_resource "$component_dir/deployment.yaml" get deployments -n "$OPERATOR_NAMESPACE" -l "$label_selector" -o yaml
+        collect_resource "$component_dir/deployment.yaml" get deployments -n "$namespace" -l "$label_selector" -o yaml
     fi
 
     # Collect pods
     local pods
-    pods=$("$KUBECTL_BIN" get pods -n "$OPERATOR_NAMESPACE" -l "$label_selector" -o name 2>/dev/null)
-
-    # Get list of selected nodes if node selector is specified
-    local selected_nodes=""
-    if [ -n "$NODE_SELECTOR" ]; then
-        selected_nodes=$("$KUBECTL_BIN" get nodes -l "$NODE_SELECTOR" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
-    fi
-
-    for pod in $pods; do
-        local pod_name
-        pod_name=$(basename "$pod")
-
-        # Skip pod if node selector is set and pod is not on selected node
-        if [ -n "$NODE_SELECTOR" ] && [ -n "$selected_nodes" ]; then
-            local pod_node
-            pod_node=$("$KUBECTL_BIN" get -n "$OPERATOR_NAMESPACE" "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
-            if ! echo "$selected_nodes" | grep -qw "$pod_node"; then
-                log_info "    Skipping pod $pod_name (not on selected node)"
-                continue
-            fi
-        fi
-
-        collect_resource "$component_dir/pods/${pod_name}.yaml" get -n "$OPERATOR_NAMESPACE" "$pod" -o yaml
-
-        # Pod logs (all containers)
-        local containers
-        containers=$("$KUBECTL_BIN" get -n "$OPERATOR_NAMESPACE" "$pod" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null)
-        for container in $containers; do
-            mkdir -p "$component_dir/pods"
-            if "$KUBECTL_BIN" logs -n "$OPERATOR_NAMESPACE" "$pod" -c "$container" --tail="$LOG_LINES" > "$component_dir/pods/${pod_name}-${container}.log" 2>> "$ERROR_LOG"; then
-                STATS[component_pods]=$((STATS[component_pods] + 1))
-            else
-                rm -f "$component_dir/pods/${pod_name}-${container}.log"
-            fi
-
-            # Previous logs if available
-            if "$KUBECTL_BIN" logs -n "$OPERATOR_NAMESPACE" "$pod" -c "$container" --previous --tail="$LOG_LINES" > "$component_dir/pods/${pod_name}-${container}-previous.log" 2>/dev/null; then
-                log_info "      Collected previous logs for container: $container"
-            else
-                rm -f "$component_dir/pods/${pod_name}-${container}-previous.log"
-            fi
-        done
-    done
+    pods=$("$KUBECTL_BIN" get pods -n "$namespace" -l "$pod_label_selector" -o name 2>/dev/null)
+    collect_pods_and_logs "$namespace" "$component_dir/pods" "$pods"
 
     # Collect Services
-    collect_resource "$component_dir/services.yaml" get services -n "$OPERATOR_NAMESPACE" -l "$label_selector" -o yaml
+    collect_resource "$component_dir/services.yaml" get services -n "$namespace" -l "$label_selector" -o yaml
+    return 0
 }
 
 # Collect all components
@@ -693,8 +971,8 @@ collect_all_components() {
     log_info "Collecting all component workloads..."
 
     # [GENERATED-COMPONENTS-START] - Auto-generated, do not edit manually
-    # Generated at: 2026-07-27T12:50:26Z
-    # Component definitions: name, label, type
+    # Generated at: 2026-07-31T11:23:32Z
+    # Component definitions: name, workload label, type, optional pod label
     declare -A components=(
         # Main Network Operator components
         ["cni-plugins-ds"]="name=cni-plugins|daemonset"
@@ -702,34 +980,85 @@ collect_all_components() {
         ["ib-kubernetes"]="name=ib-kubernetes|deployment"
         ["kube-ipoib-cni-ds"]="name=ipoib-cni|daemonset"
         ["kube-multus-ds"]="name=multus|daemonset"
-        ["network-operator-sriov-device-plugin{{"]="template=|daemonset"
+        ["network-operator-sriov-device-plugin"]="name=network-operator-sriov-device-plugin__NAME_SUFFIX__|daemonset"
         ["nic-configuration-daemon"]="app.kubernetes.io/name=nic-configuration-daemon|daemonset"
         ["nic-configuration-operator"]="app.kubernetes.io/component=nic-configuration-operator|deployment"
         ["nic-feature-discovery-ds"]="name=nic-feature-discovery|daemonset"
         ["nv-ipam-controller"]="name=nv-ipam-controller|deployment"
         ["nv-ipam-node"]="name=nv-ipam-node|daemonset"
         ["ofed-driver"]="nvidia.com/ofed-driver=|daemonset"
-        ["rdma-shared-dp-ds{{"]="template=|daemonset"
+        ["rdma-shared-dp-ds"]="app=rdma-shared-dp__NAME_SUFFIX__|daemonset"
         ["spectrum-x-flowcontroller"]="control-plane=spectrum-x-flowcontroller|daemonset"
         # Node Feature Discovery (sub-chart)
         ["nfd-master"]="app.kubernetes.io/name=node-feature-discovery,app.kubernetes.io/component=master|deployment"
         ["nfd-worker"]="app.kubernetes.io/name=node-feature-discovery,app.kubernetes.io/component=worker|daemonset"
         ["nfd-gc"]="app.kubernetes.io/name=node-feature-discovery,app.kubernetes.io/component=gc|deployment"
+        ["nfd-topology-updater"]="app.kubernetes.io/name=node-feature-discovery,role=topology-updater|daemonset"
         # SR-IOV Network Operator (sub-chart)
-        ["sriov-network-operator"]="app=sriov-network-operator|deployment"
+        ["sriov-network-operator"]="app.kubernetes.io/name=sriov-network-operator|deployment|name=sriov-network-operator"
         ["sriov-network-config-daemon"]="app=sriov-network-config-daemon|daemonset"
-        ["sriov-network-resources-injector"]="app=network-resources-injector|deployment"
+        ["sriov-network-resources-injector"]="app=network-resources-injector|daemonset"
+        ["sriov-network-operator-webhook"]="app=operator-webhook|daemonset"
+        ["sriov-network-device-plugin"]="app=sriov-device-plugin|daemonset"
+        ["sriov-network-metrics-exporter"]="app=sriov-network-metrics-exporter|daemonset"
+        ["sriov-dra-driver"]="app=sriov-dra-driver|daemonset"
         # Maintenance Operator (sub-chart)
         ["maintenance-operator"]="app.kubernetes.io/name=maintenance-operator|deployment"
     )
     # [GENERATED-COMPONENTS-END]
 
     for component in "${!components[@]}"; do
-        IFS='|' read -r label type <<< "${components[$component]}"
-        collect_component "$component" "$label" "$type"
+        local label type pod_label
+        IFS='|' read -r label type pod_label <<< "${components[$component]}"
+        collect_component "$component" "$label" "$type" "${pod_label:-$label}"
     done
 
+    collect_helm_release_components
+
     log_success "Found ${STATS[components_found]} components, skipped ${STATS[components_skipped]}"
+}
+
+# Record and execute one diagnostic command in the MOFED container.
+run_diagnostic_command() {
+    local pod="$1"
+    local node_name="$2"
+    local diagnostics_dir="$3"
+    local status_file="$4"
+    local diagnostic_name="$5"
+    local required_binary="$6"
+    local command="$7"
+
+    local probe_result
+    local probe_command="if command -v $required_binary >/dev/null 2>&1; then printf available; else printf unavailable; fi"
+    if ! probe_result=$("$KUBECTL_BIN" exec -n "$OPERATOR_NAMESPACE" "$pod" -c mofed-container -- sh -c "$probe_command" 2>&1); then
+        printf '%-28s FAILED  unable to check for executable %s\n' "$diagnostic_name" "$required_binary" >> "$status_file"
+        STATS[diagnostic_failed]=$((STATS[diagnostic_failed] + 1))
+        log_warn "Failed to check diagnostic tool '$required_binary' in $OPERATOR_NAMESPACE/$(basename "$pod")"
+        printf '  %s\n' "$probe_result" >> "$ERROR_LOG"
+        return 0
+    fi
+
+    if [ "$probe_result" != "available" ]; then
+        printf '%-28s SKIPPED executable %s is not installed in mofed-container\n' "$diagnostic_name" "$required_binary" >> "$status_file"
+        STATS[diagnostic_skipped]=$((STATS[diagnostic_skipped] + 1))
+        log_info "    Skipped $diagnostic_name ($required_binary is not installed)"
+        return 0
+    fi
+
+    local output_file="$diagnostics_dir/${node_name}-${diagnostic_name}.txt"
+    local command_error_file
+    command_error_file=$(mktemp)
+    if "$KUBECTL_BIN" exec -n "$OPERATOR_NAMESPACE" "$pod" -c mofed-container -- sh -c "$command" > "$output_file" 2> "$command_error_file"; then
+        printf '%-28s SUCCESS\n' "$diagnostic_name" >> "$status_file"
+        STATS[diagnostic_commands]=$((STATS[diagnostic_commands] + 1))
+    else
+        rm -f "$output_file"
+        printf '%-28s FAILED  command returned a non-zero exit status\n' "$diagnostic_name" >> "$status_file"
+        STATS[diagnostic_failed]=$((STATS[diagnostic_failed] + 1))
+        log_warn "Diagnostic '$diagnostic_name' failed on node $node_name"
+        sed 's/^/  /' "$command_error_file" >> "$ERROR_LOG"
+    fi
+    rm -f "$command_error_file"
 }
 
 # Run diagnostic commands in OFED pods
@@ -786,29 +1115,42 @@ collect_diagnostic_commands() {
 
         mkdir -p "$diagnostics_dir"
 
-        # Run diagnostic commands
-        local commands=(
-            "lsmod | grep mlx:${node_name}-lsmod.txt"
-            "ibstat:${node_name}-ibstat.txt"
-            "ibv_devinfo:${node_name}-ibv_devinfo.txt"
-            "mst status:${node_name}-mst_status.txt"
-            "cat /proc/version:${node_name}-kernel_version.txt"
-            "dmesg | tail -500:${node_name}-dmesg.txt"
-            "ip link show:${node_name}-ip_link.txt"
-            "ip addr show:${node_name}-ip_addr.txt"
-        )
+        local status_file="$diagnostics_dir/${node_name}-diagnostic_status.txt"
+        {
+            echo "OFED diagnostic command status"
+            echo "=============================="
+            echo "Pod: $pod_name"
+            echo "Container: mofed-container"
+            echo ""
+        } > "$status_file"
 
-        for cmd_spec in "${commands[@]}"; do
-            IFS=':' read -r cmd output_file <<< "$cmd_spec"
-            if "$KUBECTL_BIN" exec -n "$OPERATOR_NAMESPACE" "$pod" -- sh -c "$cmd" > "$diagnostics_dir/$output_file" 2>> "$ERROR_LOG"; then
-                STATS[diagnostic_commands]=$((STATS[diagnostic_commands] + 1))
-            else
-                rm -f "$diagnostics_dir/$output_file"
-            fi
-        done
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "lsmod" "lsmod" "lsmod | grep mlx"
+
+        # These legacy utilities are useful when a custom driver image provides
+        # them, but they are not part of the minimal kernel-only MOFED image.
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "ibstat" "ibstat" "ibstat"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "ibv_devinfo" "ibv_devinfo" "ibv_devinfo"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "mst_status" "mst" "mst status"
+
+        # Portable RDMA and devlink diagnostics available in the minimal driver
+        # image. These preserve useful device, port, PCI, and firmware data when
+        # the optional legacy utilities are absent.
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "rdma_dev" "rdma" "rdma dev show"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "rdma_link" "rdma" "rdma link show"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "devlink_dev" "devlink" "devlink dev show"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "devlink_info" "devlink" "devlink dev info"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "devlink_port" "devlink" "devlink port show"
+        # Keep variables quoted for expansion by the shell inside mofed-container.
+        # shellcheck disable=SC2016
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "infiniband_sysfs" "cat" 'for device in /sys/class/infiniband/*; do [ -e "$device" ] || continue; echo "device: ${device##*/}"; for attribute in node_guid sys_image_guid node_type fw_ver hca_type; do [ -r "$device/$attribute" ] && echo "  $attribute: $(cat "$device/$attribute")"; done; for port in "$device"/ports/*; do [ -e "$port" ] || continue; echo "  port: ${port##*/}"; for attribute in state phys_state rate link_layer lid sm_lid; do [ -r "$port/$attribute" ] && echo "    $attribute: $(cat "$port/$attribute")"; done; done; done'
+
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "kernel_version" "cat" "cat /proc/version"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "dmesg" "dmesg" "dmesg | tail -500"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "ip_link" "ip" "ip link show"
+        run_diagnostic_command "$pod" "$node_name" "$diagnostics_dir" "$status_file" "ip_addr" "ip" "ip addr show"
     done
 
-    log_success "Collected ${STATS[diagnostic_commands]} diagnostic command outputs"
+    log_success "Collected ${STATS[diagnostic_commands]} diagnostic command outputs (${STATS[diagnostic_skipped]} skipped, ${STATS[diagnostic_failed]} failed)"
 }
 
 # Collect node information
@@ -868,15 +1210,47 @@ collect_network_info() {
 collect_related_operators() {
     log_info "Checking for related operators..."
 
-    # Check for SR-IOV Network Operator
-    if "$KUBECTL_BIN" get namespace openshift-sriov-network-operator &> /dev/null; then
-        log_info "  Found SR-IOV Network Operator"
-        local sriov_dir="$OUTPUT_DIR/related-operators/sriov-network-operator"
+    # Discover both Helm-managed and standalone/OpenShift SR-IOV Operator
+    # namespaces. Different releases use different labels, so use the CR,
+    # controller Deployment, controller Pod, and the conventional namespace.
+    local sriov_namespaces=""
+    local discovered_namespaces
 
-        collect_resource "$sriov_dir/namespace.yaml" get namespace openshift-sriov-network-operator -o yaml
-        collect_resource "$sriov_dir/deployments.yaml" get deployments -n openshift-sriov-network-operator -o yaml
-        collect_resource "$sriov_dir/daemonsets.yaml" get daemonsets -n openshift-sriov-network-operator -o yaml
+    discovered_namespaces=$("$KUBECTL_BIN" get sriovoperatorconfigs.sriovnetwork.openshift.io -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null || true)
+    sriov_namespaces="$sriov_namespaces"$'\n'"$discovered_namespaces"
+
+    discovered_namespaces=$("$KUBECTL_BIN" get deployments -A -l app.kubernetes.io/name=sriov-network-operator -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null || true)
+    sriov_namespaces="$sriov_namespaces"$'\n'"$discovered_namespaces"
+
+    discovered_namespaces=$("$KUBECTL_BIN" get pods -A -l name=sriov-network-operator -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null || true)
+    sriov_namespaces="$sriov_namespaces"$'\n'"$discovered_namespaces"
+
+    if "$KUBECTL_BIN" get namespace openshift-sriov-network-operator &> /dev/null; then
+        sriov_namespaces="$sriov_namespaces"$'\n'"openshift-sriov-network-operator"
     fi
+
+    while IFS= read -r namespace; do
+        [ -n "$namespace" ] || continue
+
+        # Bundled SR-IOV components were already collected component-by-component.
+        if [ "$namespace" = "$OPERATOR_NAMESPACE" ]; then
+            log_info "  SR-IOV Network Operator is bundled in $namespace"
+            continue
+        fi
+
+        log_info "  Collecting standalone SR-IOV Network Operator from $namespace"
+        local sriov_dir="$OUTPUT_DIR/related-operators/sriov-network-operator/$namespace"
+
+        collect_resource "$sriov_dir/namespace.yaml" get namespace "$namespace" -o yaml
+        collect_resource "$sriov_dir/deployments.yaml" get deployments -n "$namespace" -o yaml
+        collect_resource "$sriov_dir/daemonsets.yaml" get daemonsets -n "$namespace" -o yaml
+        collect_resource "$sriov_dir/configmaps.yaml" get configmaps -n "$namespace" -o yaml
+        collect_resource "$sriov_dir/events.yaml" get events -n "$namespace" --sort-by='.lastTimestamp' -o yaml
+
+        local pods
+        pods=$("$KUBECTL_BIN" get pods -n "$namespace" -o name 2>/dev/null)
+        collect_pods_and_logs "$namespace" "$sriov_dir/pods" "$pods"
+    done < <(printf '%s\n' "$sriov_namespaces" | sed '/^$/d' | sort -u)
 
     log_success "Related operators collection completed"
 }
@@ -982,6 +1356,8 @@ generate_summary() {
         echo "Component Pods: ${STATS[component_pods]}"
         echo "Nodes: ${STATS[nodes]}"
         echo "Diagnostic Commands: ${STATS[diagnostic_commands]}"
+        echo "Diagnostic Commands Skipped: ${STATS[diagnostic_skipped]}"
+        echo "Diagnostic Commands Failed: ${STATS[diagnostic_failed]}"
         echo "Warnings: ${STATS[warnings]}"
         echo "Errors: ${STATS[errors]}"
         echo ""
@@ -1155,7 +1531,7 @@ main() {
     echo "  Components: ${STATS[components_found]} found, ${STATS[components_skipped]} skipped"
     echo "  Pods: ${STATS[operator_pods]} operator, ${STATS[component_pods]} component"
     echo "  Nodes: ${STATS[nodes]}"
-    echo "  Diagnostics: ${STATS[diagnostic_commands]} commands"
+    echo "  Diagnostics: ${STATS[diagnostic_commands]} succeeded, ${STATS[diagnostic_skipped]} skipped, ${STATS[diagnostic_failed]} failed"
     echo "  Issues: ${STATS[warnings]} warnings, ${STATS[errors]} errors"
     echo ""
 
@@ -1168,6 +1544,8 @@ main() {
     return 0
 }
 
-# Run main function
-main "$@"
-exit $?
+# Run main function when executed, but allow tests to source the helpers.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+    exit $?
+fi

--- a/scripts/sosreport/test-sosreport.sh
+++ b/scripts/sosreport/test-sosreport.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Behavioral tests source the collector dynamically and invoke mock functions
+# through KUBECTL_BIN, which ShellCheck cannot trace statically.
+# shellcheck disable=SC1090,SC2034,SC2154,SC2329
+
 #  2026 NVIDIA CORPORATION & AFFILIATES
 #
 #  Licensed under the Apache License, Version 2.0 (the License);
@@ -78,8 +82,15 @@ required_functions=(
     "collect_crd_definitions"
     "collect_crd_instances"
     "collect_operator_resources"
+    "collect_container_logs"
+    "collect_pods_and_logs"
+    "detect_helm_release_selector"
+    "resolve_pod_workload"
+    "collect_helm_release_components"
+    "resolve_component_selector"
     "collect_component"
     "collect_all_components"
+    "run_diagnostic_command"
     "collect_diagnostic_commands"
     "collect_node_info"
     "collect_network_info"
@@ -173,9 +184,16 @@ required_labels=(
     "control-plane=spectrum-x-flowcontroller"
     # Node Feature Discovery (sub-chart)
     "app.kubernetes.io/name=node-feature-discovery"
+    "role=topology-updater"
     # SR-IOV Network Operator (sub-chart)
-    "app=sriov-network-operator"
+    "app.kubernetes.io/name=sriov-network-operator"
+    "name=sriov-network-operator"
     "app=sriov-network-config-daemon"
+    "app=network-resources-injector"
+    "app=operator-webhook"
+    "app=sriov-device-plugin"
+    "app=sriov-network-metrics-exporter"
+    "app=sriov-dra-driver"
     # Maintenance Operator (sub-chart)
     "app.kubernetes.io/name=maintenance-operator"
 )
@@ -196,6 +214,44 @@ else
     echo "FAIL: Some component labels are missing"
     exit 1
 fi
+
+# Test 6c: NameSuffix selectors cover NicClusterPolicy and NicNodePolicy workloads
+echo ""
+echo "[Test 6c] Testing suffix-aware component selectors..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    fake_policy_kubectl() {
+        case "$*" in
+            "get daemonsets -n test-operator -l app -o jsonpath="*|\
+            "get pods -n test-operator -l app -o jsonpath="*)
+                printf 'rdma-shared-dp\nrdma-shared-dp-blue-policy\nrdma-shared-dp-red-policy\nunrelated\n'
+                ;;
+            *nicnodepolicies*)
+                echo "FAIL: Selector discovery must not require NicNodePolicy access"
+                exit 1
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_policy_kubectl
+    OPERATOR_NAMESPACE=test-operator
+    resolve_component_selector "app=rdma-shared-dp__NAME_SUFFIX__" "$OPERATOR_NAMESPACE" "daemonset"
+    resolved_selector="$RESOLVED_COMPONENT_SELECTOR"
+    expected_selector="app in (rdma-shared-dp,rdma-shared-dp-blue-policy,rdma-shared-dp-red-policy)"
+
+    if [ "$resolved_selector" != "$expected_selector" ]; then
+        echo "FAIL: Unexpected suffix-aware selector: $resolved_selector"
+        exit 1
+    fi
+
+    if ! grep -Fq '["rdma-shared-dp-ds"]="app=rdma-shared-dp__NAME_SUFFIX__|daemonset"' "$SOSREPORT_SCRIPT" ||
+       ! grep -Fq '["network-operator-sriov-device-plugin"]="name=network-operator-sriov-device-plugin__NAME_SUFFIX__|daemonset"' "$SOSREPORT_SCRIPT"; then
+        echo "FAIL: Generated component map does not preserve NameSuffix markers"
+        exit 1
+    fi
+)
+echo "PASS: Component selectors include non-empty NicNodePolicy suffixes"
 
 # Test 7: Script has proper error handling
 echo ""
@@ -228,6 +284,7 @@ echo "[Test 9] Checking CRD collection coverage..."
 required_crds=(
     # Main Network Operator CRDs
     "nicclusterpolicies.mellanox.com"
+    "nicnodepolicies.mellanox.com"
     "macvlannetworks.mellanox.com"
     "hostdevicenetworks.mellanox.com"
     "ipoibnetworks.mellanox.com"
@@ -264,6 +321,92 @@ else
     exit 1
 fi
 
+# Test 9b: Every collected CRD definition also has instance collection
+echo ""
+echo "[Test 9b] Checking CRD definition and instance collection parity..."
+definition_crds=$(mktemp)
+instance_crds=$(mktemp)
+sed -n '/local all_crds=(/,/# \[GENERATED-CRDS-END\]/p' "$SOSREPORT_SCRIPT" \
+    | sed -n 's/.*"\([^"]*\)".*/\1/p' \
+    | sort -u > "$definition_crds"
+sed -n '/# Collect all CR types/,/STATS\[crds_instances\]/p' "$SOSREPORT_SCRIPT" \
+    | sed -n 's/.*collect_cr_instances "\([^"]*\)".*/\1/p' \
+    | sort -u > "$instance_crds"
+
+missing_instance_collectors=$(comm -23 "$definition_crds" "$instance_crds")
+unexpected_instance_collectors=$(comm -13 "$definition_crds" "$instance_crds")
+rm -f "$definition_crds" "$instance_crds"
+
+if [ -n "$missing_instance_collectors" ]; then
+    echo "FAIL: CRDs missing instance collection:"
+    echo "$missing_instance_collectors"
+    exit 1
+fi
+if [ -n "$unexpected_instance_collectors" ]; then
+    echo "FAIL: Instance collectors missing from the CRD definition inventory:"
+    echo "$unexpected_instance_collectors"
+    exit 1
+fi
+echo "PASS: Every CRD definition has matching instance collection"
+
+# Test 9c: NicNodePolicy instances are archived as first-class artifacts
+echo ""
+echo "[Test 9c] Testing NicNodePolicy instance collection..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    TEST_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEST_DIR"' EXIT
+
+    fake_nnp_kubectl() {
+        case "$*" in
+            "get nicnodepolicies.mellanox.com -A --no-headers")
+                echo "blue-policy"
+                ;;
+            "get nicnodepolicies.mellanox.com -A -o yaml")
+                cat <<NNP_EOF
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: mellanox.com/v1alpha1
+    kind: NicNodePolicy
+    metadata:
+      name: blue-policy
+NNP_EOF
+                ;;
+            "get nicnodepolicies.mellanox.com -A")
+                return 0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_nnp_kubectl
+    OUTPUT_DIR="$TEST_DIR/report"
+    ERROR_LOG="$OUTPUT_DIR/collection-errors.log"
+    mkdir -p "$OUTPUT_DIR"
+    : > "$ERROR_LOG"
+    STATS[crds_instances]=0
+
+    if ! collect_crd_instances; then
+        echo "FAIL: CR instance collection returned an error"
+        exit 1
+    fi
+
+    NNP_FILE="$OUTPUT_DIR/crds/instances/nicnodepolicies/all.yaml"
+    if [ ! -s "$NNP_FILE" ] || ! grep -q "name: blue-policy" "$NNP_FILE"; then
+        echo "FAIL: NicNodePolicy instance YAML was not collected"
+        exit 1
+    fi
+    if [ "${STATS[crds_instances]}" -ne 1 ]; then
+        echo "FAIL: NicNodePolicy collection was not included in CR instance statistics"
+        exit 1
+    fi
+)
+echo "PASS: NicNodePolicy instance YAML is collected"
+
 # Test 10: Check diagnostic commands
 echo ""
 echo "[Test 10] Checking diagnostic commands..."
@@ -272,6 +415,12 @@ diagnostic_commands=(
     "ibstat"
     "ibv_devinfo"
     "mst status"
+    "rdma dev show"
+    "rdma link show"
+    "devlink dev show"
+    "devlink dev info"
+    "devlink port show"
+    "/sys/class/infiniband"
     "dmesg"
     "ip link"
     "ip addr"
@@ -294,6 +443,311 @@ else
     exit 1
 fi
 
+# Test 10b: Missing optional diagnostics are skipped without collection errors
+echo ""
+echo "[Test 10b] Testing capability-aware OFED diagnostics..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    TEST_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEST_DIR"' EXIT
+    DIAGNOSTIC_CALLS="$TEST_DIR/kubectl-calls.txt"
+
+    fake_diagnostics_kubectl() {
+        printf '%s\n' "$*" >> "$DIAGNOSTIC_CALLS"
+        case "$*" in
+            "get pods -n test-operator -l nvidia.com/ofed-driver= -o name")
+                echo "pod/mofed-node-1"
+                ;;
+            "get -n test-operator pod/mofed-node-1 -o jsonpath={.spec.nodeName}")
+                echo "node-1"
+                ;;
+            exec*)
+                if [[ "$*" == *"command -v ibstat"* ]] ||
+                   [[ "$*" == *"command -v ibv_devinfo"* ]] ||
+                   [[ "$*" == *"command -v mst"* ]]; then
+                    echo "unavailable"
+                elif [[ "$*" == *"command -v"* ]]; then
+                    echo "available"
+                else
+                    echo "synthetic diagnostic output"
+                fi
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_diagnostics_kubectl
+    OPERATOR_NAMESPACE=test-operator
+    OUTPUT_DIR="$TEST_DIR/report"
+    ERROR_LOG="$OUTPUT_DIR/collection-errors.log"
+    NODE_SELECTOR=""
+    SKIP_DIAGNOSTICS=false
+    mkdir -p "$OUTPUT_DIR"
+    : > "$ERROR_LOG"
+    STATS[diagnostic_commands]=0
+    STATS[diagnostic_skipped]=0
+    STATS[diagnostic_failed]=0
+
+    collect_diagnostic_commands
+
+    STATUS_FILE="$OUTPUT_DIR/operator/components/ofed-driver/diagnostics/node-1-diagnostic_status.txt"
+    for command_name in ibstat ibv_devinfo mst_status; do
+        if ! grep -Eq "^${command_name}[[:space:]]+SKIPPED" "$STATUS_FILE"; then
+            echo "FAIL: $command_name was not recorded as skipped"
+            exit 1
+        fi
+    done
+    if [ "${STATS[diagnostic_skipped]}" -ne 3 ] || [ "${STATS[diagnostic_failed]}" -ne 0 ]; then
+        echo "FAIL: Unexpected diagnostic skip/failure counts"
+        exit 1
+    fi
+    if grep -q "command not found" "$ERROR_LOG"; then
+        echo "FAIL: Missing optional tools polluted collection-errors.log"
+        exit 1
+    fi
+    for output_name in rdma_dev rdma_link devlink_dev devlink_info devlink_port infiniband_sysfs; do
+        if [ ! -s "$OUTPUT_DIR/operator/components/ofed-driver/diagnostics/node-1-${output_name}.txt" ]; then
+            echo "FAIL: Portable diagnostic output is missing: $output_name"
+            exit 1
+        fi
+    done
+    if grep '^exec ' "$DIAGNOSTIC_CALLS" | grep -vq -- '-c mofed-container -- sh -c'; then
+        echo "FAIL: A diagnostic command did not target mofed-container explicitly"
+        exit 1
+    fi
+)
+echo "PASS: Optional diagnostics are skipped and portable diagnostics are collected"
+
+# Test 10c: SR-IOV workloads and standalone operator logs are collected
+echo ""
+echo "[Test 10c] Testing SR-IOV Operator log collection..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    TEST_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEST_DIR"' EXIT
+
+    emit_resource_yaml() {
+        cat <<RESOURCE_EOF
+apiVersion: v1
+kind: List
+metadata:
+  name: synthetic
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1
+RESOURCE_EOF
+    }
+
+    fake_sriov_kubectl() {
+        case "$*" in
+            "get deployments -n test-operator -l app.kubernetes.io/name=sriov-network-operator --no-headers")
+                echo "sriov-network-operator 1/1 1 1 1m"
+                ;;
+            "get deployments -n test-operator -l app.kubernetes.io/name=sriov-network-operator -o yaml"|\
+            "get -n test-operator pod/sriov-controller -o yaml"|\
+            "get namespace standalone-sriov -o yaml"|\
+            "get deployments -n standalone-sriov -o yaml"|\
+            "get daemonsets -n standalone-sriov -o yaml"|\
+            "get configmaps -n standalone-sriov -o yaml"|\
+            "get events -n standalone-sriov --sort-by=.lastTimestamp -o yaml"|\
+            "get -n standalone-sriov pod/standalone-controller -o yaml")
+                emit_resource_yaml
+                ;;
+            "get pods -n test-operator -l name=sriov-network-operator -o name")
+                echo "pod/sriov-controller"
+                ;;
+            "get -n test-operator pod/sriov-controller -o jsonpath={.spec.containers[*].name}")
+                echo "controller sidecar"
+                ;;
+            "logs -n test-operator pod/sriov-controller -c "*" --previous --tail="*)
+                echo "bundled previous log"
+                ;;
+            "logs -n test-operator pod/sriov-controller -c "*" --tail="*)
+                echo "bundled current log"
+                ;;
+            "get sriovoperatorconfigs.sriovnetwork.openshift.io -A -o jsonpath="*)
+                echo "standalone-sriov"
+                ;;
+            "get deployments -A -l app.kubernetes.io/name=sriov-network-operator -o jsonpath="*|\
+            "get pods -A -l name=sriov-network-operator -o jsonpath="*)
+                ;;
+            "get namespace openshift-sriov-network-operator")
+                return 1
+                ;;
+            "get pods -n standalone-sriov -o name")
+                echo "pod/standalone-controller"
+                ;;
+            "get -n standalone-sriov pod/standalone-controller -o jsonpath={.spec.containers[*].name}")
+                echo "controller"
+                ;;
+            "logs -n standalone-sriov pod/standalone-controller -c controller --previous --tail="*)
+                echo "standalone previous log"
+                ;;
+            "logs -n standalone-sriov pod/standalone-controller -c controller --tail="*)
+                echo "standalone current log"
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_sriov_kubectl
+    OPERATOR_NAMESPACE=test-operator
+    OUTPUT_DIR="$TEST_DIR/report"
+    ERROR_LOG="$OUTPUT_DIR/collection-errors.log"
+    NODE_SELECTOR=""
+    LOG_LINES=100
+    mkdir -p "$OUTPUT_DIR"
+    : > "$ERROR_LOG"
+    STATS[components_found]=0
+    STATS[components_skipped]=0
+    STATS[component_pods]=0
+
+    if ! collect_component "sriov-network-operator" \
+        "app.kubernetes.io/name=sriov-network-operator" \
+        "deployment" "name=sriov-network-operator"; then
+        echo "FAIL: Bundled SR-IOV component collection failed"
+        exit 1
+    fi
+    collect_related_operators
+
+    BUNDLED_PODS="$OUTPUT_DIR/operator/components/sriov-network-operator/pods"
+    STANDALONE_PODS="$OUTPUT_DIR/related-operators/sriov-network-operator/standalone-sriov/pods"
+    for expected_file in \
+        "$BUNDLED_PODS/sriov-controller-controller.log" \
+        "$BUNDLED_PODS/sriov-controller-sidecar.log" \
+        "$BUNDLED_PODS/sriov-controller-controller-previous.log" \
+        "$STANDALONE_PODS/standalone-controller-controller.log" \
+        "$STANDALONE_PODS/standalone-controller-controller-previous.log"; do
+        if [ ! -s "$expected_file" ]; then
+            echo "FAIL: Expected SR-IOV log is missing: $expected_file"
+            exit 1
+        fi
+    done
+)
+echo "PASS: Bundled and standalone SR-IOV Operator logs are collected"
+
+# Test 10d: Helm-only workloads and every pod container type are collected
+echo ""
+echo "[Test 10d] Testing complete Helm component and init container collection..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    TEST_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEST_DIR"' EXIT
+
+    emit_resource_yaml() {
+        cat <<RESOURCE_EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chart-addon
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1
+RESOURCE_EOF
+    }
+
+    fake_helm_kubectl() {
+        case "$*" in
+            "get deployments -n test-operator -l app.kubernetes.io/name=network-operator -o jsonpath="*)
+                echo "netop-release"
+                ;;
+            "get deployments -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get deployment -n test-operator chart-addon -o yaml"|\
+            "get -n test-operator pod/chart-addon-abc -o yaml")
+                emit_resource_yaml
+                ;;
+            "get daemonsets -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get statefulsets -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get replicasets -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get jobs -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get cronjobs -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get poddisruptionbudgets -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
+            "get networkpolicies -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml")
+                cat <<EMPTY_EOF
+apiVersion: v1
+items: []
+kind: List
+metadata: {}
+EMPTY_EOF
+                ;;
+            "get pods -n test-operator -l app.kubernetes.io/instance=netop-release -o name")
+                echo "pod/chart-addon-abc"
+                ;;
+            "get -n test-operator pod/chart-addon-abc -o jsonpath={.metadata.ownerReferences[0].kind}")
+                echo "ReplicaSet"
+                ;;
+            "get -n test-operator pod/chart-addon-abc -o jsonpath={.metadata.ownerReferences[0].name}")
+                echo "chart-addon-rs"
+                ;;
+            "get replicaset -n test-operator chart-addon-rs -o jsonpath={.metadata.ownerReferences[0].kind}")
+                echo "Deployment"
+                ;;
+            "get replicaset -n test-operator chart-addon-rs -o jsonpath={.metadata.ownerReferences[0].name}")
+                echo "chart-addon"
+                ;;
+            "get -n test-operator pod/chart-addon-abc -o jsonpath={.spec.containers[*].name}")
+                echo "controller sidecar"
+                ;;
+            "get -n test-operator pod/chart-addon-abc -o jsonpath={.spec.initContainers[*].name}")
+                echo "setup"
+                ;;
+            "get -n test-operator pod/chart-addon-abc -o jsonpath={.spec.ephemeralContainers[*].name}")
+                echo "debugger"
+                ;;
+            "logs -n test-operator pod/chart-addon-abc -c "*" --previous --tail="*)
+                echo "synthetic previous log"
+                ;;
+            "logs -n test-operator pod/chart-addon-abc -c "*" --tail="*)
+                echo "synthetic current log"
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_helm_kubectl
+    OPERATOR_NAMESPACE=test-operator
+    OUTPUT_DIR="$TEST_DIR/report"
+    ERROR_LOG="$OUTPUT_DIR/collection-errors.log"
+    NODE_SELECTOR=""
+    LOG_LINES=100
+    HELM_RELEASE_SELECTOR=""
+    HELM_RELEASE_DISCOVERED=false
+    declare -A COLLECTED_PODS=()
+    declare -A DISCOVERED_COMPONENTS=()
+    mkdir -p "$OUTPUT_DIR"
+    : > "$ERROR_LOG"
+    STATS[components_found]=0
+    STATS[component_pods]=0
+
+    collect_helm_release_components
+    collect_helm_release_components
+
+    COMPONENT_DIR="$OUTPUT_DIR/operator/components/chart-addon"
+    for expected_file in \
+        "$OUTPUT_DIR/operator/helm-release/workloads/deployments.yaml" \
+        "$COMPONENT_DIR/deployment.yaml" \
+        "$COMPONENT_DIR/pods/chart-addon-abc.yaml" \
+        "$COMPONENT_DIR/pods/chart-addon-abc-controller.log" \
+        "$COMPONENT_DIR/pods/chart-addon-abc-controller-previous.log" \
+        "$COMPONENT_DIR/pods/chart-addon-abc-sidecar.log" \
+        "$COMPONENT_DIR/pods/chart-addon-abc-init-setup.log" \
+        "$COMPONENT_DIR/pods/chart-addon-abc-init-setup-previous.log" \
+        "$COMPONENT_DIR/pods/chart-addon-abc-ephemeral-debugger.log"; do
+        if [ ! -s "$expected_file" ]; then
+            echo "FAIL: Expected Helm component artifact is missing: $expected_file"
+            exit 1
+        fi
+    done
+
+    if [ "${STATS[components_found]}" -ne 1 ] || [ "${STATS[component_pods]}" -ne 1 ]; then
+        echo "FAIL: Helm component or pod was counted more than once"
+        exit 1
+    fi
+)
+echo "PASS: Helm-only workloads and all container types are collected once"
+
 # Test 11: HTML report generator exists and is executable
 echo ""
 echo "[Test 11] Checking HTML report generator..."
@@ -311,7 +765,7 @@ if [ -f "$REPORT_TEMPLATE" ]; then
     echo "  Template file exists"
     # Check for required placeholders
     missing_placeholders=false
-    for placeholder in 'SECTION_DASHBOARD' 'SECTION_NCP_STATUS' 'SECTION_COMPONENTS' 'SECTION_DIAGNOSTICS' 'SECTION_NODES' 'SECTION_EVENTS' 'SECTION_METADATA' 'SECTION_CRDS' 'SECTION_RBAC' 'SECTION_NETWORK' 'SECTION_CONFIG' 'SECTION_ERRORS'; do
+    for placeholder in 'SECTION_DASHBOARD' 'SECTION_NCP_STATUS' 'SECTION_COMPONENTS' 'SECTION_DIAGNOSTICS' 'SECTION_NODES' 'SECTION_EVENTS' 'SECTION_METADATA' 'SECTION_CRDS' 'SECTION_RBAC' 'SECTION_NETWORK' 'SECTION_CONFIG' 'SECTION_RELATED' 'SECTION_ERRORS'; do
         if grep -q "\${${placeholder}}" "$REPORT_TEMPLATE"; then
             echo "  Found placeholder: \${${placeholder}}"
         else
@@ -381,7 +835,7 @@ echo ""
 echo "[Test 14] Testing report generator with synthetic sosreport data..."
 FIXTURE_DIR="${SCRIPT_DIR}/.test-fixture-$$"
 mkdir -p "$FIXTURE_DIR"
-trap 'rm -rf "$FIXTURE_DIR"' EXIT
+trap 'rm -rf "$FIXTURE_DIR" "$SCRIPT_DIR/__pycache__"' EXIT
 
 # Create minimal sosreport directory structure
 mkdir -p "$FIXTURE_DIR/metadata"
@@ -389,6 +843,9 @@ mkdir -p "$FIXTURE_DIR/crds/definitions"
 mkdir -p "$FIXTURE_DIR/crds/instances/nicclusterpolicies"
 mkdir -p "$FIXTURE_DIR/operator/components/network-operator/pods"
 mkdir -p "$FIXTURE_DIR/operator/rbac"
+mkdir -p "$FIXTURE_DIR/operator/helm-release/workloads"
+mkdir -p "$FIXTURE_DIR/operator/components/ofed-driver/diagnostics"
+mkdir -p "$FIXTURE_DIR/related-operators/sriov-network-operator/standalone-sriov/pods"
 mkdir -p "$FIXTURE_DIR/nodes"
 mkdir -p "$FIXTURE_DIR/network"
 
@@ -444,6 +901,24 @@ status:
 FIXTURE_EOF
 
 echo "test log line" > "$FIXTURE_DIR/operator/components/network-operator/pods/network-operator-abc123.log"
+echo "sidecar container log" > "$FIXTURE_DIR/operator/components/network-operator/pods/network-operator-abc123-sidecar.log"
+echo "init setup log" > "$FIXTURE_DIR/operator/components/network-operator/pods/network-operator-abc123-init-setup.log"
+
+cat > "$FIXTURE_DIR/operator/helm-release/workloads/jobs.yaml" <<FIXTURE_EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: network-operator-upgrade-hook
+FIXTURE_EOF
+
+cat > "$FIXTURE_DIR/operator/components/ofed-driver/diagnostics/node-1-diagnostic_status.txt" <<FIXTURE_EOF
+OFED diagnostic command status
+ibstat                       SKIPPED executable ibstat is not installed in mofed-container
+rdma_dev                     SUCCESS
+FIXTURE_EOF
+echo "link mlx5_0/1 state ACTIVE" > "$FIXTURE_DIR/operator/components/ofed-driver/diagnostics/node-1-rdma_dev.txt"
+
+echo "standalone sriov namespace log" > "$FIXTURE_DIR/related-operators/sriov-network-operator/standalone-sriov/pods/sriov-controller-controller.log"
 
 cat > "$FIXTURE_DIR/nodes/nodes-summary.txt" <<FIXTURE_EOF
 NAME     STATUS   ROLES    AGE   VERSION
@@ -488,7 +963,7 @@ fi
 
 # Check for key HTML elements
 missing_elements=false
-for element in "<!DOCTYPE html>" "NicClusterPolicy" "Component Health" "OFED Diagnostics" "Node Overview" "Events" "RBAC" "sidebar"; do
+for element in "<!DOCTYPE html>" "NicClusterPolicy" "Component Health" "OFED Diagnostics" "Node Overview" "Events" "RBAC" "sidebar" "sidecar container log" "Init Container Logs (setup)" "Helm Release Artifacts" "network-operator-upgrade-hook" "Diagnostic command status" "rdma dev show" "standalone sriov namespace log"; do
     if grep -q "$element" "$REPORT_OUTPUT"; then
         echo "  Found element: $element"
     else


### PR DESCRIPTION
## Summary

- make MOFED diagnostics capability-aware: unavailable `ibstat`, `ibv_devinfo`, `mst`, and other optional executables are recorded as `SKIPPED` per node instead of polluting `collection-errors.log`
- collect portable `rdma`, `devlink`, InfiniBand sysfs, kernel, and network diagnostics from the explicit `mofed-container`; real probe or execution failures remain reported
- collect pod YAML plus current and previous logs for every regular, init, and ephemeral container across the Network Operator controller and all known managed components
- archive instances for every CRD in the generated Network Operator and sub-chart inventory, including all `NicNodePolicy` objects, and enforce definition/instance parity in regression coverage
- discover suffix-bearing NicNodePolicy workloads from their deployed workload/pod label values, without making workload discovery depend on permission to list NicNodePolicy CRs
- discover the parent Helm release and preserve a release-wide inventory of Deployments, DaemonSets, StatefulSets, ReplicaSets, Jobs, CronJobs, PodDisruptionBudgets, NetworkPolicies, and cluster RBAC
- use the Helm release label as a scoped catch-all for parent-chart and sub-chart workloads that are not yet in the generated component map, without sweeping unrelated pods from shared namespaces
- add the optional NFD topology updater to the explicit component map and retain complete bundled and standalone SR-IOV Operator coverage
- render dynamically discovered workload types, init/ephemeral logs, Helm release artifacts, diagnostic status, and related-operator data in the HTML report

The change keeps the driver image minimal and makes the collector adapt both to the tools available in each MOFED image and to the complete set of components and custom resources installed by the Network Operator chart.

## Testing

- `bash scripts/sosreport/test-sosreport.sh` under `linux/amd64` with Bash 5 and Python 3, including CRD definition/instance parity, NicNodePolicy YAML archival, permission-independent suffix discovery, Helm-only workload discovery, and regular/init/ephemeral current and previous logs
- `bash scripts/sosreport/generate-maps.sh --verify` under `linux/amd64`
- `shellcheck scripts/sosreport/kubectl-netop_sosreport scripts/sosreport/generate-maps.sh scripts/sosreport/test-sosreport.sh`
- `helm lint deployment/network-operator`
- `helm template test-release deployment/network-operator --namespace test-operator --set nfd.enabled=true --set sriovNetworkOperator.enabled=true --set maintenanceOperator.enabled=true`
- `git diff --check`
