### PR TITLE
fix: allow skipping keep NCP hooks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v7
       - name: lint helm chart
         run: make lint-helm
+      - name: test helm chart
+        run: make test-helm
   diff-manifests:
     name: check manifests
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,10 @@ lint-dockerfile: $(HADOLINT) ; $(info  running Dockerfile lint with hadolint...)
 lint-helm: $(HELM) ; $(info  running lint for helm charts...) @ ## Run helm lint
 	$Q $(HELM) lint $(CHART_PATH)
 
+.PHONY: test-helm
+test-helm: $(HELM) ; $(info  running helm chart tests...) @ ## Test Helm chart value combinations
+	$Q $(CURDIR)/hack/scripts/test-helm-hook-values.sh $(HELM) $(CHART_PATH)
+
 .PHONY: check-manifests
 check-manifests: generate manifests
 	$(info checking for git diff after running 'make manifests')

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -129,6 +129,22 @@ $ helm install --set nfd.enabled=false -n network-operator --create-namespace --
 > __Note:__ By default the operator is deployed without an instance of `NicClusterPolicy` and `MacvlanNetwork`
 > custom resources. The user is required to create it later with configuration matching the cluster or use chart parameters to deploy it together with the operator.
 
+#### Deploy Network Operator with GitOps
+
+The chart runs a `keep-ncp` hook by default to preserve a Helm-managed `NicClusterPolicy` when upgrading from an older
+chart version that deployed the custom resource. GitOps controllers such as Argo CD cannot distinguish a Helm install
+from an upgrade and run this hook during every sync.
+
+For a first-time GitOps installation where there is no existing Helm-managed `NicClusterPolicy`, disable the hook and
+its RBAC resources by setting:
+
+```yaml
+keepNCP: false
+```
+
+Keep the default value, `keepNCP: true`, when upgrading a deployment that might contain a Helm-managed
+`NicClusterPolicy` from an older chart version.
+
 #### Deploy development version of Network Operator
 
 To install development version of Network Operator you need to clone repository first and install helm chart from the

--- a/deployment/network-operator/templates/keep-ncp-hook.yaml
+++ b/deployment/network-operator/templates/keep-ncp-hook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.keepNCP }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -90,3 +91,4 @@ spec:
           command:
             - /keep-ncp
       restartPolicy: OnFailure
+{{- end }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -25,6 +25,9 @@ nfd:
 # -- Enable CRDs upgrade with helm pre-install and pre-upgrade hooks.
 upgradeCRDs: true
 
+# -- Preserve a Helm-managed NicClusterPolicy custom resource during chart upgrades.
+keepNCP: true
+
 sriovNetworkOperator:
   # -- Deploy SR-IOV Network Operator.
   enabled: false

--- a/hack/scripts/test-helm-hook-values.sh
+++ b/hack/scripts/test-helm-hook-values.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#  2026 NVIDIA CORPORATION & AFFILIATES
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+HELM_BIN="${1:?helm binary path is required}"
+CHART_PATH="${2:?chart path is required}"
+
+KEEP_NCP_RESOURCES=(
+    "network-operator-hooks-keep-ncp-sa"
+    "network-operator-hooks-keep-ncp-role"
+    "network-operator-hooks-scale-binding"
+    "network-operator-keep-ncp"
+)
+
+UPGRADE_CRD_RESOURCES=(
+    "network-operator-hooks-sa"
+    "network-operator-hooks-role"
+    "network-operator-hooks-binding"
+    "network-operator-upgrade-crd"
+)
+
+assert_resources() {
+    local manifest="$1"
+    local expected="$2"
+    shift 2
+
+    local resource
+    for resource in "$@"; do
+        if [[ "$expected" == "true" ]]; then
+            if ! grep -Fqx "  name: $resource" <<< "$manifest"; then
+                echo "expected rendered resource $resource" >&2
+                exit 1
+            fi
+        elif grep -Fqx "  name: $resource" <<< "$manifest"; then
+            echo "did not expect rendered resource $resource" >&2
+            exit 1
+        fi
+    done
+}
+
+run_case() {
+    local description="$1"
+    local expect_keep_ncp="$2"
+    local expect_upgrade_crd="$3"
+    shift 3
+
+    local manifest
+    manifest=$("$HELM_BIN" template network-operator "$CHART_PATH" \
+        --namespace network-operator "$@")
+
+    assert_resources "$manifest" "$expect_keep_ncp" "${KEEP_NCP_RESOURCES[@]}"
+    assert_resources "$manifest" "$expect_upgrade_crd" "${UPGRADE_CRD_RESOURCES[@]}"
+    echo "PASS: $description"
+}
+
+run_case "default hook values" true true
+run_case "both hook groups enabled" true true \
+    --set keepNCP=true \
+    --set upgradeCRDs=true
+run_case "keep NCP hooks disabled" false true \
+    --set keepNCP=false \
+    --set upgradeCRDs=true
+run_case "CRD upgrade hooks disabled" true false \
+    --set keepNCP=true \
+    --set upgradeCRDs=false
+run_case "all hook groups disabled" false false \
+    --set keepNCP=false \
+    --set upgradeCRDs=false

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -25,6 +25,9 @@ nfd:
 # -- Enable CRDs upgrade with helm pre-install and pre-upgrade hooks.
 upgradeCRDs: true
 
+# -- Preserve a Helm-managed NicClusterPolicy custom resource during chart upgrades.
+keepNCP: true
+
 sriovNetworkOperator:
   # -- Deploy SR-IOV Network Operator.
   enabled: false


### PR DESCRIPTION
## What this PR does

- adds a `keepNCP` Helm value, defaulting to `true` to preserve existing upgrade behavior
- gates the complete keep-NCP hook group, including its ServiceAccount, ClusterRole, ClusterRoleBinding, and Job
- documents `keepNCP: false` for first-time GitOps installations with no existing Helm-managed `NicClusterPolicy`
- adds Helm render tests for every `keepNCP` / `upgradeCRDs` combination and runs them in CI

## Why

The keep-NCP hook exists to protect a Helm-managed `NicClusterPolicy` when upgrading from older chart versions that created the custom resource. It has nothing to preserve on a fresh installation.

GitOps controllers such as Argo CD map both Helm `pre-install` and `pre-upgrade` hooks to `PreSync` and cannot distinguish an install from an upgrade. On affected Argo CD versions, the weight-0 RBAC hooks can remain running, so the weight-1 Job is never created and the initial sync cannot progress.

The new value gives fresh GitOps installations a supported way to omit these unnecessary hooks. Keeping the default at `true` avoids changing existing Helm upgrade behavior.

## Validation

- `make test-helm`
- `make lint-helm`
- `make check-release-build`
- `shellcheck hack/scripts/test-helm-hook-values.sh`
