### PR TITLE
fix: disable leader election for single replica deployment

### DIFF
--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -22,7 +22,7 @@ metadata:
     control-plane: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "network-operator.selectorLabels" . | nindent 6 }}
@@ -83,7 +83,9 @@ spec:
           command:
           - /manager
           args:
+          {{- if gt (int (.Values.operator.replicas | default 1)) 1 }}
           - --leader-elect
+          {{- end }}
           env:
             - name: STATE_MANIFEST_BASE_DIR
               value: "/manifests"


### PR DESCRIPTION
Aligning to the same logic introduced for NFD master in PR #2304, this change avoids unnecessary leader-election overhead. It improves the operator reconciliation process by up to 10 minutes during API downtimes.