### PR TITLE
feat: add MTU support to IPoIBNetwork CRD

### DIFF
--- a/api/v1alpha1/ipoibnetwork_types.go
+++ b/api/v1alpha1/ipoibnetwork_types.go
@@ -31,6 +31,9 @@ type IPoIBNetworkSpec struct {
 	NetworkNamespace string `json:"networkNamespace,omitempty"`
 	// Name of the host interface to enslave. Defaults to default route interface
 	Master string `json:"master,omitempty"`
+	// MTU of interface to the specified value. 0 for master's MTU
+	// +kubebuilder:validation:Minimum=0
+	Mtu int `json:"mtu,omitempty"`
 	// IPAM configuration to be used for this network.
 	IPAM string `json:"ipam,omitempty"`
 }

--- a/bundle/manifests/mellanox.com_ipoibnetworks.yaml
+++ b/bundle/manifests/mellanox.com_ipoibnetworks.yaml
@@ -53,6 +53,11 @@ spec:
                 description: Name of the host interface to enslave. Defaults to default
                   route interface
                 type: string
+              mtu:
+                description: MTU of interface to the specified value. 0 for master's
+                  MTU
+                minimum: 0
+                type: integer
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource
                 type: string

--- a/config/crd/bases/mellanox.com_ipoibnetworks.yaml
+++ b/config/crd/bases/mellanox.com_ipoibnetworks.yaml
@@ -53,6 +53,11 @@ spec:
                 description: Name of the host interface to enslave. Defaults to default
                   route interface
                 type: string
+              mtu:
+                description: MTU of interface to the specified value. 0 for master's
+                  MTU
+                minimum: 0
+                type: integer
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource
                 type: string

--- a/deployment/network-operator/crds/mellanox.com_ipoibnetworks.yaml
+++ b/deployment/network-operator/crds/mellanox.com_ipoibnetworks.yaml
@@ -53,6 +53,11 @@ spec:
                 description: Name of the host interface to enslave. Defaults to default
                   route interface
                 type: string
+              mtu:
+                description: MTU of interface to the specified value. 0 for master's
+                  MTU
+                minimum: 0
+                type: integer
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource
                 type: string

--- a/manifests/state-ipoib-network/0010-ipoib-net-cr.yaml
+++ b/manifests/state-ipoib-network/0010-ipoib-net-cr.yaml
@@ -9,5 +9,8 @@ spec:
   "name":"{{.NetworkName}}",
   "type":"ipoib",
   "master": "{{.Master}}",
+{{- if .Mtu -}}
+  "mtu" : {{.Mtu}},
+{{- end -}}
   {{.Ipam}}
 }'

--- a/pkg/state/state_ipoib_network.go
+++ b/pkg/state/state_ipoib_network.go
@@ -138,6 +138,7 @@ func (s *stateIPoIBNetwork) getManifestObjects(
 	}
 
 	data["Master"] = cr.Spec.Master
+	data["Mtu"] = cr.Spec.Mtu
 
 	if cr.Spec.IPAM != "" {
 		data["Ipam"] = "\"ipam\":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")

--- a/pkg/state/state_ipoib_network_test.go
+++ b/pkg/state/state_ipoib_network_test.go
@@ -36,6 +36,7 @@ var _ = Describe("IPoIBNetwork Network state rendering tests", func() {
 		testNamespace = "ipoib"
 		testType      = "ipoib"
 		testMaster    = "eth0"
+		testMtu       = 1496
 	)
 
 	var (
@@ -80,6 +81,19 @@ var _ = Describe("IPoIBNetwork Network state rendering tests", func() {
 			Expect(status).To(BeEquivalentTo(state.SyncStateReady))
 
 			expectedNadConfig.IPAM = ipam
+			assertNetworkAttachmentDefinition(ts.client, &expectedNadConfig, testName, testNamespace, "")
+		})
+		It("Should Render NetworkAttachmentDefinition with MTU", func() {
+			cr := getIPoIBNetwork(testName, testNamespace, testMaster)
+			cr.Spec.Mtu = testMtu
+			err := ts.client.Create(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+			status, err := ts.state.Sync(context.Background(), cr, ts.catalog)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeEquivalentTo(state.SyncStateReady))
+
+			expectedNadConfig.IPAM = nadConfigIPAM{}
+			expectedNadConfig.MTU = testMtu
 			assertNetworkAttachmentDefinition(ts.client, &expectedNadConfig, testName, testNamespace, "")
 		})
 		It("Should Render NetworkAttachmentDefinition with default namespace", func() {


### PR DESCRIPTION
Adds MTU support to the IPoIBNetwork CRD, allowing the per-pod IPoIB interface MTU to be set explicitly.

Adds an optional `mtu` field to `IPoIBNetworkSpec`. When set, it is rendered into the `ipoib` CNI config of the generated NetworkAttachmentDefinition. A value of `0` (default) omits the field, so the fabric MTU set by the Subnet Manager is used.

Requires the MTU support merged in ipoib-cni: https://github.com/Mellanox/ipoib-cni/pull/132

Closes #1664
