### PR TITLE
fix: do not cache Pods in the manager client

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,6 +192,18 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "12620820.mellanox.com",
+		// No controller watches Pods; they are only listed by label to find which
+		// nodes still run an OFED or nic-configuration daemon pod. A List through
+		// the cached client would lazily start a cluster-wide Pod informer and
+		// apply the label selector client-side, caching every Pod in the cluster
+		// so the operator's memory scales with total Pod count rather than with
+		// the handful of pods it cares about. Uncached, the selector is applied
+		// server-side and only the matching pods are transferred.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Pod{}},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Fixes: #3173

## Problem

The manager is built with no `Cache` option, and the reconcilers use
`mgr.GetClient()`. So the label-filtered Pod `List` in
`handleWaitLabelsNoConfig` lazily starts a cluster-wide Pod informer and applies
the selector client-side, caching every Pod in the cluster with full spec and
status.

No controller in `controllers/` ever watches Pods; there is no
`Owns(&corev1.Pod{})` or `Watches(&corev1.Pod{}, ...)`. The informer therefore
exists only to answer which nodes still run an OFED or nic-configuration daemon
pod, a question about a handful of pods.

The consequence is that the controller's memory scales with total cluster Pod
count rather than with its own working set, and terminal pods count. They are
not collected until kube-controller-manager's `--terminated-pod-gc-threshold`
(default 12500), so any repeating node-level admission failure quietly builds
thousands of Pod objects while a controller retries.

We hit this on a 9-node GPU cluster. A GPU that needed a reset made the device
plugin's `GetPreferredAllocation` fail while it still advertised the full GPU
count, so the scheduler kept placing pods, kubelet admission kept failing, and
a ReplicaSet kept recreating: 9,684 `Failed` pods on one node at roughly
2,160/hour. The network-operator was OOMKilled repeatedly as a result, first
against 256Mi and again after raising the limit to 512Mi, even though its own
working set is around 12 MiB.

Two triggers we can name, both on stock configuration:

1. Device plugin allocation failure, as above.
2. Strict Topology Manager. With `topologyManagerPolicy: restricted` or
   `single-numa-node` and `topologyManagerScope: pod`, a pod whose resources
   cannot be NUMA-aligned is rejected with `TopologyAffinityError` and left in
   `Failed`. A controller retrying against that node produces the same pile.
   That is a normal configuration for pinned GPU workloads.

In both cases the operator is collateral rather than the fault, which sends
whoever is on call in the wrong direction.

## Change

Disable the cache for `corev1.Pod` on the manager's client. This is the idiom
already used in this file for the drain client:

```go
// we need a client that doesn't use the local cache for the objects
drainKClient, err := client.New(restConfig, client.Options{
    Scheme: scheme,
    Cache: &client.CacheOptions{
        DisableFor: []client.Object{
            &sriovnetworkv1.SriovNetworkNodeState{},
            &corev1.Node{},
            &mcfgv1.MachineConfigPool{},
        },
    },
})
```

Setting it on `ctrl.Options.Client` covers every controller using
`mgr.GetClient()` in one place rather than touching the individual `List` call
sites (`nicclusterpolicy_controller.go`, `mofed_wait_labels.go`,
`nicnodepolicy_controller.go`, `upgrade_controller.go`, `pkg/migrate`).
Uncached, the label selector is applied server-side, so only the matching pods
are transferred and the informer is never started.

I also considered restricting the cache with `cache.Options.ByObject` for
`&corev1.Pod{}`, which is arguably more idiomatic. It does not fit here: the
code needs pods matching `OfedDriverLabel` **or** `NicConfigurationDaemonLabel`,
and `ByObject.Label` accepts a single selector, which cannot express that
disjunction.

## Measurement

Same cluster, same workload, only the image changed. The load was 500 Pod
objects with a nonexistent `spec.schedulerName`, so they stayed `Pending` as
pure API objects with no scheduler, kubelet or node involvement, each padded to
a realistic serialized size.

| arm | cluster pods | live heap | RSS | goroutines |
| --- | --- | --- | --- | --- |
| before, no pile | 323 | 21.9 MiB | 58.0 MiB | 259 |
| before, +500 | 825 | 40.6 MiB | 73.9 MiB | 259 |
| after, +500 | 824 | 13.3 MiB | 51.9 MiB | 248 |
| after, no pile | 325 | 12.8 MiB | 51.9 MiB | 248 |

38.1 KiB per Pod before, roughly 1 KiB after. After the change the controller at
824 pods sits below its own previous footprint at 323, because it no longer
holds any Pods. The 11 fewer goroutines are the Pod informer and its watch
machinery no longer running.

Live heap is `next_gc / 2` rather than `heap_alloc`: with `GOGC=100` the runtime
targets twice the live heap at the last GC, so that ratio isolates reachable
memory, whereas `heap_alloc` also counts unswept garbage and cannot distinguish
a leak from GC headroom.

## Verification

- `go build ./...`, `go vet ./...` and `gofmt -l` clean.
- Ran the built image on the affected cluster: `NicClusterPolicy` stayed `ready`
  with `MultusCNIReady`, `CNIPluginsReady`, `NVIPAMReady` and the aggregate
  `Ready=AllComponentsReady` all true.
- The `network.nvidia.com/operator.mofed.wait` node labels were identical to
  before: `false` on the five Mellanox-NIC nodes, absent on the other four. So
  the uncached List does not change behaviour.
- The NicClusterPolicy under test carries no `ofedDriver` (host OFED via the
  node image), which is the path that reaches `handleWaitLabelsNoConfig`.
