### PR TITLE
ci: OCP bundle from release-nvstaging.yaml on GA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,6 +213,11 @@ jobs:
           export CHANNELS=stable,$version_major_minor
           export DEFAULT_CHANNEL=stable
           export VERSION=${{ env.VERSION_WITHOUT_PREFIX }}
+          # GA tags: release.yaml points at production, which is empty until NGC
+          # promotion. Resolve related-image SHAs from nvstaging instead.
+          if [[ "$VERSION_WITH_PREFIX" != *-* ]]; then
+            export RELEASE_DEFAULTS=release-nvstaging.yaml
+          fi
         elif [[ "${{ github.ref_type }}" == "branch" ]]; then
           export DEFAULT_CHANNEL=stable
           export NETWORK_OPERATOR_VERSION=${{ env.VERSION_WITH_PREFIX }} # for push use commit sha

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ CONTROLLER_IMAGE=$(REGISTRY)/$(IMAGE_NAME)
 IMAGE_BUILD_OPTS?=
 BUNDLE_IMG?=network-operator-bundle:$(VERSION)
 BUNDLE_OCP_VERSIONS?=v4.17-v4.20
+# release.yaml (production) or release-nvstaging.yaml (pre-GA; images not yet public)
+RELEASE_DEFAULTS ?= release.yaml
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 BUILD_ARCH= amd64 arm64
@@ -427,13 +429,13 @@ generate: $(CONTROLLER_GEN) ## Generate code
 
 .PHONY: bundle
 bundle: $(OPERATOR_SDK) $(KUSTOMIZE) manifests ## Generate bundle manifests and metadata, then validate generated files.
-	cd hack && $(GO) run release.go --with-sha256 --templateDir ./templates/config/manager --outputDir ../config/manager/
-	cd hack && $(GO) run release.go --with-sha256 --templateDir ./templates/samples/ --outputDir ../config/samples/
+	cd hack && $(GO) run release.go --with-sha256 --releaseDefaults $(RELEASE_DEFAULTS) --templateDir ./templates/config/manager --outputDir ../config/manager/
+	cd hack && $(GO) run release.go --with-sha256 --releaseDefaults $(RELEASE_DEFAULTS) --templateDir ./templates/samples/ --outputDir ../config/samples/
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(TAG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	git checkout -- config/manager/kustomization.yaml
-	GO=$(GO) BUNDLE_OCP_VERSIONS=$(BUNDLE_OCP_VERSIONS) TAG=$(TAG) hack/scripts/ocp-bundle-postprocess.sh
+	GO=$(GO) BUNDLE_OCP_VERSIONS=$(BUNDLE_OCP_VERSIONS) TAG=$(TAG) RELEASE_DEFAULTS=$(RELEASE_DEFAULTS) hack/scripts/ocp-bundle-postprocess.sh
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/hack/scripts/ocp-bundle-postprocess.sh
+++ b/hack/scripts/ocp-bundle-postprocess.sh
@@ -24,7 +24,7 @@ fi
 
 # Generate relatedImages
 cd hack
-if ! $GO run release.go --with-sha256 --templateDir ./templates/related-images/ --outputDir .; then
+if ! $GO run release.go --with-sha256 --releaseDefaults "${RELEASE_DEFAULTS:-release.yaml}" --templateDir ./templates/related-images/ --outputDir .; then
     echo "release.go code execution failed"
     exit 1
 fi


### PR DESCRIPTION
Public registry images are not published until NGC promotion, so SHA lookup against hack/release.yaml fails. Use nvstaging for related-image resolution instead.

cherry-pick from d3cfb8911b3155fe4c281545e0136e6afbeff2f9