### PR TITLE
task: update bundle to v26.7.0-rc.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ $(HELM): | $(TOOLSDIR)
 # operator-sdk is used to generate operator-sdk bundles
 OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download
 OPERATOR_SDK_BIN = operator-sdk
-OPERATOR_SDK_VER = v1.33.0
+OPERATOR_SDK_VER = v1.37.0
 OPERATOR_SDK = $(abspath $(TOOLSDIR)/$(OPERATOR_SDK_BIN)-$(OPERATOR_SDK_VER))
 $(OPERATOR_SDK): | $(TOOLSDIR)
 	$Q echo "Installing $(OPERATOR_SDK_BIN)-$(OPERATOR_SDK_VER) to $(TOOLSDIR)"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=nvidia-network-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,v26.7
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    containerImage: nvcr.io/nvstaging/mellanox/network-operator@sha256:e5de653650d1b498a5e957db45c68ae2cbe489cdaf20d7ab5e8ce49384d7988c
+    containerImage: nvcr.io/nvstaging/mellanox/network-operator@sha256:291861b4a06f45b5e08fa1cd97f6fc691d96a518a7934661665569a5c833c5ec
     alm-examples: |-
       [
         {
@@ -77,13 +77,13 @@ metadata:
                 },
                 "maxParallelUpgrades": 1
               },
-              "version": "doca3.5.0-26.07-0.5.1.0-0"
+              "version": "doca3.5.0-26.07-0.7.1.0-0"
             },
             "rdmaSharedDevicePlugin": {
               "config": "{\n  \"configList\": [\n    {\n      \"resourceName\": \"rdma_shared_device_a\",\n      \"rdmaHcaMax\": 63,\n      \"selectors\": {\n        \"vendors\": [\"15b3\"]\n      }\n    }\n  ]\n}\n",
               "image": "k8s-rdma-shared-dev-plugin",
               "repository": "nvcr.io/nvstaging/mellanox",
-              "version": "sha256:50c9f41b6fba8457260ac37854a86c6f905dc9e7ad7b19d6a70b07578da95379"
+              "version": "sha256:eb8ffd745fafd37d07688dc442b356633bc7d091bd87743bc9e6907bae5396da"
             }
           }
         },
@@ -124,19 +124,19 @@ metadata:
                 },
                 "maxParallelUpgrades": 1
               },
-              "version": "doca3.5.0-26.07-0.5.1.0-0"
+              "version": "doca3.5.0-26.07-0.7.1.0-0"
             },
             "rdmaSharedDevicePlugin": {
               "config": "{\n  \"configList\": [\n    {\n      \"resourceName\": \"rdma_shared_device_a\",\n      \"rdmaHcaMax\": 63,\n      \"selectors\": {\n        \"vendors\": [\"15b3\"]\n      }\n    }\n  ]\n}\n",
               "image": "k8s-rdma-shared-dev-plugin",
               "repository": "nvcr.io/nvstaging/mellanox",
-              "version": "sha256:50c9f41b6fba8457260ac37854a86c6f905dc9e7ad7b19d6a70b07578da95379"
+              "version": "sha256:eb8ffd745fafd37d07688dc442b356633bc7d091bd87743bc9e6907bae5396da"
             }
           }
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-08-02T14:00:54Z"
+    createdAt: "2026-08-18T12:24:08Z"
     description: Deploy and manage NVIDIA networking resources in Kubernetes
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -149,7 +149,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: nvidia-network-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.33.0
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: NVIDIA
     repository: https://github.com/Mellanox/network-operator/
@@ -157,7 +157,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: nvidia-network-operator.v26.7.0-rc.1
+  name: nvidia-network-operator.v26.7.0-rc.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -618,8 +618,8 @@ spec:
                 - name: USE_DTK
                   value: "true"
                 - name: OFED_INIT_CONTAINER_IMAGE
-                  value: nvcr.io/nvstaging/mellanox/network-operator-init-container@sha256:f23ae7023d4f558e9c9f99cc10813c2d39592a5aef02eb18bf26fd6f81107651
-                image: nvcr.io/nvstaging/mellanox/network-operator@sha256:e5de653650d1b498a5e957db45c68ae2cbe489cdaf20d7ab5e8ce49384d7988c
+                  value: nvcr.io/nvstaging/mellanox/network-operator-init-container@sha256:86bad106eb165413a6c856a009f7fd1d4e8566a74eb24b253606e247afb1678a
+                image: nvcr.io/nvstaging/mellanox/network-operator@sha256:291861b4a06f45b5e08fa1cd97f6fc691d96a518a7934661665569a5c833c5ec
                 imagePullPolicy: IfNotPresent
                 lifecycle:
                   preStop:
@@ -731,7 +731,7 @@ spec:
   provider:
     name: NVIDIA
     url: https://github.com/Mellanox/network-operator/
