### PR TITLE
fix: hash NicNodePolicy DaemonSet names

### DIFF
--- a/docs/heterogeneous-cluster-support.md
+++ b/docs/heterogeneous-cluster-support.md
@@ -71,18 +71,18 @@ Two NicNodePolicies must not select overlapping sets of nodes. This is validated
 
 ## DaemonSet Naming and Ownership
 
-Each NNP produces uniquely-named DaemonSets by appending the policy name as a suffix:
+NicClusterPolicy keeps the existing DaemonSet names. All three NicNodePolicy
+components append the same short, deterministic policy-name hash:
 
-| Policy | DaemonSet Name |
-|--------|---------------|
-| NicClusterPolicy | `mofed-ubuntu22.04-<hash>-ds` |
-| NicNodePolicy `pool-a` | `mofed-ubuntu22.04-<hash>-pool-a-ds` |
+| Component | NicClusterPolicy | NicNodePolicy |
+|-----------|------------------|---------------|
+| OFED | `mofed-ubuntu22.04-<kernel-hash>-ds` | `mofed-ubuntu22.04-<kernel-hash>-<policy-name-hash>-ds` |
+| RDMA shared device plugin | `rdma-shared-dp-ds` | `rdma-shared-dp-ds-<policy-name-hash>` |
+| SR-IOV device plugin | `network-operator-sriov-device-plugin` | `network-operator-sriov-device-plugin-<policy-name-hash>` |
 
-The SR-IOV device plugin keeps its existing
-`network-operator-sriov-device-plugin` DaemonSet name for NicClusterPolicy.
-NicNodePolicy instances use `net-op-sriov-device-plugin-<policy-name>` and the
-complete name is capped at 63 characters because it is also used as a pod
-selector label value.
+The policy-name hash uses the same mechanism as the OFED kernel hash. Only
+DaemonSet identity is hashed: policy-specific ConfigMap names and the RDMA
+shared device plugin `app` label retain the readable policy-name suffix.
 
 The `ds-owner` label (on both DaemonSet and pod template) tracks which policy owns each resource:
 - NCP: `ds-owner: NicClusterPolicy`

--- a/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
+++ b/manifests/state-ofed-driver/0050_ofed-driver-ds.yaml
@@ -15,22 +15,22 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .NameSuffix }}
+    app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .DaemonSetNameSuffix }}
     nvidia.com/ofed-driver: ""
     mofed-ds-format-version: "1"
     ds-owner: {{ .DSOwner }}
-  name: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .NameSuffix }}-ds
+  name: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .DaemonSetNameSuffix }}-ds
   namespace: {{ .RuntimeSpec.Namespace }}
 spec:
   updateStrategy:
     type: OnDelete
   selector:
     matchLabels:
-      app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .NameSuffix }}
+      app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .DaemonSetNameSuffix }}
   template:
     metadata:
       labels:
-        app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .NameSuffix }}
+        app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}{{ .DaemonSetNameSuffix }}
         kernel: {{ .RuntimeSpec.Kernel }}
         nvidia.com/ofed-driver: ""
         ds-owner: {{ .DSOwner }}

--- a/manifests/state-rdma-shared-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
+++ b/manifests/state-rdma-shared-device-plugin/0060_rdma-shared-dev-plugin-ds.yaml
@@ -14,7 +14,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: rdma-shared-dp-ds{{ .NameSuffix }}
+  name: rdma-shared-dp-ds{{ .DaemonSetNameSuffix }}
   namespace: {{ .RuntimeSpec.Namespace }}
   labels:
     ds-owner: {{ .DSOwner }}

--- a/pkg/state/state_ofed.go
+++ b/pkg/state/state_ofed.go
@@ -19,7 +19,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -37,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -270,7 +268,7 @@ type ofedManifestRenderData struct {
 	NodeAffinity           *v1.NodeAffinity
 	NodeSelector           map[string]string
 	DSOwner                string
-	NameSuffix             string
+	DaemonSetNameSuffix    string
 	RuntimeSpec            *ofedRuntimeSpec
 	AdditionalVolumeMounts additionalVolumeMounts
 }
