### PR TITLE
chore: bump nvidia/distroless/go from v4.0.8 to v4.0.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir crds && \
 # Fall back to ARCH from Makefile for traditional builds (backward compatibility)
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH}
-FROM --platform=linux/${ARCH} nvcr.io/nvidia/distroless/go:v4.0.8
+FROM --platform=linux/${ARCH} nvcr.io/nvidia/distroless/go:v4.0.9
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Bumps nvidia/distroless/go from v4.0.8 to v4.0.9.

---
updated-dependencies:
- dependency-name: nvidia/distroless/go dependency-version: v4.0.9 dependency-type: direct:production ...