### PR TITLE
fix: keep controller alive to set mofed.wait on node shutdown

### DIFF
--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -621,6 +621,10 @@ spec:
                   value: nvcr.io/nvstaging/mellanox/network-operator-init-container@sha256:f23ae7023d4f558e9c9f99cc10813c2d39592a5aef02eb18bf26fd6f81107651
                 image: nvcr.io/nvstaging/mellanox/network-operator@sha256:e5de653650d1b498a5e957db45c68ae2cbe489cdaf20d7ab5e8ce49384d7988c
                 imagePullPolicy: IfNotPresent
+                lifecycle:
+                  preStop:
+                    sleep:
+                      seconds: 25
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -651,10 +655,11 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
                   readOnly: true
+              priorityClassName: system-node-critical
               securityContext:
                 runAsUser: 65532
               serviceAccountName: nvidia-network-operator-controller-manager
-              terminationGracePeriodSeconds: 10
+              terminationGracePeriodSeconds: 30
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,10 @@ spec:
                     values: [ "" ]
       securityContext:
         runAsUser: 65532
+      # system-node-critical keeps the controller in the same graceful node shutdown
+      # phase as MOFED so it can update network.nvidia.com/operator.mofed.wait
+      # before the node goes down. See https://github.com/Mellanox/network-operator/issues/2954.
+      priorityClassName: system-node-critical
       containers:
       - command:
         - /manager
@@ -70,6 +74,12 @@ spec:
             value: "false"
           - name: USE_DTK
             value: "true"
+        # Keep the controller reconciling while MOFED pods begin terminating
+        # during graceful node shutdown. Requires Kubernetes >= 1.29.
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 25
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:
@@ -92,4 +102,5 @@ spec:
             cpu: 5m
             memory: 64Mi
       serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 10
+      # Must be greater than the preStop sleep duration above.
+      terminationGracePeriodSeconds: 30

--- a/deployment/network-operator/Chart.yaml
+++ b/deployment/network-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-operator
 version: 26.7.0-rc.1
-kubeVersion: '>= 1.21.0-0'
+kubeVersion: '>= 1.32.0-0'
 appVersion: v26.7.0-rc.1
 description: Nvidia network operator
 type: application

--- a/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
+++ b/deployment/network-operator/charts/sriov-network-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sriov-network-operator
 version: 0.1.0
-kubeVersion: '>= 1.16.0-0'
+kubeVersion: '>= 1.32.0-0'
 appVersion: 1.2.0
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster
 type: application

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -47,6 +47,9 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ include "network-operator.fullname" . }}
       imagePullSecrets: {{ include "network-operator.operator.imagePullSecrets" . }}
       containers:
@@ -62,6 +65,12 @@ spec:
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
+          {{- end }}
+          {{- if gt (int (.Values.operator.preStopSleepSeconds | default 0)) 0 }}
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: {{ .Values.operator.preStopSleepSeconds }}
           {{- end }}
           command:
           - /manager
@@ -140,7 +149,7 @@ spec:
           {{- end }}
       securityContext:
         runAsUser: 65532
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.operator.terminationGracePeriodSeconds | default 30 }}
       {{- if .Values.operator.admissionController.enabled }}
       volumes:
       - name: cert

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -227,6 +227,18 @@ operator:
     requests:
       cpu: 5m
       memory: 64Mi
+  # -- Priority class for the operator controller. ``system-node-critical`` keeps the
+  # controller in the same graceful node shutdown phase as MOFED so it can update
+  # ``network.nvidia.com/operator.mofed.wait`` before the node goes down. See
+  # https://github.com/Mellanox/network-operator/issues/2954.
+  priorityClassName: system-node-critical
+  # -- Termination grace period for the operator controller. Must be greater than
+  # ``preStopSleepSeconds``.
+  terminationGracePeriodSeconds: 30
+  # -- Seconds to sleep in ``preStop`` before SIGTERM. Keeps the controller reconciling
+  # while MOFED pods begin terminating during graceful node shutdown. Requires
+  # Kubernetes >= 1.29 (PodLifecycleSleepAction). Set to ``0`` to disable.
+  preStopSleepSeconds: 25
   # -- Set additional tolerations for various Daemonsets deployed by the operator.
   # @notationType -- yaml
   tolerations:

--- a/docs/heterogeneous-cluster-support.md
+++ b/docs/heterogeneous-cluster-support.md
@@ -86,6 +86,25 @@ The `ds-owner` label (on both DaemonSet and pod template) tracks which policy ow
 
 Several downstream DaemonSets (RDMA DP, SR-IOV DP, DOCA telemetry, NIC configuration daemon) use `network.nvidia.com/operator.mofed.wait: "false"` as a nodeSelector. This label gates their scheduling until the OFED driver is ready on a node.
 
+### Graceful Node Shutdown
+
+The controller updates `mofed.wait` when MOFED pods become unready. On node reboot or shutdown this only works if the controller is still running while MOFED starts terminating.
+
+To support that, the Network Operator controller Deployment uses:
+
+- `priorityClassName: system-node-critical` (same critical graceful-shutdown phase as MOFED)
+- a `preStop` sleep (default 25s) so the manager keeps reconciling while MOFED begins termination
+- `terminationGracePeriodSeconds` greater than the sleep (default 30s)
+
+This depends on Kubernetes [Graceful Node Shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/) being enabled on the cluster. Configure the kubelet with non-zero values, for example:
+
+```yaml
+shutdownGracePeriod: 90s
+shutdownGracePeriodCriticalPods: 60s
+```
+
+Without those kubelet settings, the priority class and `preStop` sleep have no effect during node shutdown. Helm users can tune `operator.priorityClassName`, `operator.preStopSleepSeconds`, and `operator.terminationGracePeriodSeconds`.
+
 ### Label Management Flow
 
 ```mermaid

--- a/hack/scripts/test-helm-hook-values.sh
+++ b/hack/scripts/test-helm-hook-values.sh
@@ -62,6 +62,7 @@ run_case() {
 
     local manifest
     manifest=$("$HELM_BIN" template network-operator "$CHART_PATH" \
+        --kube-version 1.32.0 \
         --namespace network-operator "$@")
 
     assert_resources "$manifest" "$expect_keep_ncp" "${KEEP_NCP_RESOURCES[@]}"

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -227,6 +227,18 @@ operator:
     requests:
       cpu: 5m
       memory: 64Mi
+  # -- Priority class for the operator controller. ``system-node-critical`` keeps the
+  # controller in the same graceful node shutdown phase as MOFED so it can update
+  # ``network.nvidia.com/operator.mofed.wait`` before the node goes down. See
+  # https://github.com/Mellanox/network-operator/issues/2954.
+  priorityClassName: system-node-critical
+  # -- Termination grace period for the operator controller. Must be greater than
+  # ``preStopSleepSeconds``.
+  terminationGracePeriodSeconds: 30
+  # -- Seconds to sleep in ``preStop`` before SIGTERM. Keeps the controller reconciling
+  # while MOFED pods begin terminating during graceful node shutdown. Requires
+  # Kubernetes >= 1.29 (PodLifecycleSleepAction). Set to ``0`` to disable.
+  preStopSleepSeconds: 25
   # -- Set additional tolerations for various Daemonsets deployed by the operator.
   # @notationType -- yaml
   tolerations:


### PR DESCRIPTION
Raise the controller to system-node-critical and add a configurable preStop sleep so it can observe MOFED becoming unready and set network.nvidia.com/operator.mofed.wait before the node goes down.

Fixes: #2954