### PR TITLE
fix: fail NIC Configuration Operator sync when NodeMaintenance CRD is…

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	consts "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	mellanoxcomv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/api/v1alpha1/validator"
@@ -67,6 +68,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	utilruntime.Must(mellanoxcomv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(netattdefv1.AddToScheme(scheme))

--- a/pkg/state/state_nic_configuration_operator.go
+++ b/pkg/state/state_nic_configuration_operator.go
@@ -23,7 +23,11 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,6 +38,8 @@ import (
 	"github.com/Mellanox/network-operator/pkg/render"
 	"github.com/Mellanox/network-operator/pkg/utils"
 )
+
+const nodeMaintenanceCRDName = "nodemaintenances.maintenance.nvidia.com"
 
 // NewStateNicConfigurationOperator creates a new state for NIC Configuration Operator
 func NewStateNicConfigurationOperator(
@@ -74,6 +80,25 @@ type NicConfigurationOperatorManifestRenderData struct {
 	RuntimeSpec            *nicConfigurationOperatorRuntimeSpec
 }
 
+// isNodeMaintenanceCRDInstalled checks if the NodeMaintenance CRD is installed in the cluster
+func (s *stateNicConfigurationOperator) isNodeMaintenanceCRDInstalled(ctx context.Context) error {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err := s.client.Get(ctx, types.NamespacedName{Name: nodeMaintenanceCRDName}, crd)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return errors.New("NodeMaintenance CRD is not installed")
+		}
+		return errors.Wrap(err, "failed to check NodeMaintenance CRD")
+	}
+	if !crd.DeletionTimestamp.IsZero() {
+		return errors.New("NodeMaintenance CRD is terminating")
+	}
+	if !apihelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+		return errors.New("NodeMaintenance CRD is not established")
+	}
+	return nil
+}
+
 // Sync attempt to get the system to match the desired state which State represent.
 // a sync operation must be relatively short and must not block the execution thread.
 //
@@ -99,6 +124,11 @@ func (s *stateNicConfigurationOperator) Sync(
 	clusterInfo := infoCatalog.GetClusterTypeProvider()
 	if clusterInfo == nil {
 		return SyncStateError, errors.New("unexpected state, catalog does not provide cluster type info")
+	}
+
+	// Check if the NodeMaintenance CRD is installed in the cluster
+	if err := s.isNodeMaintenanceCRDInstalled(ctx); err != nil {
+		return SyncStateNotReady, err
 	}
 
 	// Fill ManifestRenderData and render objects

--- a/pkg/state/state_nic_configuration_operator_test.go
+++ b/pkg/state/state_nic_configuration_operator_test.go
@@ -23,7 +23,9 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -31,12 +33,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/pkg/config"
 	"github.com/Mellanox/network-operator/pkg/state"
-	staticconfig_mocks "github.com/Mellanox/network-operator/pkg/staticconfig/mocks"
-
-	mellanoxv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/Mellanox/network-operator/pkg/staticconfig"
+	staticconfig_mocks "github.com/Mellanox/network-operator/pkg/staticconfig/mocks"
 )
 
 var _ = Describe("NIC Configuration Operator Controller", func() {
@@ -57,7 +58,10 @@ var _ = Describe("NIC Configuration Operator Controller", func() {
 		scheme := runtime.NewScheme()
 		Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(mellanoxv1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
-		client = fake.NewClientBuilder().WithScheme(scheme).Build()
+		Expect(apiextensionsv1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			newNodeMaintenanceCRD(),
+		).Build()
 		manifestDir := "../../manifests/state-nic-configuration-operator"
 		s, r, err := state.NewStateNicConfigurationOperator(client, manifestDir)
 		Expect(err).NotTo(HaveOccurred())
@@ -624,6 +628,42 @@ var _ = Describe("NIC Configuration Operator Controller", func() {
 			Expect(status).To(BeEquivalentTo(state.SyncStateReady))
 		})
 
+		It("should fail if NodeMaintenance CRD is not installed", func() {
+			By("Sync without the NodeMaintenance CRD present")
+			s := newNicConfigurationOperatorState(nil)
+			cr := getMinimalNicClusterPolicyWithNicConfigurationOperator(deploymentName, daemonSetName)
+			status, err := s.Sync(context.Background(), cr, catalog)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("NodeMaintenance CRD is not installed"))
+			Expect(status).To(BeEquivalentTo(state.SyncStateNotReady))
+		})
+
+		It("should fail if NodeMaintenance CRD is not established", func() {
+			By("Sync with a NodeMaintenance CRD that is not Established")
+			crd := newNodeMaintenanceCRD()
+			crd.Status.Conditions = nil
+			s := newNicConfigurationOperatorState(crd)
+			cr := getMinimalNicClusterPolicyWithNicConfigurationOperator(deploymentName, daemonSetName)
+			status, err := s.Sync(context.Background(), cr, catalog)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("NodeMaintenance CRD is not established"))
+			Expect(status).To(BeEquivalentTo(state.SyncStateNotReady))
+		})
+
+		It("should fail if NodeMaintenance CRD is terminating", func() {
+			By("Sync with a terminating NodeMaintenance CRD")
+			crd := newNodeMaintenanceCRD()
+			now := metav1.Now()
+			crd.DeletionTimestamp = &now
+			crd.Finalizers = []string{"foregroundDeletion"}
+			s := newNicConfigurationOperatorState(crd)
+			cr := getMinimalNicClusterPolicyWithNicConfigurationOperator(deploymentName, daemonSetName)
+			status, err := s.Sync(context.Background(), cr, catalog)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("NodeMaintenance CRD is terminating"))
+			Expect(status).To(BeEquivalentTo(state.SyncStateNotReady))
+		})
+
 		It("should fail if static config provider not set in catalog", func() {
 			By("Sync")
 			catalog := state.NewInfoCatalog()
@@ -660,4 +700,35 @@ func getMinimalNicClusterPolicyWithNicConfigurationOperator(
 	}
 	cr.Spec.NicConfigurationOperator = spec
 	return cr
+}
+
+func newNicConfigurationOperatorState(crd *apiextensionsv1.CustomResourceDefinition) state.State {
+	scheme := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(mellanoxv1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(apiextensionsv1.AddToScheme(scheme)).NotTo(HaveOccurred())
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if crd != nil {
+		builder = builder.WithObjects(crd)
+	}
+	s, _, err := state.NewStateNicConfigurationOperator(builder.Build(),
+		"../../manifests/state-nic-configuration-operator")
+	Expect(err).NotTo(HaveOccurred())
+	return s
+}
+
+func newNodeMaintenanceCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nodemaintenances.maintenance.nvidia.com",
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{
+					Type:   apiextensionsv1.Established,
+					Status: apiextensionsv1.ConditionTrue,
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
… missing (#3049)

Require nodemaintenances.maintenance.nvidia.com before deploying so NicClusterPolicy stays NotReady with a clear error instead of installing a broken operator.