-  version: 26.7.0-rc.1
+  version: 26.7.0-rc.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
@@ -795,50 +795,62 @@ spec:
     webhookPath: /validate-mellanox-com-v1alpha1-nicnodepolicy
   relatedImages:
     - name: nvidia-network-operator
-      image: nvcr.io/nvstaging/mellanox/network-operator@sha256:e5de653650d1b498a5e957db45c68ae2cbe489cdaf20d7ab5e8ce49384d7988c
+      image: nvcr.io/nvstaging/mellanox/network-operator@sha256:291861b4a06f45b5e08fa1cd97f6fc691d96a518a7934661665569a5c833c5ec
     - name: nvidia-network-operator-init-container
-      image: nvcr.io/nvstaging/mellanox/network-operator-init-container@sha256:f23ae7023d4f558e9c9f99cc10813c2d39592a5aef02eb18bf26fd6f81107651
+      image: nvcr.io/nvstaging/mellanox/network-operator-init-container@sha256:86bad106eb165413a6c856a009f7fd1d4e8566a74eb24b253606e247afb1678a
     - name: rdma-shared-device-plugin
-      image: nvcr.io/nvstaging/mellanox/k8s-rdma-shared-dev-plugin@sha256:50c9f41b6fba8457260ac37854a86c6f905dc9e7ad7b19d6a70b07578da95379
+      image: nvcr.io/nvstaging/mellanox/k8s-rdma-shared-dev-plugin@sha256:eb8ffd745fafd37d07688dc442b356633bc7d091bd87743bc9e6907bae5396da
     - name: sriov-network-device-plugin
-      image: nvcr.io/nvstaging/mellanox/sriov-network-device-plugin@sha256:e743f2d53c5fdfff3cc6da27db9651731fd0f59e7fcb06a2144a4990a2e4571a
+      image: nvcr.io/nvstaging/mellanox/sriov-network-device-plugin@sha256:9d6446d5e0ebdac463397bf5e12a6de7d954086eab1c2acc7133ff14ea729592
     - name: ib-kubernetes
-      image: nvcr.io/nvstaging/mellanox/ib-kubernetes@sha256:6ce8f4128f5c3ac4be3ddfac9ab9896661ff3423b24280b6e4242abadf6c905b
+      image: nvcr.io/nvstaging/mellanox/ib-kubernetes@sha256:37a1d0ccfa5c6392d86210904b348519a0032a04853fec07c4d8417436e469bb
     - name: ipoib-cni
-      image: nvcr.io/nvstaging/mellanox/ipoib-cni@sha256:f517f66fd024b6d685b5156fb4042d5cc533dd6dfdcb5525d6aadc2039ad123f
+      image: nvcr.io/nvstaging/mellanox/ipoib-cni@sha256:e2c6ed08264c35ece8100f28662295056c7a22b33f744ac6b597d9a54fb406e5
     - name: nv-ipam
-      image: nvcr.io/nvstaging/mellanox/nvidia-k8s-ipam@sha256:d21beefab87ff51a88543bc0133c7ea5609d3b52ce122e9d6b7a6ee04b05e1bf
+      image: nvcr.io/nvstaging/mellanox/nvidia-k8s-ipam@sha256:a5040ead85992ef2ea84f060dd34e6fb6010fcd89ef56779e2e0fa945b577a74
     - name: nic-feature-discovery
-      image: nvcr.io/nvstaging/mellanox/nic-feature-discovery@sha256:3d9f4f86a1f4d7bc85ed939be727ad0e354bff850f917d874d177caeb4f1b694
+      image: nvcr.io/nvstaging/mellanox/nic-feature-discovery@sha256:ea8d91fcc41f5a4ae9a9ec687b755ebc4c03936552c1fa97a68dc6098159972a
     - name: doca-telemetry-service
       image: nvcr.io/nvidia/doca/doca_telemetry@sha256:e728430bdde27bc0f2e57cedb83814f21d23113385328034af9727e900724d09
     - name: nic-configuration-operator
-      image: nvcr.io/nvstaging/mellanox/nic-configuration-operator@sha256:345616b046a389e352e9c3731977c90afffb7d1940de12f1106f58f41df2e8df
+      image: nvcr.io/nvstaging/mellanox/nic-configuration-operator@sha256:93e4157f7bf4706f0ce224c0280f3bcdd1cf0b22ada1e19e54ea297ec8fc2874
     - name: nic-configuration-operator-daemon
-      image: nvcr.io/nvstaging/mellanox/nic-configuration-operator-daemon@sha256:d0ad73ca054676b3cca3a75ba51890c4a3c282f1cdb056acd61c5575cd000a19
+      image: nvcr.io/nvstaging/mellanox/nic-configuration-operator-daemon@sha256:dc5064800a6d2e2da3b0faeb06859cacf9a94a1b8275e469573eebdcff242cc8
     - name: spectrum-x-operator
