### PR TITLE
ci: publish Helm charts and OCP bundles on v*.x branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,12 @@ jobs:
         push=true
         echo "push=$push" | tee -a $GITHUB_OUTPUT
 
-        # determine if chart & bundle shall be published
-        if [[ "$push" == "true" && ("${{ github.ref_type }}" == "tag" || "${{ github.ref_name }}" == "${{ env.DEFAULT_BRANCH }}") ]]; then
+        # determine if chart & bundle shall be published (tags, master, or release branches v*.x)
+        if [[ "$push" == "true" && (
+              "${{ github.ref_type }}" == "tag" ||
+              "${{ github.ref_name }}" == "${{ env.DEFAULT_BRANCH }}" ||
+              "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.x$
+            ) ]]; then
           publish=true
         else
           publish=false
@@ -192,13 +196,22 @@ jobs:
           export DEFAULT_CHANNEL=stable
           export VERSION=${{ env.VERSION_WITHOUT_PREFIX }}
         elif [[ "${{ github.ref_type }}" == "branch" ]]; then
-          export CHANNELS=stable,v1.1  # hard coded
-          export DEFAULT_CHANNEL=stable  # hard coded
-          export VERSION=1.1.0-${{ env.VERSION_WITH_PREFIX }}  # using the commit hash
-          export NETWORK_OPERATOR_VERSION=${{ env.VERSION_WITH_PREFIX }} #  for push use commit sha
+          export DEFAULT_CHANNEL=stable
+          export NETWORK_OPERATOR_VERSION=${{ env.VERSION_WITH_PREFIX }} # for push use commit sha
+          if [[ "${{ github.ref_name }}" == "${{ env.DEFAULT_BRANCH }}" ]]; then
+            export CHANNELS=stable,v1.1  # hard coded for master
+            export VERSION=1.1.0-${{ env.VERSION_WITH_PREFIX }}  # using the commit hash
+          else
+            # release branch vX.Y.x → channels stable,vX.Y and version X.Y.0-<sha>
+            # release.yaml points at production; SHA tags exist only on nvstaging
+            version_major_minor=$(echo "${{ github.ref_name }}" | grep -Eo '^v[0-9]+\.[0-9]+')
+            export CHANNELS=stable,$version_major_minor
+            export VERSION=${version_major_minor:1}.0-${{ env.VERSION_WITH_PREFIX }}
+            export NETWORK_OPERATOR_REPO=${{ env.REGISTRY }}
+          fi
         fi
         make bundle bundle-build bundle-push
-        if [[ "${{ github.ref_type }}" == "branch" ]]; then
+        if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" == "${{ env.DEFAULT_BRANCH }}" ]]; then
           export BUNDLE_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:latest  # hard coded
           make bundle-build bundle-push
         fi


### PR DESCRIPTION
Derive bundle channels/version from the release branch name and keep :latest limited to master.