### PR TITLE
chore: bump operator-sdk to v1.37.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ $(HELM): | $(TOOLSDIR)
 # operator-sdk is used to generate operator-sdk bundles
 OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download
 OPERATOR_SDK_BIN = operator-sdk
-OPERATOR_SDK_VER = v1.33.0
+OPERATOR_SDK_VER = v1.37.0
 OPERATOR_SDK = $(abspath $(TOOLSDIR)/$(OPERATOR_SDK_BIN)-$(OPERATOR_SDK_VER))
 $(OPERATOR_SDK): | $(TOOLSDIR)
 	$Q echo "Installing $(OPERATOR_SDK_BIN)-$(OPERATOR_SDK_VER) to $(TOOLSDIR)"


### PR DESCRIPTION
Preserve SleepAction in generated OLM CSVs (preStop sleep) so make bundle no longer drops the controller shutdown delay.