### PR TITLE
feat: add Go integration coverage image and Helm toggle (#2950)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,12 @@ jobs:
         done
         echo "tags=$tags" | tee -a $GITHUB_OUTPUT
 
+        coverage_tags="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${git_sha}-coverage"
+        if [ -n "$git_tag" ]; then
+          coverage_tags="$coverage_tags,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${git_tag}-coverage"
+        fi
+        echo "coverage_tags=$coverage_tags" | tee -a $GITHUB_OUTPUT
+
         # all events reaching here are trusted:
         # - push to master/v*.x/tags: standard ci
         # - push to pull-request/*: copy-pr-bot is the trust gate; untrusted fork prs
@@ -82,6 +88,18 @@ jobs:
         push: ${{ steps.docker-tags.outputs.push }}
         build-args: |
           GOPROXY=${{ env.GOPROXY }}
+    - uses: docker/build-push-action@v7
+      env:
+        GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url || 'direct' }}
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.docker-tags.outputs.coverage_tags }}
+        push: ${{ steps.docker-tags.outputs.push }}
+        build-args: |
+          GOPROXY=${{ env.GOPROXY }}
+          GO_COVERAGE=1
     outputs:
       default_branch: ${{ env.DEFAULT_BRANCH }}  # we output this here, to use in the following job's conditioning (due to github actions environment variable scope limitations).
       publish: ${{ steps.docker-tags.outputs.publish }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY ./ ./
 ARG LDFLAGS
 ARG GCFLAGS
 ARG GOPROXY
+ARG GO_COVERAGE=0
 ENV GOPROXY=$GOPROXY
 
 # Use TARGETARCH provided by Docker Buildx for cross-compilation
@@ -47,9 +48,15 @@ ARG ARCH=${TARGETARCH}
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o manager main.go  && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o keep-ncp cmd/keep-ncp/main.go && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o apply-crds cmd/apply-crds/main.go
+    if [ "$GO_COVERAGE" = "1" ]; then \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -cover -covermode=atomic -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o manager main.go && \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -cover -covermode=atomic -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o keep-ncp cmd/keep-ncp/main.go && \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -cover -covermode=atomic -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o apply-crds cmd/apply-crds/main.go; \
+    else \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o manager main.go && \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o keep-ncp cmd/keep-ncp/main.go && \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="${LDFLAGS}" -gcflags="${GCFLAGS}" -o apply-crds cmd/apply-crds/main.go; \
+    fi
 
 # copy CRDs from helm charts
 COPY deployment/network-operator/ ./network-operator-chart/

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,19 @@ image: ; $(info Building Docker image...)  @ ## Build container image
 image-push:
 	$(IMAGE_BUILDER) push $(TAG)
 
+.PHONY: image-coverage
+image-coverage: ; $(info Building coverage Docker image...)  @ ## Build container image with Go coverage instrumentation
+	$Q DOCKER_BUILDKIT=1 $(IMAGE_BUILDER) build --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
+		--build-arg VERSION="$(BUILD_VERSION)" \
+		--build-arg VCS_REF="$(VCS_REF)" \
+		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \
+		--build-arg LDFLAGS=$(LDFLAGS) \
+		--build-arg ARCH="$(ARCH)" \
+		--build-arg GCFLAGS="$(GCFLAGS)" \
+		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg GO_COVERAGE=1 \
+		-t $(TAG)-coverage -f $(DOCKERFILE)  $(CURDIR) $(IMAGE_BUILD_OPTS)
+
 # Targets for multi-arch container builds
 # The multi arch build flow first builds containers locally with a suffix in the image tag stating the architecture.
 # Each of these images is then tagged and pushed to the registry as `$(CONTROLLER_IMAGE):$(VERSION)`.

--- a/deployment/network-operator/README.md
+++ b/deployment/network-operator/README.md
@@ -198,6 +198,21 @@ Replace `SVCNAME` with the SVC name follows this convention <Release_Name>-webho
 This command will generate a new RSA key pair with 2048 bits and create a self-signed certificate (`server.crt`) and
 private key (`server.key`) that are valid for 365 days.
 
+#### Deploy Network Operator with Go integration coverage
+
+For integration test coverage collection (e.g. Jinx regression), enable coverage and deploy
+with the immutable instrumented image tag published by CI (`<git-sha>-coverage`):
+
+```bash
+helm install network-operator ./deployment/network-operator \
+  --set operator.coverage.enabled=true \
+  --set operator.tag=<git-sha>-coverage
+```
+
+When enabled, the controller sets `GOCOVERDIR=/coverage`, mounts an `emptyDir` at `/coverage`, and
+sets `COVERAGE_CLEAR_AFTER_FLUSH=1`. Send **SIGUSR1** to the manager process to flush runtime
+coverage counters without restarting the pod. On distroless images, signal the container host PID
+rather than relying on `kubectl exec kill`.
 
 ## Upgrade
 

--- a/deployment/network-operator/templates/operator.yaml
+++ b/deployment/network-operator/templates/operator.yaml
@@ -61,10 +61,18 @@ spec:
           - containerPort: 9443
             name: webhook-server
             protocol: TCP
+          {{- end }}
+          {{- if or .Values.operator.coverage.enabled .Values.operator.admissionController.enabled }}
           volumeMounts:
+          {{- if .Values.operator.coverage.enabled }}
+          - name: go-coverage
+            mountPath: /coverage
+          {{- end }}
+          {{- if .Values.operator.admissionController.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if gt (int (.Values.operator.preStopSleepSeconds | default 0)) 0 }}
           lifecycle:
@@ -85,6 +93,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "network-operator"
+            {{- if .Values.operator.coverage.enabled }}
+            - name: GOCOVERDIR
+              value: "/coverage"
+            - name: COVERAGE_CLEAR_AFTER_FLUSH
+              value: "1"
+            {{- end }}
             - name: ENABLE_WEBHOOKS
               value: "{{ .Values.operator.admissionController.enabled }}"
             - name: USE_DTK
@@ -150,10 +164,16 @@ spec:
       securityContext:
         runAsUser: 65532
       terminationGracePeriodSeconds: {{ .Values.operator.terminationGracePeriodSeconds | default 30 }}
-      {{- if .Values.operator.admissionController.enabled }}
+      {{- if or .Values.operator.coverage.enabled .Values.operator.admissionController.enabled }}
       volumes:
+      {{- if .Values.operator.coverage.enabled }}
+      - name: go-coverage
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.operator.admissionController.enabled }}
       - name: cert
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      {{- end }}
       {{- end }}

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -273,6 +273,9 @@ operator:
   repository: nvcr.io/nvstaging/mellanox
   # -- Network Operator image name
   image: network-operator