@@ -712,7 +710,7 @@ func renderObjects(ctx context.Context, nodePool *nodeinfo.NodePool, useDtk bool
 		NodeAffinity:           cr.GetNodeAffinity(),
 		NodeSelector:           cr.GetNodeSelector(),
 		DSOwner:                dsOwnerValue(cr),
-		NameSuffix:             nameSuffix(cr),
+		DaemonSetNameSuffix:    hashedNameSuffix(cr),
 		AdditionalVolumeMounts: additionalVolMounts,
 	}
 
@@ -1079,13 +1077,4 @@ func (s *stateOFED) getOCPDriverToolkitImage(ctx context.Context, ostreeVersion 
 		return "", fmt.Errorf("failed to find DTK image for RHCOS version: %v", ostreeVersion)
 	}
 	return image, nil
-}
-
-// getStringHash returns a short deterministic hash
-func getStringHash(s string) string {
-	hasher := fnv.New32a()
-	if _, err := hasher.Write([]byte(s)); err != nil {
-		panic(err)
-	}
-	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 }

--- a/pkg/state/state_ofed_test.go
+++ b/pkg/state/state_ofed_test.go
@@ -327,6 +327,7 @@ var _ = Describe("MOFED state test", func() {
 			// Expect 5 objects: 1 DS per pool, Service Account, Role, RoleBinding
 			Expect(len(objs)).To(Equal(5))
 			By("Verify DaemonSets NodeSelector")
+			daemonSetNames := []string{}
 			for _, obj := range objs {
 				if obj.GetKind() != "DaemonSet" {
 					continue
@@ -334,6 +335,7 @@ var _ = Describe("MOFED state test", func() {
 				ds := appsv1.DaemonSet{}
 				err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &ds)
 				Expect(err).NotTo(HaveOccurred())
+				daemonSetNames = append(daemonSetNames, ds.Name)
 				if ds.Name == fmt.Sprintf("mofed-%s%s-%s-ds", osName, osVer, "54669c9886") {
 					verifyDSNodeSelector(ds.Spec.Template.Spec.NodeSelector, kernelFull1)
 				}
@@ -342,7 +344,71 @@ var _ = Describe("MOFED state test", func() {
 				}
 				verifyPodAntiInfinity(ds.Spec.Template.Spec.Affinity)
 			}
+			Expect(daemonSetNames).To(ConsistOf(
+				fmt.Sprintf("mofed-%s%s-%s-ds", osName, osVer, "54669c9886"),
+				fmt.Sprintf("mofed-%s%s-%s-ds", osName, osVer, "6d568d699f"),
+			))
 		})
+		DescribeTable("Should hash the NicNodePolicy name in DaemonSet names and app labels",
+			func(policyName, expectedPolicyHash string) {
+				ofedState := getOfedState()
+				cr := &v1alpha1.NicNodePolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: policyName},
+					Spec: v1alpha1.NicNodePolicySpec{
+						OFEDDriver: &v1alpha1.OFEDDriverSpec{
+							ImageSpec: v1alpha1.ImageSpec{
+								Image:      "mofed",
+								Repository: "nvcr.io/mellanox",
+								Version:    "23.10-0.5.5.0",
+							},
+						},
+						RdmaSharedDevicePlugin: nil,
+						SriovDevicePlugin:      nil,
+						NodeSelector:           map[string]string{"node-role.kubernetes.io/worker": ""},
+						Labels:                 map[string]string{},
+						Annotations:            map[string]string{},
+						Tolerations:            []v1.Toleration{},
+					},
+					Status: v1alpha1.NicNodePolicyStatus{
+						State:         v1alpha1.StateIgnore,
+						Reason:        "",
+						AppliedStates: []v1alpha1.AppliedState{},
+						Conditions:    []metav1.Condition{},
+					},
+				}
+
+				catalog := NewInfoCatalog()
+				catalog.Add(InfoTypeClusterType, &dummyProvider{})
+				catalog.Add(InfoTypeNodeInfo, nodeinfo.NewProvider([]*v1.Node{getNode("node1", kernelFull1)}))
+				catalog.Add(InfoTypeDocaDriverImage, &dummyOfedImageProvider{tagExists: true})
+
+				objs, err := ofedState.GetManifestObjects(ctx, cr, catalog, testLogger)
+				Expect(err).NotTo(HaveOccurred())
+				expectedApp := fmt.Sprintf(
+					"mofed-%s%s-%s-%s", osName, osVer, "54669c9886", expectedPolicyHash)
+				expectedName := expectedApp + "-ds"
+
+				var renderedDaemonSet *appsv1.DaemonSet
+				for _, obj := range objs {
+					if obj.GetKind() != "DaemonSet" {
+						continue
+					}
+					renderedDaemonSet = &appsv1.DaemonSet{}
+					Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
+						obj.Object, renderedDaemonSet)).To(Succeed())
+					break
+				}
+
+				Expect(renderedDaemonSet).NotTo(BeNil())
+				Expect(renderedDaemonSet.Name).To(Equal(expectedName))
+				Expect(renderedDaemonSet.Labels).To(HaveKeyWithValue("app", expectedApp))
+				Expect(renderedDaemonSet.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", expectedApp))
+				Expect(renderedDaemonSet.Spec.Template.Labels).To(HaveKeyWithValue("app", expectedApp))
+				Expect(renderedDaemonSet.Labels).To(HaveKeyWithValue("ds-owner", "nnp-"+policyName))
+			},
+			Entry("for a readable policy name", "pool-a", "779d97f8c7"),
+			Entry("for the maximum admitted policy name length", strings.Repeat("a", 30), "84bb999775"),
+		)
 		It("Should Render subscription mounts for RHEL + containerd", func() {
 			client := mocks.ControllerRuntimeClient{}
 			manifestBaseDir := "../../manifests/state-ofed-driver"

--- a/pkg/state/state_rdma_shared_device_plugin.go
+++ b/pkg/state/state_rdma_shared_device_plugin.go
@@ -66,13 +66,14 @@ type stateRDMASharedDevicePluginSpec struct {
 	ContainerResources ContainerResourcesMap
 }
 type stateRDMASharedDevicePluginManifestRenderData struct {
-	CrSpec       *mellanoxv1alpha1.DevicePluginSpec
-	Tolerations  []v1.Toleration
-	NodeAffinity *v1.NodeAffinity
-	NodeSelector map[string]string
-	DSOwner      string
-	NameSuffix   string
-	RuntimeSpec  *stateRDMASharedDevicePluginSpec
+	CrSpec              *mellanoxv1alpha1.DevicePluginSpec
+	Tolerations         []v1.Toleration
+	NodeAffinity        *v1.NodeAffinity
+	NodeSelector        map[string]string
+	DSOwner             string
+	NameSuffix          string
+	DaemonSetNameSuffix string
+	RuntimeSpec         *stateRDMASharedDevicePluginSpec
 }
 
 // Sync attempt to get the system to match the desired state which State represent.
@@ -161,12 +162,13 @@ func (s *stateRDMASharedDevicePlugin) GetManifestObjects(
 	}
 
 	renderData := &stateRDMASharedDevicePluginManifestRenderData{
-		CrSpec:       cr.GetRdmaSharedDevicePluginSpec(),
-		Tolerations:  cr.GetTolerations(),
-		NodeAffinity: cr.GetNodeAffinity(),
-		NodeSelector: cr.GetNodeSelector(),
-		DSOwner:      dsOwnerValue(cr),
-		NameSuffix:   nameSuffix(cr),
+		CrSpec:              cr.GetRdmaSharedDevicePluginSpec(),
+		Tolerations:         cr.GetTolerations(),
+		NodeAffinity:        cr.GetNodeAffinity(),
+		NodeSelector:        cr.GetNodeSelector(),
+		DSOwner:             dsOwnerValue(cr),
+		NameSuffix:          nameSuffix(cr),
+		DaemonSetNameSuffix: hashedNameSuffix(cr),
 		RuntimeSpec: &stateRDMASharedDevicePluginSpec{
 			runtimeSpec:        runtimeSpec{config.FromEnv().State.NetworkOperatorResourceNamespace},
 			IsOpenshift:        clusterInfo.IsOpenshift(),

--- a/pkg/state/state_rdma_shared_device_plugin_test.go
+++ b/pkg/state/state_rdma_shared_device_plugin_test.go
@@ -17,9 +17,16 @@ limitations under the License.
 package state_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/pkg/state"
@@ -41,6 +48,7 @@ var _ = Describe("RDMA Shared Device Plugin", func() {
 			// We only expect a single manifest here, which should be the DaemonSet.
 			// The other manifests are only if RuntimeSpec.IsOpenshift == true.
 			Expect(len(objs)).To(Equal(1))
+			Expect(objs[0].GetName()).To(Equal("rdma-shared-dp-ds"))
 			GetManifestObjectsTest(ts.context, cr, ts.catalog, &cr.Spec.RdmaSharedDevicePlugin.ImageSpec, ts.renderer)
 		})
 		It("manifests with RdmaSharedDevicePlugin - image as SHA256", func() {
@@ -58,6 +66,27 @@ var _ = Describe("RDMA Shared Device Plugin", func() {
 			Expect(len(objs)).To(Equal(4))
 			GetManifestObjectsTest(ts.context, cr, ts.catalog, &cr.Spec.RdmaSharedDevicePlugin.ImageSpec, ts.renderer)
 		})
+	})
+	Context("When rendering a NicNodePolicy", func() {
+		DescribeTable("should use a deterministic policy name hash only in the DaemonSet name",
+			func(policyName, expectedHash string) {
+				expectedName := "rdma-shared-dp-ds-" + expectedHash
+				ds := renderRdmaSharedDevicePluginDaemonSet(
+					&ts, getMinimalNicNodePolicyWithRdmaSharedDevicePlugin(policyName))
+
+				Expect(ds.Name).To(Equal(expectedName))
+				Expect(len(ds.Name)).To(BeNumerically("<=", validation.DNS1123LabelMaxLength))
+				Expect(validation.IsDNS1123Subdomain(ds.Name)).To(BeEmpty())
+				Expect(ds.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", "rdma-shared-dp-"+policyName))
+				Expect(ds.Spec.Template.Labels).To(HaveKeyWithValue("app", "rdma-shared-dp-"+policyName))
+				Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(And(
+					HaveField("Name", "config"),
+					HaveField("ConfigMap.Name", "rdma-devices-"+policyName),
+				)))
+			},
+			Entry("for a readable policy name", "pool-a", "779d97f8c7"),
+			Entry("for the maximum admitted policy name length", strings.Repeat("a", 30), "84bb999775"),
+		)
 	})
 	Context("should sync", func() {
 		It("without any errors", func() {
@@ -204,4 +233,44 @@ func getRDMASharedDevicePlugin() *mellanoxv1alpha1.NicClusterPolicy {
 		},
 	}
 	return cr
+}
+
+func getMinimalNicNodePolicyWithRdmaSharedDevicePlugin(name string) *mellanoxv1alpha1.NicNodePolicy {
+	clusterPolicy := getRDMASharedDevicePlugin()
+	return &mellanoxv1alpha1.NicNodePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: mellanoxv1alpha1.NicNodePolicySpec{
+			OFEDDriver:             nil,
+			RdmaSharedDevicePlugin: clusterPolicy.Spec.RdmaSharedDevicePlugin.DeepCopy(),
+			SriovDevicePlugin:      nil,
+			NodeSelector:           map[string]string{"node-role.kubernetes.io/worker": ""},
+			Labels:                 map[string]string{},
+			Annotations:            map[string]string{},
+			Tolerations:            []v1.Toleration{},
+		},
+		Status: mellanoxv1alpha1.NicNodePolicyStatus{
+			State:         mellanoxv1alpha1.StateIgnore,
+			Reason:        "",
+			AppliedStates: []mellanoxv1alpha1.AppliedState{},
+			Conditions:    []metav1.Condition{},
+		},
+	}
+}
+
+func renderRdmaSharedDevicePluginDaemonSet(
+	ts *testScope, cr mellanoxv1alpha1.NicPolicyCR) *appsv1.DaemonSet {
+	objects, err := ts.renderer.GetManifestObjects(ts.context, cr, ts.catalog, testLogger)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, object := range objects {
+		if object.GetKind() != "DaemonSet" {
+			continue
+		}
+		ds := &appsv1.DaemonSet{}
+		Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, ds)).To(Succeed())
+		return ds
+	}
+
+	Fail("RDMA shared device plugin DaemonSet was not rendered")
+	return nil
 }

--- a/pkg/state/state_skel.go
+++ b/pkg/state/state_skel.go
@@ -19,6 +19,8 @@ package state
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -28,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -89,6 +92,25 @@ func nameSuffix(cr mellanoxv1alpha1.NicPolicyCR) string {
 		return ""
 	}
 	return "-" + cr.GetName()
+}
+
+// hashedNameSuffix returns a bounded resource name suffix for the given CR.
+// NicClusterPolicy resources keep their existing names, while NicNodePolicy
+// resources use the same short deterministic hash as OFED DaemonSet names.
+func hashedNameSuffix(cr mellanoxv1alpha1.NicPolicyCR) string {
+	if cr.GetCRDName() == mellanoxv1alpha1.NicClusterPolicyCRDName {
+		return ""
+	}
+	return "-" + getStringHash(cr.GetName())
+}
+
+// getStringHash returns a short deterministic hash.
+func getStringHash(s string) string {
+	hasher := fnv.New32a()
+	if _, err := hasher.Write([]byte(s)); err != nil {
+		panic(err)
+	}
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 }
 
 // GetSupportedGVKs returns a list of GetSupportedGVKs managed by Network Operator

--- a/pkg/state/state_sriov_dp.go
+++ b/pkg/state/state_sriov_dp.go
@@ -19,14 +19,12 @@ package state //nolint:dupl
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,8 +37,7 @@ import (
 )
 
 const (
-	sriovDpDaemonSetBaseName    = "network-operator-sriov-device-plugin"
-	sriovDpNodePolicyNamePrefix = "net-op-sriov-device-plugin"
+	sriovDpDaemonSetBaseName = "network-operator-sriov-device-plugin"
 )
 
 // NewStateSriovDp creates a new shared device plugin state
@@ -87,19 +84,14 @@ type sriovDpManifestRenderData struct {
 
 // sriovDpDaemonSetName returns the SR-IOV device plugin DaemonSet name for a policy.
 // Keep the NicClusterPolicy name unchanged for backwards compatibility. NicNodePolicy
-// names use a shorter prefix and are capped because the name is also used as a label value.
-// Admitted policy names are limited to 30 characters, so their full unique suffix is preserved;
-// truncation is defensive for callers that render objects without admission validation.
+// names use the same short deterministic hash mechanism as OFED DaemonSet names so the
+// rendered name has a bounded length and remains valid when used as a label value.
 func sriovDpDaemonSetName(cr mellanoxv1alpha1.NicPolicyCR) string {
 	if cr.GetCRDName() == mellanoxv1alpha1.NicClusterPolicyCRDName {
 		return sriovDpDaemonSetBaseName
 	}
 
-	name := sriovDpNodePolicyNamePrefix + nameSuffix(cr)
-	if len(name) > validation.DNS1123LabelMaxLength {
-		return strings.TrimRight(name[:validation.DNS1123LabelMaxLength], "-.")
-	}
-	return name
+	return sriovDpDaemonSetBaseName + hashedNameSuffix(cr)
 }
 
 // Sync attempt to get the system to match the desired state which State represent.

--- a/pkg/state/state_sriov_dp_test.go
+++ b/pkg/state/state_sriov_dp_test.go
@@ -103,24 +103,9 @@ var _ = Describe("SR-IOV Device Plugin State tests", func() {
 		})
 	})
 	Context("When rendering a NicNodePolicy with SRIOV-device-plugin", func() {
-		It("should use the shortened prefix and preserve the complete supported policy name", func() {
-			policyName := strings.Repeat("a", 30)
-			expectedName := "net-op-sriov-device-plugin-" + policyName
-
-			ds := renderSriovDpDaemonSet(&ts, getMinimalNicNodePolicyWithSriovDp(policyName))
-
-			Expect(ds.Name).To(Equal(expectedName))
-			Expect(ds.Name).To(HaveLen(len(expectedName)))
-			Expect(ds.Spec.Selector.MatchLabels).To(HaveKeyWithValue("name", expectedName))
-			Expect(ds.Spec.Template.Labels).To(HaveKeyWithValue("name", expectedName))
-			Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(And(
-				HaveField("Name", "config-volume"),
-				HaveField("ConfigMap.Name", "network-operator-sriovdp-config-"+policyName),
-			)))
-		})
-
-		DescribeTable("should cap the complete DaemonSet name at a valid Kubernetes label value",
-			func(policyName, expectedName string) {
+		DescribeTable("should use a deterministic policy name hash in the DaemonSet name",
+			func(policyName, expectedHash string) {
+				expectedName := "network-operator-sriov-device-plugin-" + expectedHash
 				ds := renderSriovDpDaemonSet(&ts, getMinimalNicNodePolicyWithSriovDp(policyName))
 
 				Expect(ds.Name).To(Equal(expectedName))
@@ -129,16 +114,13 @@ var _ = Describe("SR-IOV Device Plugin State tests", func() {
 				Expect(validation.IsValidLabelValue(ds.Name)).To(BeEmpty())
 				Expect(ds.Spec.Selector.MatchLabels).To(HaveKeyWithValue("name", expectedName))
 				Expect(ds.Spec.Template.Labels).To(HaveKeyWithValue("name", expectedName))
+				Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(And(
+					HaveField("Name", "config-volume"),
+					HaveField("ConfigMap.Name", "network-operator-sriovdp-config-"+policyName),
+				)))
 			},
-			Entry("at the boundary",
-				strings.Repeat("b", 36),
-				"net-op-sriov-device-plugin-"+strings.Repeat("b", 36)),
-			Entry("past the boundary",
-				strings.Repeat("c", 37),
-				"net-op-sriov-device-plugin-"+strings.Repeat("c", 36)),
-			Entry("when the cut would leave a trailing separator",
-				strings.Repeat("d", 35)+"-x",
-				"net-op-sriov-device-plugin-"+strings.Repeat("d", 35)),
+			Entry("for a readable policy name", "pool-a", "779d97f8c7"),
+			Entry("for the maximum admitted policy name length", strings.Repeat("a", 30), "84bb999775"),
 		)
 	})
 	Context("Verify Sync flows", func() {


### PR DESCRIPTION
## Summary

- use one deterministic policy-name hash suffix for NicNodePolicy-owned OFED, RDMA shared device plugin, and SR-IOV device plugin DaemonSets
- preserve all existing NicClusterPolicy DaemonSet names
- render NNP DaemonSets as:
  - `mofed-<os>-<kernel-hash>-<policy-name-hash>-ds`
  - `rdma-shared-dp-ds-<policy-name-hash>`
  - `network-operator-sriov-device-plugin-<policy-name-hash>`
- use the hashed OFED identity consistently in DaemonSet metadata, selectors, and pod labels
- preserve readable `ds-owner` values, policy-specific ConfigMap names, and the RDMA `app` selector used by SOS report discovery
- centralize the shared hashed suffix helper and update focused render tests and heterogeneous-cluster documentation

This is a follow-up to #3019 and replaces direct policy-name suffixes in NicNodePolicy-owned DaemonSet names.

## Verification

- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test ./pkg/state/... -count=1`
- `CGO_ENABLED=0 make lint`
- `bash -n scripts/sosreport/generate-maps.sh scripts/sosreport/kubectl-netop_sosreport scripts/sosreport/test-sosreport.sh`
- verified the OFED SOS component selector remains `nvidia.com/ofed-driver=`
- verified the RDMA SOS component key remains `rdma-shared-dp-ds` with selector `app=rdma-shared-dp__NAME_SUFFIX__`