### PR TITLE
feat: support meta-plugins for secondary networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,28 @@ plugins in order. This allows tools such as k8s-launch-kit to add the `sbr`
 plugin for source-based routing and the `tuning` plugin for
 `ignoreARP: true` without replacing the primary network configuration.
 
+The value uses the same raw fragment format as the SR-IOV Network Operator:
+one or more plugin JSON objects separated by commas, without enclosing array
+brackets. For example, the combined k8s-launch-kit configuration is:
+
+```yaml
+metaPlugins: |
+  {
+    "type": "tuning",
+    "sysctl": {
+      "net.ipv4.conf.all.arp_ignore": "1",
+      "net.ipv4.conf.all.arp_announce": "2",
+      "net.ipv4.conf.all.rp_filter": "0",
+      "net.ipv4.conf.IFNAME.arp_ignore": "1",
+      "net.ipv4.conf.IFNAME.arp_announce": "2",
+      "net.ipv4.conf.IFNAME.rp_filter": "0"
+    }
+  },
+  {
+    "type": "sbr"
+  }
+```
+
 ### IPoIBNetwork CRD
 This CRD defines an IPoIBNetwork secondary network. It is translated by the Operator to a `NetworkAttachmentDefinition` instance as defined in [k8snetworkplumbingwg/multi-net-spec](https://github.com/k8snetworkplumbingwg/multi-net-spec).
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ MacvlanNetwork CRD Spec includes the following fields:
 - `mode`: Mode of interface one of "bridge", "private", "vepa", "passthru", default "bridge".
 - `mtu`: MTU of interface to the specified value. 0 for master's MTU.
 - `ipam`: IPAM configuration to be used for this network.
+- `metaPlugins`: Additional CNI plugin configurations to chain after the macvlan plugin.
 
 
 ### HostDeviceNetwork CRD
@@ -159,6 +160,13 @@ HostDeviceNetwork CRD Spec includes the following fields:
 - `networkNamespace`: Namespace for NetworkAttachmentDefinition related to this HostDeviceNetwork CRD.
 - `resourceName`: Host device resource pool.
 - `ipam`: IPAM configuration to be used for this network.
+- `metaPlugins`: Additional CNI plugin configurations to chain after the host-device plugin.
+
+When `metaPlugins` is set, the Operator renders a CNI configuration list with
+the primary `macvlan` or `host-device` plugin first, followed by the supplied
+plugins in order. This allows tools such as k8s-launch-kit to add the `sbr`
+plugin for source-based routing and the `tuning` plugin for
+`ignoreARP: true` without replacing the primary network configuration.
 
 ### IPoIBNetwork CRD
 This CRD defines an IPoIBNetwork secondary network. It is translated by the Operator to a `NetworkAttachmentDefinition` instance as defined in [k8snetworkplumbingwg/multi-net-spec](https://github.com/k8snetworkplumbingwg/multi-net-spec).

--- a/api/v1alpha1/hostdevicenetwork_types.go
+++ b/api/v1alpha1/hostdevicenetwork_types.go
@@ -33,7 +33,8 @@ type HostDeviceNetworkSpec struct {
 	ResourceName string `json:"resourceName,omitempty"`
 	// IPAM configuration to be used for this network
 	IPAM string `json:"ipam,omitempty"`
-	// MetaPluginsConfig contains additional CNI plugin configurations to chain after the host-device plugin.
+	// MetaPluginsConfig contains a raw, comma-separated sequence of CNI plugin objects without enclosing
+	// array brackets to chain after the host-device plugin.
 	MetaPluginsConfig string `json:"metaPlugins,omitempty"`
 }
 

--- a/api/v1alpha1/hostdevicenetwork_types.go
+++ b/api/v1alpha1/hostdevicenetwork_types.go
@@ -33,6 +33,8 @@ type HostDeviceNetworkSpec struct {
 	ResourceName string `json:"resourceName,omitempty"`
 	// IPAM configuration to be used for this network
 	IPAM string `json:"ipam,omitempty"`
+	// MetaPluginsConfig contains additional CNI plugin configurations to chain after the host-device plugin.
+	MetaPluginsConfig string `json:"metaPlugins,omitempty"`
 }
 
 // HostDeviceNetworkStatus defines the observed state of HostDeviceNetwork

--- a/api/v1alpha1/macvlannetwork_types.go
+++ b/api/v1alpha1/macvlannetwork_types.go
@@ -39,6 +39,8 @@ type MacvlanNetworkSpec struct {
 	Mtu int `json:"mtu,omitempty"`
 	// IPAM configuration to be used for this network.
 	IPAM string `json:"ipam,omitempty"`
+	// MetaPluginsConfig contains additional CNI plugin configurations to chain after the macvlan plugin.
+	MetaPluginsConfig string `json:"metaPlugins,omitempty"`
 }
 
 // MacvlanNetworkStatus defines the observed state of MacvlanNetwork

--- a/api/v1alpha1/macvlannetwork_types.go
+++ b/api/v1alpha1/macvlannetwork_types.go
@@ -39,7 +39,8 @@ type MacvlanNetworkSpec struct {
 	Mtu int `json:"mtu,omitempty"`
 	// IPAM configuration to be used for this network.
 	IPAM string `json:"ipam,omitempty"`
-	// MetaPluginsConfig contains additional CNI plugin configurations to chain after the macvlan plugin.
+	// MetaPluginsConfig contains a raw, comma-separated sequence of CNI plugin objects without enclosing
+	// array brackets to chain after the macvlan plugin.
 	MetaPluginsConfig string `json:"metaPlugins,omitempty"`
 }
 

--- a/config/crd/bases/mellanox.com_hostdevicenetworks.yaml
+++ b/config/crd/bases/mellanox.com_hostdevicenetworks.yaml
@@ -49,6 +49,10 @@ spec:
               ipam:
                 description: IPAM configuration to be used for this network
                 type: string
+              metaPlugins:
+                description: MetaPluginsConfig contains additional CNI plugin configurations
+                  to chain after the host-device plugin.
+                type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource
                 type: string

--- a/config/crd/bases/mellanox.com_hostdevicenetworks.yaml
+++ b/config/crd/bases/mellanox.com_hostdevicenetworks.yaml
@@ -50,8 +50,9 @@ spec:
                 description: IPAM configuration to be used for this network
                 type: string
               metaPlugins:
-                description: MetaPluginsConfig contains additional CNI plugin configurations
-                  to chain after the host-device plugin.
+                description: |-
+                  MetaPluginsConfig contains a raw, comma-separated sequence of CNI plugin objects without enclosing
+                  array brackets to chain after the host-device plugin.
                 type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource

--- a/config/crd/bases/mellanox.com_macvlannetworks.yaml
+++ b/config/crd/bases/mellanox.com_macvlannetworks.yaml
@@ -54,8 +54,9 @@ spec:
                   route interface
                 type: string
               metaPlugins:
-                description: MetaPluginsConfig contains additional CNI plugin configurations
-                  to chain after the macvlan plugin.
+                description: |-
+                  MetaPluginsConfig contains a raw, comma-separated sequence of CNI plugin objects without enclosing
+                  array brackets to chain after the macvlan plugin.
                 type: string
               mode:
                 description: Mode of interface one of "bridge", "private", "vepa",

--- a/config/crd/bases/mellanox.com_macvlannetworks.yaml
+++ b/config/crd/bases/mellanox.com_macvlannetworks.yaml
@@ -53,6 +53,10 @@ spec:
                 description: Name of the host interface to enslave. Defaults to default
                   route interface
                 type: string
+              metaPlugins:
+                description: MetaPluginsConfig contains additional CNI plugin configurations
+                  to chain after the macvlan plugin.
+                type: string
               mode:
                 description: Mode of interface one of "bridge", "private", "vepa",
                   "passthru"

--- a/controllers/hostdevicenetwork_controller_test.go
+++ b/controllers/hostdevicenetwork_controller_test.go
@@ -44,8 +44,9 @@ var _ = Describe("HostDeviceNetwork Controller", func() {
 					Namespace: "",
 				},
 				Spec: mellanoxv1alpha1.HostDeviceNetworkSpec{
-					NetworkNamespace: "default",
-					ResourceName:     "test",
+					NetworkNamespace:  "default",
+					ResourceName:      "test",
+					MetaPluginsConfig: testMetaPluginsConfig,
 				},
 			}
 
@@ -58,6 +59,7 @@ var _ = Describe("HostDeviceNetwork Controller", func() {
 			Expect(found.Spec.NetworkNamespace).To(Equal("default"))
 			Expect(found.Spec.ResourceName).To(Equal("test"))
 			Expect(found.Spec.IPAM).To(Equal(""))
+			Expect(found.Spec.MetaPluginsConfig).To(Equal(testMetaPluginsConfig))
 
 			err = k8sClient.Delete(goctx.TODO(), &cr)
 			Expect(err).NotTo(HaveOccurred())

--- a/controllers/macvlannetwork_controller_test.go
+++ b/controllers/macvlannetwork_controller_test.go
@@ -36,6 +36,7 @@ const (
 	testNetworkNamespace      = "default"
 	crName                    = "test"
 	crNamespace               = "default"
+	testMetaPluginsConfig     = `{"type":"sbr"}`
 )
 
 //nolint:dupl
@@ -49,10 +50,11 @@ var _ = Describe("MacVlanNetwork Controller", func() {
 					Namespace: crNamespace,
 				},
 				Spec: mellanoxv1alpha1.MacvlanNetworkSpec{
-					NetworkNamespace: testNetworkNamespace,
-					Master:           "ibs3",
-					Mode:             "bridge",
-					Mtu:              150,
+					NetworkNamespace:  testNetworkNamespace,
+					Master:            "ibs3",
+					Mode:              "bridge",
+					Mtu:               150,
+					MetaPluginsConfig: testMetaPluginsConfig,
 				},
 			}
 
@@ -66,6 +68,7 @@ var _ = Describe("MacVlanNetwork Controller", func() {
 			Expect(found.Spec.NetworkNamespace).To(Equal(testNetworkNamespace))
 			Expect(found.Spec.Master).To(Equal("ibs3"))
 			Expect(found.Spec.IPAM).To(Equal(""))
+			Expect(found.Spec.MetaPluginsConfig).To(Equal(testMetaPluginsConfig))
 
 			By("Verify NAD is created")
 			verifyNADCreated(cr.GetName(), testNetworkNamespace)

--- a/deployment/network-operator/crds/mellanox.com_hostdevicenetworks.yaml
+++ b/deployment/network-operator/crds/mellanox.com_hostdevicenetworks.yaml
@@ -49,6 +49,10 @@ spec:
               ipam:
                 description: IPAM configuration to be used for this network
                 type: string
+              metaPlugins:
+                description: MetaPluginsConfig contains additional CNI plugin configurations
+                  to chain after the host-device plugin.
+                type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource
                 type: string

--- a/deployment/network-operator/crds/mellanox.com_hostdevicenetworks.yaml
+++ b/deployment/network-operator/crds/mellanox.com_hostdevicenetworks.yaml
@@ -50,8 +50,9 @@ spec:
                 description: IPAM configuration to be used for this network
                 type: string
               metaPlugins:
-                description: MetaPluginsConfig contains additional CNI plugin configurations
-                  to chain after the host-device plugin.
+                description: |-
+                  MetaPluginsConfig contains a raw, comma-separated sequence of CNI plugin objects without enclosing
+                  array brackets to chain after the host-device plugin.
                 type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource

--- a/deployment/network-operator/crds/mellanox.com_macvlannetworks.yaml
+++ b/deployment/network-operator/crds/mellanox.com_macvlannetworks.yaml
@@ -54,8 +54,9 @@ spec:
                   route interface
                 type: string
               metaPlugins:
-                description: MetaPluginsConfig contains additional CNI plugin configurations
-                  to chain after the macvlan plugin.
+                description: |-
+                  MetaPluginsConfig contains a raw, comma-separated sequence of CNI plugin objects without enclosing
+                  array brackets to chain after the macvlan plugin.
                 type: string
               mode:
                 description: Mode of interface one of "bridge", "private", "vepa",

--- a/deployment/network-operator/crds/mellanox.com_macvlannetworks.yaml
+++ b/deployment/network-operator/crds/mellanox.com_macvlannetworks.yaml
@@ -53,6 +53,10 @@ spec:
                 description: Name of the host interface to enslave. Defaults to default
                   route interface
                 type: string
+              metaPlugins:
+                description: MetaPluginsConfig contains additional CNI plugin configurations
+                  to chain after the macvlan plugin.
+                type: string
               mode:
                 description: Mode of interface one of "bridge", "private", "vepa",
                   "passthru"

--- a/manifests/state-hostdevice-network/0010-hostdevice-net-cr.yml
+++ b/manifests/state-hostdevice-network/0010-hostdevice-net-cr.yml
@@ -9,6 +9,17 @@ spec:
   config: '{
   "cniVersion":"0.3.1",
   "name":"{{.HostDeviceNetworkName}}",
+{{- if .CrSpec.MetaPluginsConfig }}
+  "plugins": [
+    {
+{{- end }}
   "type":"host-device",
   "ipam":{{or .CrSpec.IPAM "{}"}}
-}'
+}
+{{- if .CrSpec.MetaPluginsConfig }}
+  ,
+  {{.CrSpec.MetaPluginsConfig}}
+  ]
+}
+{{- end }}
+'

--- a/manifests/state-macvlan-network/0010-macvlan-net-cr.yml
+++ b/manifests/state-macvlan-network/0010-macvlan-net-cr.yml
@@ -7,6 +7,10 @@ spec:
   config: '{
   "cniVersion":"0.3.1",
   "name":"{{.NetworkName}}",
+{{- if .MetaPlugins }}
+  "plugins": [
+    {
+{{- end }}
   "type":"macvlan",
 {{- if .Master -}}
   "master": "{{.Master}}",
@@ -18,4 +22,11 @@ spec:
   "mtu" : {{.Mtu}},
 {{- end -}}
   {{.Ipam}}
-}'
+}
+{{- if .MetaPlugins }}
+  ,
+  {{.MetaPlugins}}
+  ]
+}
+{{- end }}
+'

--- a/pkg/state/common_test.go
+++ b/pkg/state/common_test.go
@@ -55,6 +55,20 @@ const (
 	defaultTestImage                    = "myImage"
 	defaultTestVersion                  = "myVersion"
 	defaultTestVersionSha256            = "sha256:1699d23027ea30c9fa"
+	testMetaPluginsConfig               = `{
+  "type": "tuning",
+  "sysctl": {
+    "net.ipv4.conf.all.arp_ignore": "1",
+    "net.ipv4.conf.all.arp_announce": "2",
+    "net.ipv4.conf.all.rp_filter": "0",
+    "net.ipv4.conf.IFNAME.arp_ignore": "1",
+    "net.ipv4.conf.IFNAME.arp_announce": "2",
+    "net.ipv4.conf.IFNAME.rp_filter": "0"
+  }
+},
+{
+  "type": "sbr"
+}`
 )
 
 var testLogger = log.Log.WithName("testLog")
@@ -132,6 +146,15 @@ type nadConfigIPAM struct {
 	PoolName string `json:"range"`
 }
 
+type nadPlugin struct {
+	Type   string            `json:"type"`
+	Master string            `json:"master"`
+	Mode   string            `json:"mode"`
+	MTU    int               `json:"mtu"`
+	IPAM   nadConfigIPAM     `json:"ipam"`
+	Sysctl map[string]string `json:"sysctl"`
+}
+
 type nadConfig struct {
 	CNIVersion string        `json:"cniVersion"`
 	Name       string        `json:"name"`
@@ -140,6 +163,7 @@ type nadConfig struct {
 	Mode       string        `json:"mode"`
 	MTU        int           `json:"mtu"`
 	IPAM       nadConfigIPAM `json:"ipam"`
+	Plugins    []nadPlugin   `json:"plugins"`
 }
 
 func defaultNADConfig(cfg *nadConfig) nadConfig {
@@ -151,6 +175,43 @@ func defaultNADConfig(cfg *nadConfig) nadConfig {
 		Mode:       cfg.Mode,
 		IPAM:       cfg.IPAM,
 		MTU:        cfg.MTU,
+		Plugins:    nil,
+	}
+}
+
+func chainedNADConfig(name string, primaryPlugin *nadPlugin) nadConfig {
+	return nadConfig{
+		CNIVersion: "0.3.1",
+		Name:       name,
+		Type:       "",
+		Master:     "",
+		Mode:       "",
+		MTU:        0,
+		IPAM:       nadConfigIPAM{},
+		Plugins: append([]nadPlugin{*primaryPlugin},
+			nadPlugin{
+				Type:   "tuning",
+				Master: "",
+				Mode:   "",
+				MTU:    0,
+				IPAM:   nadConfigIPAM{},
+				Sysctl: map[string]string{
+					"net.ipv4.conf.all.arp_ignore":      "1",
+					"net.ipv4.conf.all.arp_announce":    "2",
+					"net.ipv4.conf.all.rp_filter":       "0",
+					"net.ipv4.conf.IFNAME.arp_ignore":   "1",
+					"net.ipv4.conf.IFNAME.arp_announce": "2",
+					"net.ipv4.conf.IFNAME.rp_filter":    "0",
+				},
+			},
+			nadPlugin{
+				Type:   "sbr",
+				Master: "",
+				Mode:   "",
+				MTU:    0,
+				IPAM:   nadConfigIPAM{},
+				Sysctl: nil,
+			}),
 	}
 }
 

--- a/pkg/state/state_hostdevice_network_test.go
+++ b/pkg/state/state_hostdevice_network_test.go
@@ -26,10 +26,15 @@ import (
 	"github.com/Mellanox/network-operator/pkg/state"
 )
 
+const (
+	hostDeviceNetworkTestName      = "host-device"
+	hostDeviceNetworkTestNamespace = "hostdevice"
+)
+
 var _ = Describe("HostDevice Network State rendering tests", func() {
 	const (
-		testName      = "host-device"
-		testNamespace = "hostdevice"
+		testName      = hostDeviceNetworkTestName
+		testNamespace = hostDeviceNetworkTestNamespace
 		testType      = "host-device"
 	)
 
@@ -51,7 +56,7 @@ var _ = Describe("HostDevice Network State rendering tests", func() {
 	Context("HostDevice Network State", func() {
 		It("Should Render NetworkAttachmentDefinition", func() {
 			testResourceName := "test"
-			cr := getHostDeviceNetwork(testName, testNamespace, testResourceName)
+			cr := getHostDeviceNetwork(testResourceName)
 			err := ts.client.Create(context.Background(), cr)
 			Expect(err).NotTo(HaveOccurred())
 			status, err := ts.state.Sync(context.Background(), cr, ts.catalog)
@@ -66,7 +71,7 @@ var _ = Describe("HostDevice Network State rendering tests", func() {
 		// The annotations resource name MUST have to prefix anyway.
 		It("Should Render NetworkAttachmentDefinition with resource with prefix", func() {
 			testResourceName := hostDeviceNetworkResourceNamePrefix + testName
-			cr := getHostDeviceNetwork(testName, testNamespace, testResourceName)
+			cr := getHostDeviceNetwork(testResourceName)
 			err := ts.client.Create(context.Background(), cr)
 			Expect(err).NotTo(HaveOccurred())
 			status, err := ts.state.Sync(context.Background(), cr, ts.catalog)
@@ -82,7 +87,7 @@ var _ = Describe("HostDevice Network State rendering tests", func() {
 				PoolName: "my-pool",
 			}
 			testResourceName := "test"
-			cr := getHostDeviceNetwork(testName, testNamespace, testResourceName)
+			cr := getHostDeviceNetwork(testResourceName)
 			cr.Spec.IPAM = getNADConfigIPAMJSON(ipam)
 			err := ts.client.Create(context.Background(), cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -93,16 +98,41 @@ var _ = Describe("HostDevice Network State rendering tests", func() {
 			expectedNadConfig.IPAM = ipam
 			assertNetworkAttachmentDefinition(ts.client, &expectedNadConfig, testName, testNamespace, testResourceName)
 		})
+		It("Should Render NetworkAttachmentDefinition with meta plugins", func() {
+			ipam := nadConfigIPAM{
+				Type:     "nv-ipam",
+				PoolName: "my-pool",
+			}
+			testResourceName := "test"
+			cr := getHostDeviceNetwork(testResourceName)
+			cr.Spec.IPAM = getNADConfigIPAMJSON(ipam)
+			cr.Spec.MetaPluginsConfig = testMetaPluginsConfig
+			err := ts.client.Create(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+			status, err := ts.state.Sync(context.Background(), cr, ts.catalog)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeEquivalentTo(state.SyncStateReady))
+
+			expectedNadConfig = chainedNADConfig(testName, &nadPlugin{
+				Type:   testType,
+				Master: "",
+				Mode:   "",
+				MTU:    0,
+				IPAM:   ipam,
+				Sysctl: nil,
+			})
+			assertNetworkAttachmentDefinition(ts.client, &expectedNadConfig, testName, testNamespace, testResourceName)
+		})
 	})
 })
 
-func getHostDeviceNetwork(testName, testNamespace, resourceName string) *mellanoxv1alpha1.HostDeviceNetwork {
+func getHostDeviceNetwork(resourceName string) *mellanoxv1alpha1.HostDeviceNetwork {
 	cr := &mellanoxv1alpha1.HostDeviceNetwork{
 		Spec: mellanoxv1alpha1.HostDeviceNetworkSpec{
-			NetworkNamespace: testNamespace,
+			NetworkNamespace: hostDeviceNetworkTestNamespace,
 			ResourceName:     resourceName,
 		},
 	}
-	cr.Name = testName
+	cr.Name = hostDeviceNetworkTestName
 	return cr
 }

--- a/pkg/state/state_macvlan_network.go
+++ b/pkg/state/state_macvlan_network.go
@@ -140,6 +140,7 @@ func (s *stateMacvlanNetwork) getManifestObjects(
 	data["Master"] = cr.Spec.Master
 	data["Mode"] = cr.Spec.Mode
 	data["Mtu"] = cr.Spec.Mtu
+	data["MetaPlugins"] = cr.Spec.MetaPluginsConfig
 
 	if cr.Spec.IPAM != "" {
 		data["Ipam"] = "\"ipam\":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")

--- a/pkg/state/state_macvlan_network_test.go
+++ b/pkg/state/state_macvlan_network_test.go
@@ -87,6 +87,30 @@ var _ = Describe("MacVlan Network State rendering tests", func() {
 			expectedNadConfig.IPAM = ipam
 			assertNetworkAttachmentDefinition(ts.client, &expectedNadConfig, testName, testNamespace, "")
 		})
+		It("Should Render NetworkAttachmentDefinition with meta plugins", func() {
+			ipam := nadConfigIPAM{
+				Type:     "nv-ipam",
+				PoolName: "my-pool",
+			}
+			cr := getMacvlanNetwork(testName, testNamespace, testMaster, testBridgeMode, testMtu)
+			cr.Spec.IPAM = getNADConfigIPAMJSON(ipam)
+			cr.Spec.MetaPluginsConfig = testMetaPluginsConfig
+			err := ts.client.Create(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+			status, err := ts.state.Sync(context.Background(), cr, ts.catalog)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeEquivalentTo(state.SyncStateReady))
+
+			expectedNadConfig = chainedNADConfig(testName, &nadPlugin{
+				Type:   testType,
+				Master: testMaster,
+				Mode:   testBridgeMode,
+				MTU:    testMtu,
+				IPAM:   ipam,
+				Sysctl: nil,
+			})
+			assertNetworkAttachmentDefinition(ts.client, &expectedNadConfig, testName, testNamespace, "")
+		})
 		It("Should Render NetworkAttachmentDefinition with default namespace", func() {
 			cr := getMacvlanNetwork(testName, testNamespace, testMaster, testBridgeMode, testMtu)
 			cr.Spec.NetworkNamespace = ""


### PR DESCRIPTION
## What

- add the optional `spec.metaPlugins` field to `MacvlanNetwork` and `HostDeviceNetwork`
- render a CNI configuration list with the primary plugin first, followed by the supplied meta-plugins in their original order
- preserve the existing single-plugin `NetworkAttachmentDefinition` when `metaPlugins` is empty
- regenerate both source and Helm CRDs, and document the new field

## Why

k8s-launch-kit uses one `secondaryNetworkMetaPlugins` helper across non-Spectrum-X secondary-network profiles. SR-IOV profiles already work because the SR-IOV Network Operator accepts `spec.metaPlugins`, but launch-kit also emits the same field for Macvlan RDMA-shared and host-device profiles. Network Operator did not expose that field or build a CNI configuration list, leaving those generated profiles unable to use either feature.

The launch-kit use cases are:

- `profile.routing: source-based` adds the `sbr` CNI plugin so traffic sourced from a rail IP leaves through that rail's interface and gateway.
- `profile.ignoreARP: true` adds the `tuning` CNI plugin before `sbr`, setting `arp_ignore=1`, `arp_announce=2`, and `rp_filter=0` at both `all` and `IFNAME` scopes. This prevents ARP flux between pod rails from advertising one rail's IP through another rail's VF/MAC and steering RoCE traffic to the wrong HCA.

The API and fragment format intentionally match the established SR-IOV Network Operator contract. This is additive and backwards compatible: without `metaPlugins`, rendered NAD configuration is unchanged.

## Testing

- `go build ./...`
- `KUBEBUILDER_ASSETS=<envtest-assets> go test ./... -count=1`
- focused MacvlanNetwork and HostDeviceNetwork state rendering tests with the launch-kit `tuning` + `sbr` fragment
- focused MacvlanNetwork and HostDeviceNetwork controller envtests
- `make lint`
- `make check-manifests`