+  # -- Enable Go integration coverage collection (GOCOVERDIR, coverage volume, instrumented image tag).
+  coverage:
+    enabled: false
   # imagePullSecrets: []
   # -- Name to be used as part of objects name generation.
   nameOverride: ""

--- a/hack/templates/values/values.template
+++ b/hack/templates/values/values.template
@@ -273,6 +273,9 @@ operator:
   repository: {{ .NetworkOperator.Repository }}
   # -- Network Operator image name
   image: {{ .NetworkOperator.Image }}
+  # -- Enable Go integration coverage collection (GOCOVERDIR, coverage volume, instrumented image tag).
+  coverage:
+    enabled: false
   # imagePullSecrets: []
   # -- Name to be used as part of objects name generation.
   nameOverride: ""

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/Mellanox/network-operator/api/v1alpha1/validator"
 	"github.com/Mellanox/network-operator/controllers"
 	"github.com/Mellanox/network-operator/pkg/clustertype"
+	"github.com/Mellanox/network-operator/pkg/coverage"
 	"github.com/Mellanox/network-operator/pkg/docadriverimages"
 	"github.com/Mellanox/network-operator/pkg/drain"
 	"github.com/Mellanox/network-operator/pkg/migrate"
@@ -176,6 +177,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	coverage.SetupSignalHandler()
 
 	stopCtx := ctrl.SetupSignalHandler()
 

--- a/pkg/coverage/flush.go
+++ b/pkg/coverage/flush.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package coverage supports runtime coverage collection for integration tests.
+package coverage
+
+import (
+	"os"
+	"os/signal"
+	"runtime/coverage"
+	"syscall"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var flushLog = ctrl.Log.WithName("coverage")
+
+// SetupSignalHandler registers SIGUSR1 to flush in-memory coverage counters to
+// GOCOVERDIR. No-op when GOCOVERDIR is unset (normal production images).
+func SetupSignalHandler() {
+	dir, ok := os.LookupEnv("GOCOVERDIR")
+	if !ok {
+		return
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR1)
+	flushLog.Info("coverage flush handler enabled", "dir", dir)
+	go func() {
+		for range c {
+			if err := coverage.WriteCountersDir(dir); err != nil {
+				flushLog.Error(err, "failed to write coverage counters", "dir", dir)
+				continue
+			}
+			flushLog.Info("flushed coverage counters", "dir", dir)
+			if os.Getenv("COVERAGE_CLEAR_AFTER_FLUSH") == "1" {
+				if err := coverage.ClearCounters(); err != nil {
+					flushLog.Error(err, "failed to clear coverage counters after flush")
+				}
+			}
+		}
+	}()
+}

--- a/pkg/coverage/flush_test.go
+++ b/pkg/coverage/flush_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the License governing permissions and limitations.
+*/
+
+package coverage
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSetupSignalHandlerWithoutGOCOVERDIR(t *testing.T) {
+	if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
+		t.Skip("GOCOVERDIR is set in the test environment")
+	}
+	SetupSignalHandler()
+}


### PR DESCRIPTION
Adds an optional Go integration-coverage path for the network-operator controller, intended for Jinx regression and similar E2E coverage workflows. Production behavior is unchanged unless coverage is explicitly enabled.
- CI publishes a second instrumented image (`<sha>-coverage`, plus `coverage` on `master`) alongside the normal image
- Runtime SIGUSR1 handler flushes in-memory counters to `GOCOVERDIR` without restarting the pod
- Helm overlay (`values-go-coverage.yaml`) and `operator.coverage.enabled` toggle wire up env, volume mount, and image selection