-      image: nvcr.io/nvstaging/mellanox/spectrum-x-operator@sha256:9a32c82cfdcc80e2676e59e84405eefb83b6c1dbaad6e5188f18d9a50af016fb
+      image: nvcr.io/nvstaging/mellanox/spectrum-x-operator@sha256:1b52ce04c78645261189a75ced797aac65e9dd9c9389bdb6c52a9f0a9867e637
     - name: doca-driver-0
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:fad0a4590dea38202abdff5e63381f639ca8cdc9815bac57c47930a0fdca3247
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:cb474a37bed06572cd7301d189dec5fabcf2fe80d469ded34679818b497518a7
     - name: doca-driver-1
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:dc48b6c458f7c71bb336e3254c4055f13261803e04f06a5737ccb61d3791bdbd
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:b16352643457df84c3b17d5eed5e683d2241f70209d675a1c75f5f4909fb9db3
     - name: doca-driver-2
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:d18802d915570881bb4cdb4e5dbd177aa7569137c88a7e25a4b2425884504c59
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:f41affa058d8b378fb85560b7763a980c7d0c4cb4f1abeef49f3ef29d8c9e914
     - name: doca-driver-3
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:e6852c8e27766a78f9fc8110ac9a8b72a0517615b14dea2a6c0522f0a435e6ba
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:9e9ada932deb0d2b7b808f27dad9b73bf9a3f1047eea36f4933df512838ab963
     - name: doca-driver-4
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:aed916f68583e916b2f53fac632fdf7dd3f420ca81c5bd818c67f2501c080b6b
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:ca4df3459056a48c36af18776f60a62ff0707652d05deb47db8436f4787fd330
     - name: doca-driver-5
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:c4a97b64fbc49e96b6cac7523b56e281456f8861677ad2dacba79a22620a291f
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:fd94d0574aa2dd4f093bcd43f5969c6f58f4dd8b88de27e64a68705d956f503d
     - name: doca-driver-6
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:dc67e64116d7d5f638c5e3e9040ac1cc672a3007bd6939b64435e5ef93bc1b19
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:5f26c162f04346dfc7d2f5b43130a632ad05d913ec6c0460b71fdec9e7162fbe
     - name: doca-driver-7
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:ead834a62ead0527abe0ab0b17c8435b5d73459e7d7a25673343b80b52ec3428
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:2e7da60e30de92ea45204ab9bfc7f552570f50a3c0dabdd93fa30c1d5a400a9f
     - name: doca-driver-8
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:d4ce188a39f5e0bf17081b3d348652c008f6222459b5fef3160a1f142279af33
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:99d3099c3a034024441b13c83060e3b7b62367266ed2b533a3e47726dce13315
     - name: doca-driver-9
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:886e1a28b9dff739ced73637181cac612491dea5a83ae41e3671cc09eca7cdb3
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:51e1a43852a960e0c53bda834bf775942022c143d57306248d33164e9be09c5f
     - name: doca-driver-10
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:18501736875bb46db04d302f0463b5d8539bedc61bea782046a82057c3f6bfbe
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:634ff585c3516326a91bff40933d25804942f09ee6490b37efffdaa3a78a1a1b
     - name: doca-driver-11
-      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:58eae9f43af4d4931e497d8b70aee91cfad4906e27e2beb5a98b49c450f59f23
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:c8f9c0acacaaf74450c42fb266540b27a9d851785d0c273af960d08dc9938d38
+    - name: doca-driver-12
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:3b592968389d20760357c97af202c7a974e0148782d2cb7732c9820bb8dcce7a
+    - name: doca-driver-13
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:eaa6f123bceb914df14bd1455ab0668464c9f893bd888dff6ae78aacdbdcb0f3
+    - name: doca-driver-14
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:8cf64a1d492c0471cc8096e8eecbef6973b42003bc2923b1bdef8e4a77533daf
+    - name: doca-driver-15
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:aff6f9b855e133c61bfe2738020fe818d9801c1c3000a0a5ba0774988ea37bc3
+    - name: doca-driver-16
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:80714878d9b8058a5b7fb9fa3e256b0667dcda470e224f80a879a212c0f3ab30
+    - name: doca-driver-17
+      image: nvcr.io/nvstaging/mellanox/doca-driver@sha256:ae91d3ad54f3e96aa3f19e2e0a4d37bfdeb17d4ca9ea6d31c6f8cbe012d9b52c

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: nvidia-network-operator
   operators.operatorframework.io.bundle.channels.v1: stable,v26.7
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
Bump operator-sdk to v1.37.0 so generate bundle preserves the controller preStop SleepAction required for MOFED graceful node shutdown.