### PR TITLE
fix: cap NicNodePolicy SR-IOV device plugin names

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -44,6 +44,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	mellanoxcomv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/pkg/clustertype"
@@ -173,7 +174,8 @@ var _ = BeforeSuite(func() {
 
 	// Start controllers
 	k8sManager, err = ctrl.NewManager(k8sConfig, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:  scheme.Scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
 	})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -225,12 +227,12 @@ var _ = BeforeSuite(func() {
 
 	setupDrainControllerWithManager(k8sManager, migrationCompletionChan)
 
+	ctx, k8sManagerCancelFn = context.WithCancel(context.Background())
 	go func() {
 		defer GinkgoRecover()
 
-		ctx, k8sManagerCancelFn = context.WithCancel(ctrl.SetupSignalHandler())
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		startErr := k8sManager.Start(ctx)
+		Expect(startErr).ToNot(HaveOccurred())
 	}()
 })
 

--- a/docs/heterogeneous-cluster-support.md
+++ b/docs/heterogeneous-cluster-support.md
@@ -78,6 +78,12 @@ Each NNP produces uniquely-named DaemonSets by appending the policy name as a su
 | NicClusterPolicy | `mofed-ubuntu22.04-<hash>-ds` |
 | NicNodePolicy `pool-a` | `mofed-ubuntu22.04-<hash>-pool-a-ds` |
 
+The SR-IOV device plugin keeps its existing
+`network-operator-sriov-device-plugin` DaemonSet name for NicClusterPolicy.
+NicNodePolicy instances use `net-op-sriov-device-plugin-<policy-name>` and the
+complete name is capped at 63 characters because it is also used as a pod
+selector label value.
+
 The `ds-owner` label (on both DaemonSet and pod template) tracks which policy owns each resource:
 - NCP: `ds-owner: NicClusterPolicy`
 - NNP: `ds-owner: NicNodePolicy-<name>`

--- a/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yaml
+++ b/manifests/state-sriov-device-plugin/0030-sriov-dp-daemonset.yaml
@@ -14,7 +14,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: network-operator-sriov-device-plugin{{ .NameSuffix }}
+  name: {{ .DaemonSetName }}
   namespace: {{ .RuntimeSpec.Namespace }}
   labels:
     tier: node
@@ -23,11 +23,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: network-operator-sriov-device-plugin{{ .NameSuffix }}
+      name: {{ .DaemonSetName }}
   template:
     metadata:
       labels:
-        name: network-operator-sriov-device-plugin{{ .NameSuffix }}
+        name: {{ .DaemonSetName }}
         tier: node
         app: sriovdp
         ds-owner: {{ .DSOwner }}

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -19,12 +19,14 @@ package state //nolint:dupl
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,6 +36,11 @@ import (
 	"github.com/Mellanox/network-operator/pkg/consts"
 	"github.com/Mellanox/network-operator/pkg/render"
 	"github.com/Mellanox/network-operator/pkg/utils"
+)
+
+const (
+	sriovDpDaemonSetBaseName    = "network-operator-sriov-device-plugin"
+	sriovDpNodePolicyNamePrefix = "net-op-sriov-device-plugin"
 )
 
 // NewStateSriovDp creates a new shared device plugin state
@@ -68,13 +75,31 @@ type sriovDpRuntimeSpec struct {
 }
 
 type sriovDpManifestRenderData struct {
-	CrSpec       *mellanoxv1alpha1.DevicePluginSpec
-	Tolerations  []v1.Toleration
-	NodeAffinity *v1.NodeAffinity
-	NodeSelector map[string]string
-	DSOwner      string
-	NameSuffix   string
-	RuntimeSpec  *sriovDpRuntimeSpec
+	CrSpec        *mellanoxv1alpha1.DevicePluginSpec
+	Tolerations   []v1.Toleration
+	NodeAffinity  *v1.NodeAffinity
+	NodeSelector  map[string]string
+	DSOwner       string
+	NameSuffix    string
+	DaemonSetName string
+	RuntimeSpec   *sriovDpRuntimeSpec
+}
+
+// sriovDpDaemonSetName returns the SR-IOV device plugin DaemonSet name for a policy.
+// Keep the NicClusterPolicy name unchanged for backwards compatibility. NicNodePolicy
+// names use a shorter prefix and are capped because the name is also used as a label value.
+// Admitted policy names are limited to 30 characters, so their full unique suffix is preserved;
+// truncation is defensive for callers that render objects without admission validation.
+func sriovDpDaemonSetName(cr mellanoxv1alpha1.NicPolicyCR) string {
+	if cr.GetCRDName() == mellanoxv1alpha1.NicClusterPolicyCRDName {
+		return sriovDpDaemonSetBaseName
+	}
+
+	name := sriovDpNodePolicyNamePrefix + nameSuffix(cr)
+	if len(name) > validation.DNS1123LabelMaxLength {
+		return strings.TrimRight(name[:validation.DNS1123LabelMaxLength], "-.")
+	}
+	return name
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -163,12 +188,13 @@ func (s *stateSriovDp) GetManifestObjects(
 	}
 
 	renderData := &sriovDpManifestRenderData{
-		CrSpec:       cr.GetSriovDevicePluginSpec(),
-		Tolerations:  cr.GetTolerations(),
-		NodeAffinity: cr.GetNodeAffinity(),
-		NodeSelector: cr.GetNodeSelector(),
-		DSOwner:      dsOwnerValue(cr),
-		NameSuffix:   nameSuffix(cr),
+		CrSpec:        cr.GetSriovDevicePluginSpec(),
+		Tolerations:   cr.GetTolerations(),
+		NodeAffinity:  cr.GetNodeAffinity(),
+		NodeSelector:  cr.GetNodeSelector(),
+		DSOwner:       dsOwnerValue(cr),
+		NameSuffix:    nameSuffix(cr),
+		DaemonSetName: sriovDpDaemonSetName(cr),
 		RuntimeSpec: &sriovDpRuntimeSpec{
 			runtimeSpec:        runtimeSpec{config.FromEnv().State.NetworkOperatorResourceNamespace},
 			IsOpenshift:        clusterInfo.IsOpenshift(),

--- a/pkg/state/state_sriov_dp_test.go
+++ b/pkg/state/state_sriov_dp_test.go
@@ -18,6 +18,7 @@ package state_test
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,7 +27,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 
 	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
@@ -97,6 +101,45 @@ var _ = Describe("SR-IOV Device Plugin State tests", func() {
 			assertSriovDpPodTemplatesVolumeMountFields(&ds.Spec.Template, true)
 			Expect(ds.Spec.Template.Spec.Containers[0].Args).Should(ContainElement(ContainSubstring("--use-cdi")))
 		})
+	})
+	Context("When rendering a NicNodePolicy with SRIOV-device-plugin", func() {
+		It("should use the shortened prefix and preserve the complete supported policy name", func() {
+			policyName := strings.Repeat("a", 30)
+			expectedName := "net-op-sriov-device-plugin-" + policyName
+
+			ds := renderSriovDpDaemonSet(&ts, getMinimalNicNodePolicyWithSriovDp(policyName))
+
+			Expect(ds.Name).To(Equal(expectedName))
+			Expect(ds.Name).To(HaveLen(len(expectedName)))
+			Expect(ds.Spec.Selector.MatchLabels).To(HaveKeyWithValue("name", expectedName))
+			Expect(ds.Spec.Template.Labels).To(HaveKeyWithValue("name", expectedName))
+			Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(And(
+				HaveField("Name", "config-volume"),
+				HaveField("ConfigMap.Name", "network-operator-sriovdp-config-"+policyName),
+			)))
+		})
+
+		DescribeTable("should cap the complete DaemonSet name at a valid Kubernetes label value",
+			func(policyName, expectedName string) {
+				ds := renderSriovDpDaemonSet(&ts, getMinimalNicNodePolicyWithSriovDp(policyName))
+
+				Expect(ds.Name).To(Equal(expectedName))
+				Expect(len(ds.Name)).To(BeNumerically("<=", validation.DNS1123LabelMaxLength))
+				Expect(validation.IsDNS1123Subdomain(ds.Name)).To(BeEmpty())
+				Expect(validation.IsValidLabelValue(ds.Name)).To(BeEmpty())
+				Expect(ds.Spec.Selector.MatchLabels).To(HaveKeyWithValue("name", expectedName))
+				Expect(ds.Spec.Template.Labels).To(HaveKeyWithValue("name", expectedName))
+			},
+			Entry("at the boundary",
+				strings.Repeat("b", 36),
+				"net-op-sriov-device-plugin-"+strings.Repeat("b", 36)),
+			Entry("past the boundary",
+				strings.Repeat("c", 37),
+				"net-op-sriov-device-plugin-"+strings.Repeat("c", 36)),
+			Entry("when the cut would leave a trailing separator",
+				strings.Repeat("d", 35)+"-x",
+				"net-op-sriov-device-plugin-"+strings.Repeat("d", 35)),
+		)
 	})
 	Context("Verify Sync flows", func() {
 		It("should create Daemonset, update state to Ready", func() {
@@ -172,6 +215,46 @@ func getMinimalNicClusterPolicyWithSriovDp(useCDI bool) *mellanoxv1alpha1.NicClu
 	}
 	cr.Spec.SriovDevicePlugin = dpSpec
 	return cr
+}
+
+func getMinimalNicNodePolicyWithSriovDp(name string) *mellanoxv1alpha1.NicNodePolicy {
+	clusterPolicy := getMinimalNicClusterPolicyWithSriovDp(false)
+	return &mellanoxv1alpha1.NicNodePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: mellanoxv1alpha1.NicNodePolicySpec{
+			OFEDDriver:             nil,
+			RdmaSharedDevicePlugin: nil,
+			SriovDevicePlugin:      clusterPolicy.Spec.SriovDevicePlugin.DeepCopy(),
+			NodeSelector:           map[string]string{"node-role.kubernetes.io/worker": ""},
+			Labels:                 map[string]string{},
+			Annotations:            map[string]string{},
+			Tolerations:            []v1.Toleration{},
+		},
+		Status: mellanoxv1alpha1.NicNodePolicyStatus{
+			State:         mellanoxv1alpha1.StateIgnore,
+			Reason:        "",
+			AppliedStates: []mellanoxv1alpha1.AppliedState{},
+			Conditions:    []metav1.Condition{},
+		},
+	}
+}
+
+func renderSriovDpDaemonSet(ts *testScope, cr mellanoxv1alpha1.NicPolicyCR) *appsv1.DaemonSet {
+	ctx := context.Background()
+	objects, err := ts.renderer.GetManifestObjects(ctx, cr, ts.catalog, log.FromContext(ctx))
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, object := range objects {
+		if object.GetKind() != "DaemonSet" {
+			continue
+		}
+		ds := &appsv1.DaemonSet{}
+		Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, ds)).To(Succeed())
+		return ds
+	}
+
+	Fail("SR-IOV device plugin DaemonSet was not rendered")
+	return nil
 }
 
 func assertSriovDpPodTemplatesVolumeFields(tpl *v1.PodTemplateSpec, useCdi bool) {

--- a/scripts/sosreport/generate-maps.sh
+++ b/scripts/sosreport/generate-maps.sh
@@ -109,6 +109,12 @@ extract_components() {
 
                 # Extract component name from metadata.name in the manifest
                 comp_name=$(grep -A2 "^metadata:" "$manifest" 2>/dev/null | grep "name:" | head -1 | awk '{print $2}' | sed 's/{{.*//')
+                # The SR-IOV device plugin has policy-specific rendered names.
+                # Keep its established report directory and select every NCP/NNP
+                # instance through the stable app label.
+                if grep -q 'name: {{ .DaemonSetName }}' "$manifest" 2>/dev/null; then
+                    comp_name="network-operator-sriov-device-plugin"
+                fi
                 # Fallback to directory name if metadata.name not found
                 [ -z "$comp_name" ] && comp_name=$(basename "$state_dir" | sed 's/state-//')
 
@@ -126,6 +132,10 @@ extract_components() {
                 # Get the first label, preserving a runtime marker for
                 # NicNodePolicy suffixes.
                 label=$(format_label_selector "$(echo "$labels" | head -1)")
+
+                if grep -q 'name: {{ .DaemonSetName }}' "$manifest" 2>/dev/null; then
+                    label="app=sriovdp"
+                fi
 
                 # The OFED app label is entirely runtime-generated, so prefer
                 # its stable presence label when it is available.

--- a/scripts/sosreport/kubectl-netop_sosreport
+++ b/scripts/sosreport/kubectl-netop_sosreport
@@ -971,7 +971,7 @@ collect_all_components() {
     log_info "Collecting all component workloads..."
 
     # [GENERATED-COMPONENTS-START] - Auto-generated, do not edit manually
-    # Generated at: 2026-07-31T11:23:32Z
+    # Generated at: 2026-08-14T14:12:46Z
     # Component definitions: name, workload label, type, optional pod label
     declare -A components=(
         # Main Network Operator components
@@ -980,7 +980,7 @@ collect_all_components() {
         ["ib-kubernetes"]="name=ib-kubernetes|deployment"
         ["kube-ipoib-cni-ds"]="name=ipoib-cni|daemonset"
         ["kube-multus-ds"]="name=multus|daemonset"
-        ["network-operator-sriov-device-plugin"]="name=network-operator-sriov-device-plugin__NAME_SUFFIX__|daemonset"
+        ["network-operator-sriov-device-plugin"]="app=sriovdp|daemonset"
         ["nic-configuration-daemon"]="app.kubernetes.io/name=nic-configuration-daemon|daemonset"
         ["nic-configuration-operator"]="app.kubernetes.io/component=nic-configuration-operator|deployment"
         ["nic-feature-discovery-ds"]="name=nic-feature-discovery|daemonset"

--- a/scripts/sosreport/test-sosreport.sh
+++ b/scripts/sosreport/test-sosreport.sh
@@ -170,7 +170,7 @@ required_labels=(
     # Main Network Operator components (from manifests/state-*)
     "nvidia.com/ofed-driver"
     "name=nic-feature-discovery"
-    "name=network-operator-sriov-device-plugin"
+    "app=sriovdp"
     "app=rdma-shared-dp"
     "name=multus"
     "name=cni-plugins"
@@ -245,13 +245,16 @@ echo "[Test 6c] Testing suffix-aware component selectors..."
         exit 1
     fi
 
-    if ! grep -Fq '["rdma-shared-dp-ds"]="app=rdma-shared-dp__NAME_SUFFIX__|daemonset"' "$SOSREPORT_SCRIPT" ||
-       ! grep -Fq '["network-operator-sriov-device-plugin"]="name=network-operator-sriov-device-plugin__NAME_SUFFIX__|daemonset"' "$SOSREPORT_SCRIPT"; then
+    if ! grep -Fq '["rdma-shared-dp-ds"]="app=rdma-shared-dp__NAME_SUFFIX__|daemonset"' "$SOSREPORT_SCRIPT"; then
         echo "FAIL: Generated component map does not preserve NameSuffix markers"
         exit 1
     fi
+    if ! grep -Fq '["network-operator-sriov-device-plugin"]="app=sriovdp|daemonset"' "$SOSREPORT_SCRIPT"; then
+        echo "FAIL: SR-IOV device plugin selector does not cover NCP and NNP workloads"
+        exit 1
+    fi
 )
-echo "PASS: Component selectors include non-empty NicNodePolicy suffixes"
+echo "PASS: Component selectors include NicNodePolicy workloads"
 
 # Test 7: Script has proper error handling
 echo ""


### PR DESCRIPTION
## Summary

- preserve the existing NicClusterPolicy SR-IOV device plugin DaemonSet name
- use `net-op-sriov-device-plugin-<policy-name>` for NicNodePolicy-owned DaemonSets
- cap the complete rendered DaemonSet name and selector label at 63 characters while retaining a valid terminal character
- keep SOS report discovery working across NicClusterPolicy and NicNodePolicy workloads
- document the policy-specific naming behavior

## Root cause

The SR-IOV device plugin template appended `-<NicNodePolicy name>` to the 36-character `network-operator-sriov-device-plugin` base. A valid 30-character policy name therefore produced a 67-character `name` selector label, which Kubernetes rejects because label values are limited to 63 characters.

## Verification

- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test ./pkg/state/... -count=1`
- focused max-length, exact-boundary, overlength, and trailing-separator render cases
- `CGO_ENABLED=0 make lint`
- `scripts/sosreport/generate-maps.sh --verify` in Linux/amd64
- `scripts/sosreport/test-sosreport.sh` in Linux/amd64

A repository-wide envtest run was also attempted with Kubernetes 1.36.2 assets. It was stopped after the unrelated `controllers` package made no progress for more than five minutes; the changed `pkg/state` suite and all checks listed above pass.
