### PR TITLE
fix: collect complete sosreport context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -665,9 +665,11 @@ jobs:
           yq -i         '.Mofed.repository = "${{ env.DOCKER_REGISTRY_MANAGED_COMPONENTS }}"' hack/release.yaml
           yq -i '.MofedStigFips.repository = "${{ env.DOCKER_REGISTRY_MANAGED_COMPONENTS }}"' hack/release.yaml
 
-          # Update chart versions
+          # Update chart and SOS-report collector versions
           yq -i '.version = "${{ env.CHART_VERSION }}"'  deployment/network-operator/Chart.yaml
           yq -i '.appVersion = "${{ env.APP_VERSION }}"' deployment/network-operator/Chart.yaml
+          sed -i -e "s/^SCRIPT_VERSION=.*/SCRIPT_VERSION=\"${APP_VERSION}\"/" \
+            scripts/sosreport/kubectl-netop_sosreport
           make release-build
           make generate-sosreport-maps
 

--- a/scripts/releases/prepare-release.sh
+++ b/scripts/releases/prepare-release.sh
@@ -101,6 +101,8 @@ chart=`echo $release | cut -c 2-`
 sed -e s"/appVersion:.*/appVersion: $release/" \
     -e s"/^version:.*/version: $chart/" \
     -i deployment/network-operator/Chart.yaml
+sed -e s"/SCRIPT_VERSION=.*/SCRIPT_VERSION=\"$release\"/" \
+    -i scripts/sosreport/kubectl-netop_sosreport
 sed -e s"/pullPolicy:.*/pullPolicy: IfNotPresent/" \
     -i deployment/network-operator/values.yaml
 
@@ -132,4 +134,3 @@ cat << EOF
 ***
 *******************************************************************************
 EOF
-

--- a/scripts/sosreport/README.md
+++ b/scripts/sosreport/README.md
@@ -40,8 +40,8 @@ kubectl netop-sosreport --help
 ### Features
 
 - **Automatic Detection**: Auto-detects the Network Operator namespace
-- **Comprehensive Collection**: Gathers CRDs, workloads, logs, and diagnostic data from every known component
-- **Helm Release Discovery**: Finds chart and sub-chart workloads by release label so optional or newly added components are not omitted
+- **Comprehensive Collection**: Gathers CRDs, workloads, logs, and diagnostic data from every pod in the Network Operator namespace
+- **Helm Release Discovery**: Records release/chart/app versions, revision metadata, and parent/sub-chart workloads
 - **Graceful Error Handling**: Continues collection even if some resources fail
 - **Capability-Aware Diagnostics**: Records unavailable optional tools as skipped instead of collection failures
 - **All Container Logs**: Collects current and previous logs from regular, init, and ephemeral containers
@@ -92,7 +92,7 @@ python3 generate-report.py ./network-operator-sosreport-20260218-143000/ --templ
 - Node maintenance objects (if present)
 
 #### Operator Resources
-- Deployment, Pods, ConfigMaps, Secrets (metadata only)
+- Deployment, every Pod in the operator namespace, ConfigMaps, Secrets (metadata only)
 - RBAC resources (ServiceAccounts, Roles, RoleBindings)
 - Events in operator namespace
 - Webhook configurations
@@ -115,11 +115,15 @@ python3 generate-report.py ./network-operator-sosreport-20260218-143000/ --templ
   device plugin, metrics exporter, and DRA driver (when deployed by Network Operator)
 - Maintenance Operator (when deployed by Network Operator)
 
-The collector also discovers every workload carrying the Network Operator Helm
-release's `app.kubernetes.io/instance` label. This release-scoped fallback
-captures optional and future parent-chart or sub-chart components without
-collecting unrelated pods when the operator shares a namespace. A complete
-release inventory is stored under `operator/helm-release/`, including
+The collector discovers every workload carrying the Network Operator Helm
+release's `app.kubernetes.io/instance` label, then sweeps every remaining pod
+in the operator namespace. The namespace sweep captures workloads with missing,
+custom, or changed labels, including config daemons, while preserving the
+component-oriented report layout. Dynamically discovered component directories
+use `<workload-kind>-<workload-name>` so same-named resources of different kinds
+remain separate. A complete release inventory is stored under
+`operator/helm-release/`, including the release name, chart and app versions,
+Helm revision metadata (without Secret payloads), optional Helm CLI metadata,
 Deployments, DaemonSets, StatefulSets, ReplicaSets, Jobs, CronJobs,
 PodDisruptionBudgets, and NetworkPolicies that are present during collection.
 
@@ -226,7 +230,7 @@ The script creates a timestamped archive with the following structure:
 ```
 network-operator-sosreport-<timestamp>/
 ├── metadata/
-│   ├── collection-info.txt           # Script version, collection time, cluster info
+│   ├── collection-info.txt           # Collector/operator versions, collection time, cluster info
 │   ├── cluster-version.yaml          # Kubernetes/OpenShift version
 │   ├── namespaces.txt                # List of all namespaces
 │   └── api-resources.txt             # Available API resources
@@ -241,13 +245,18 @@ network-operator-sosreport-<timestamp>/
 │       └── ...
 ├── operator/
 │   ├── namespace.yaml                # Operator namespace details
+│   ├── pods.yaml                     # Namespace-wide pod inventory
 │   ├── configmaps.yaml               # ConfigMaps in operator namespace
 │   ├── secrets-metadata.txt          # Secret names only (no data)
 │   ├── rbac/                         # Roles, RoleBindings, etc.
 │   ├── events.yaml                   # Namespace events
 │   ├── validatingwebhookconfigurations.yaml
 │   ├── mutatingwebhookconfigurations.yaml
-│   ├── helm-release/                 # Complete parent/sub-chart resource inventory
+│   ├── helm-release/                 # Helm release/chart metadata and resource inventory
+│   │   ├── chart-info.txt            # Release, chart, and app versions
+│   │   ├── revisions.txt             # Helm Secret metadata only (no payloads)
+│   │   ├── helm-list.yaml            # Optional Helm CLI release listing
+│   │   ├── helm-metadata.yaml        # Optional detailed chart metadata
 │   │   ├── workloads/                # Deployments, DaemonSets, Jobs, etc.
 │   │   ├── poddisruptionbudgets.yaml
 │   │   └── networkpolicies.yaml
@@ -268,7 +277,7 @@ network-operator-sosreport-<timestamp>/
 │       ├── sriov-device-plugin/
 │       ├── nv-ipam-node/
 │       ├── nv-ipam-controller/
-│       └── ...                       # Known and Helm-discovered components
+│       └── ...                       # Known, Helm-discovered, and namespace-discovered components
 ├── nodes/
 │   ├── all-nodes.yaml                # All nodes with full details
 │   ├── nodes-summary.txt             # Node summary table

--- a/scripts/sosreport/generate-report.py
+++ b/scripts/sosreport/generate-report.py
@@ -190,7 +190,10 @@ def render_dashboard(report_dir):
 
     # Extract metadata
     collection_time = ""
-    script_version = ""
+    collector_version = ""
+    operator_version = ""
+    helm_release = ""
+    helm_chart = ""
     operator_ns = ""
     platform = ""
     cluster_context = ""
@@ -201,9 +204,22 @@ def render_dashboard(report_dir):
         m = re.search(r"Collection Time:\s*(.*)", info_content, re.IGNORECASE)
         if m:
             collection_time = m.group(1).strip()
-        m = re.search(r"Script Version:\s*(.*)", info_content, re.IGNORECASE)
+        m = re.search(r"Collector Version:\s*(.*)", info_content, re.IGNORECASE)
+        if not m:
+            # Backward compatibility for reports generated before the
+            # collector/operator versions were distinguished.
+            m = re.search(r"Script Version:\s*(.*)", info_content, re.IGNORECASE)
         if m:
-            script_version = m.group(1).strip()
+            collector_version = m.group(1).strip()
+        m = re.search(r"Network Operator Version:\s*(.*)", info_content, re.IGNORECASE)
+        if m:
+            operator_version = m.group(1).strip()
+        m = re.search(r"Helm Release:\s*(.*)", info_content, re.IGNORECASE)
+        if m:
+            helm_release = m.group(1).strip()
+        m = re.search(r"Helm Chart:\s*(.*)", info_content, re.IGNORECASE)
+        if m:
+            helm_chart = m.group(1).strip()
         m = re.search(r"Operator Namespace:\s*(.*)", info_content, re.IGNORECASE)
         if m:
             operator_ns = m.group(1).strip()
@@ -286,8 +302,14 @@ def render_dashboard(report_dir):
     meta_parts = []
     if collection_time:
         meta_parts.append(f"Collected: {html.escape(collection_time)}")
-    if script_version:
-        meta_parts.append(f"Version: {html.escape(script_version)}")
+    if operator_version:
+        meta_parts.append(f"Operator: {html.escape(operator_version)}")
+    if collector_version:
+        meta_parts.append(f"Collector: {html.escape(collector_version)}")
+    if helm_release:
+        meta_parts.append(f"Helm release: {html.escape(helm_release)}")
+    if helm_chart:
+        meta_parts.append(f"Chart: {html.escape(helm_chart)}")
     if operator_ns:
         meta_parts.append(f"Namespace: {html.escape(operator_ns)}")
     if platform:

--- a/scripts/sosreport/kubectl-netop_sosreport
+++ b/scripts/sosreport/kubectl-netop_sosreport
@@ -25,8 +25,9 @@
 
 set -o pipefail
 
-# Script version
-SCRIPT_VERSION="v26.1.0"
+# Collector version. scripts/releases/prepare-release.sh keeps this aligned
+# with the Network Operator chart appVersion for each release.
+SCRIPT_VERSION="v26.7.0-rc.1"
 
 # Default values
 KUBECONFIG_PATH=""
@@ -37,17 +38,23 @@ LOG_LINES=5000
 SKIP_DIAGNOSTICS=false
 SKIP_REPORT=false
 KUBECTL_BIN="kubectl"
+HELM_BIN="${HELM_BIN:-helm}"
 VERBOSE=false
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 ERROR_LOG=""
 NODE_SELECTOR=""
 HELM_RELEASE_SELECTOR=""
+HELM_RELEASE_NAME=""
+HELM_CHART=""
+HELM_APP_VERSION=""
+HELM_MANAGED_BY=""
+NETWORK_OPERATOR_VERSION=""
 HELM_RELEASE_DISCOVERED=false
+HELM_RELEASE_INFO_COLLECTED=false
 RESOLVED_COMPONENT_SELECTOR=""
 
-# Track pods and dynamically discovered components so the Helm release
-# catch-all does not duplicate artifacts already collected by a known
-# component selector.
+# Track pods and dynamically discovered components so the Helm and namespace
+# catch-alls do not duplicate artifacts already collected by a known selector.
 declare -A COLLECTED_PODS=()
 declare -A DISCOVERED_COMPONENTS=()
 
@@ -77,7 +84,7 @@ NC='\033[0m' # No Color
 # Usage information
 usage() {
     cat <<EOF
-NVIDIA Network Operator SOS-Report Collection Script v${SCRIPT_VERSION}
+NVIDIA Network Operator SOS-Report Collector ${SCRIPT_VERSION}
 
 Collects comprehensive diagnostic data from a Kubernetes cluster running
 the NVIDIA Network Operator for troubleshooting purposes.
@@ -190,7 +197,7 @@ parse_args() {
                 shift
                 ;;
             --version)
-                echo "NVIDIA Network Operator SOS-Report v${SCRIPT_VERSION}"
+                echo "NVIDIA Network Operator SOS-Report Collector ${SCRIPT_VERSION}"
                 exit 0
                 ;;
             --help|-h)
@@ -384,12 +391,17 @@ collect_metadata() {
 
     local metadata_dir="$OUTPUT_DIR/metadata"
     mkdir -p "$metadata_dir"
+    detect_network_operator_version
+    detect_helm_release_selector
 
     # Collection info
     cat > "$metadata_dir/collection-info.txt" <<EOF
 NVIDIA Network Operator SOS-Report
 ====================================
-Script Version: $SCRIPT_VERSION
+Collector Version: $SCRIPT_VERSION
+Network Operator Version: ${NETWORK_OPERATOR_VERSION:-unknown}
+Helm Release: ${HELM_RELEASE_NAME:-unknown}
+Helm Chart: ${HELM_CHART:-unknown}
 Collection Time: $(date)
 Collection Hostname: $(hostname)
 Kubeconfig: $KUBECONFIG
@@ -714,6 +726,48 @@ collect_pods_and_logs() {
     done
 }
 
+# Discover the deployed Network Operator version from the Deployment label,
+# with its image tag as a fallback for non-Helm installations.
+detect_network_operator_version() {
+    if [ -n "$NETWORK_OPERATOR_VERSION" ]; then
+        return 0
+    fi
+
+    local deployment_metadata
+    deployment_metadata=$("$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" \
+        -l app.kubernetes.io/name=network-operator \
+        -o jsonpath='{.items[0].metadata.labels.app\.kubernetes\.io/version}{"|"}{.items[0].spec.template.spec.containers[0].image}' 2>/dev/null)
+
+    # OLM and raw-manifest installations may use different labels. Fall back
+    # to the deployment name already accepted by namespace auto-detection.
+    if [ -z "$deployment_metadata" ] || [ "$deployment_metadata" = "|" ]; then
+        deployment_metadata=$("$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.labels.app\.kubernetes\.io/version}{"|"}{.spec.template.spec.containers[0].image}{"\n"}{end}' 2>/dev/null \
+            | awk -F'|' 'tolower($1) ~ /network-operator/ { print $2 "|" $3; exit }')
+    fi
+
+    local deployment_version
+    local image_reference
+    IFS='|' read -r deployment_version image_reference <<< "$deployment_metadata"
+    if [ -n "$deployment_version" ]; then
+        NETWORK_OPERATOR_VERSION="$deployment_version"
+    elif [ -n "$image_reference" ]; then
+        case "$image_reference" in
+            *@*)
+                NETWORK_OPERATOR_VERSION="${image_reference##*@}"
+                ;;
+            *)
+                local image_name="${image_reference##*/}"
+                if [[ "$image_name" == *:* ]]; then
+                    NETWORK_OPERATOR_VERSION="${image_name##*:}"
+                else
+                    NETWORK_OPERATOR_VERSION="latest"
+                fi
+                ;;
+        esac
+    fi
+}
+
 # Discover the Helm release that owns the Network Operator deployment. Parent
 # and sub-chart workloads all inherit app.kubernetes.io/instance, which gives
 # the collector a future-proof catch-all without collecting unrelated pods in
@@ -744,10 +798,86 @@ detect_helm_release_selector() {
     fi
 
     if [ -n "$release_name" ]; then
+        HELM_RELEASE_NAME="$release_name"
         HELM_RELEASE_SELECTOR="app.kubernetes.io/instance=$release_name"
+
+        local chart_metadata
+        chart_metadata=$("$KUBECTL_BIN" get deployments -n "$OPERATOR_NAMESPACE" \
+            -l "$HELM_RELEASE_SELECTOR" \
+            -o jsonpath='{range .items[*]}{.metadata.labels.helm\.sh/chart}{"|"}{.metadata.labels.app\.kubernetes\.io/version}{"|"}{.metadata.labels.app\.kubernetes\.io/managed-by}{"\n"}{end}' 2>/dev/null \
+            | awk -F'|' '$1 ~ /^network-operator-/ { print; exit }')
+        if [ -n "$chart_metadata" ]; then
+            IFS='|' read -r HELM_CHART HELM_APP_VERSION HELM_MANAGED_BY <<< "$chart_metadata"
+            if [ -z "$NETWORK_OPERATOR_VERSION" ]; then
+                NETWORK_OPERATOR_VERSION="$HELM_APP_VERSION"
+            fi
+        fi
+
         log_info "Detected Network Operator Helm release: $release_name"
     else
         log_info "Network Operator Helm release label not found"
+    fi
+}
+
+# Collect non-secret Helm release and chart metadata. Kubernetes-derived
+# metadata is always attempted; the Helm CLI adds its release listing when it
+# is available without becoming a collector prerequisite.
+collect_helm_release_info() {
+    if [ "$HELM_RELEASE_INFO_COLLECTED" = true ]; then
+        return 0
+    fi
+
+    detect_helm_release_selector
+    if [ -z "$HELM_RELEASE_NAME" ]; then
+        return 0
+    fi
+    HELM_RELEASE_INFO_COLLECTED=true
+
+    local release_dir="$OUTPUT_DIR/operator/helm-release"
+    mkdir -p "$release_dir"
+
+    {
+        echo "Network Operator Helm Release"
+        echo "============================="
+        echo "Release Name: $HELM_RELEASE_NAME"
+        echo "Namespace: $OPERATOR_NAMESPACE"
+        echo "Chart: ${HELM_CHART:-unknown}"
+        echo "App Version: ${HELM_APP_VERSION:-unknown}"
+        echo "Managed By: ${HELM_MANAGED_BY:-unknown}"
+    } > "$release_dir/chart-info.txt"
+
+    # Helm release Secrets contain the full encoded release payload. Record
+    # only their metadata so credentials or other values are never archived.
+    local release_secrets="$release_dir/revisions.txt"
+    if ! "$KUBECTL_BIN" get secrets -n "$OPERATOR_NAMESPACE" \
+        -l "owner=helm,name=$HELM_RELEASE_NAME" \
+        -o 'custom-columns=SECRET:.metadata.name,STATUS:.metadata.labels.status,REVISION:.metadata.labels.version,CREATED:.metadata.creationTimestamp' \
+        > "$release_secrets" 2>> "$ERROR_LOG"; then
+        rm -f "$release_secrets"
+    fi
+
+    if command -v "$HELM_BIN" &> /dev/null; then
+        local helm_listing="$release_dir/helm-list.yaml"
+        if ! "$HELM_BIN" list --namespace "$OPERATOR_NAMESPACE" --all \
+            --filter "^${HELM_RELEASE_NAME}$" --output yaml \
+            > "$helm_listing" 2>> "$ERROR_LOG"; then
+            rm -f "$helm_listing"
+            log_warn "Failed to collect Helm CLI metadata for release $HELM_RELEASE_NAME"
+        fi
+
+        # helm get metadata is not available in every Helm 3 release. Use it
+        # when supported; helm-list.yaml and chart-info.txt remain the fallback.
+        if "$HELM_BIN" get metadata --help &> /dev/null; then
+            local helm_metadata="$release_dir/helm-metadata.yaml"
+            if ! "$HELM_BIN" get metadata "$HELM_RELEASE_NAME" \
+                --namespace "$OPERATOR_NAMESPACE" --output yaml \
+                > "$helm_metadata" 2>> "$ERROR_LOG"; then
+                rm -f "$helm_metadata"
+                log_warn "Failed to collect detailed Helm metadata for release $HELM_RELEASE_NAME"
+            fi
+        fi
+    else
+        log_info "Helm CLI not found; Kubernetes-derived chart metadata was collected"
     fi
 }
 
@@ -794,6 +924,7 @@ collect_helm_release_components() {
         return 0
     fi
 
+    collect_helm_release_info
     log_info "Collecting complete Helm release workload inventory..."
     local release_dir="$OUTPUT_DIR/operator/helm-release"
     local resource_type
@@ -822,9 +953,10 @@ collect_helm_release_components() {
         workload=$(resolve_pod_workload "$OPERATOR_NAMESPACE" "$pod")
         IFS='|' read -r workload_type workload_name <<< "$workload"
 
-        local component_dir="$OUTPUT_DIR/operator/components/$workload_name"
+        local component_id="${workload_type}-${workload_name}"
+        local component_dir="$OUTPUT_DIR/operator/components/$component_id"
         if [ -z "${DISCOVERED_COMPONENTS[$component_dir]:-}" ]; then
-            log_info "  Discovered Helm component: $workload_name ($workload_type)"
+            log_info "  Discovered Helm component: $component_id"
             DISCOVERED_COMPONENTS["$component_dir"]="true"
             STATS[components_found]=$((STATS[components_found] + 1))
 
@@ -834,6 +966,59 @@ collect_helm_release_components() {
 
         collect_pods_and_logs "$OPERATOR_NAMESPACE" "$component_dir/pods" "$pod"
     done
+}
+
+# Collect a namespace-wide pod inventory and archive any pod that was not
+# discovered through a known component or Helm release label. This guarantees
+# coverage for renamed, custom, and future workloads in the operator namespace.
+collect_operator_namespace_pods() {
+    log_info "Collecting all pods in the Network Operator namespace..."
+
+    local operator_dir="$OUTPUT_DIR/operator"
+    collect_resource "$operator_dir/pods.yaml" \
+        get pods -n "$OPERATOR_NAMESPACE" -o yaml || true
+
+    local pods
+    pods=$("$KUBECTL_BIN" get pods -n "$OPERATOR_NAMESPACE" -o name 2>/dev/null)
+
+    local pod
+    for pod in $pods; do
+        local pod_name
+        pod_name=$(basename "$pod")
+        if [ -n "${COLLECTED_PODS[$OPERATOR_NAMESPACE/$pod_name]:-}" ]; then
+            continue
+        fi
+
+        local workload
+        local workload_type
+        local workload_name
+        workload=$(resolve_pod_workload "$OPERATOR_NAMESPACE" "$pod")
+        IFS='|' read -r workload_type workload_name <<< "$workload"
+
+        case "$workload_type" in
+            cronjob|daemonset|deployment|job|pod|replicaset|statefulset)
+                ;;
+            *)
+                workload_type="pod"
+                workload_name="$pod_name"
+                ;;
+        esac
+
+        local component_id="${workload_type}-${workload_name}"
+        local component_dir="$OUTPUT_DIR/operator/components/$component_id"
+        if [ -z "${DISCOVERED_COMPONENTS[$component_dir]:-}" ]; then
+            log_info "  Discovered namespace component: $component_id"
+            DISCOVERED_COMPONENTS["$component_dir"]="true"
+            STATS[components_found]=$((STATS[components_found] + 1))
+
+            collect_resource "$component_dir/${workload_type}.yaml" \
+                get "$workload_type" -n "$OPERATOR_NAMESPACE" "$workload_name" -o yaml || true
+        fi
+
+        collect_pods_and_logs "$OPERATOR_NAMESPACE" "$component_dir/pods" "$pod"
+    done
+
+    log_success "All Network Operator namespace pods were considered for collection"
 }
 
 # Expand a generated NameSuffix marker into one selector that matches every
@@ -1320,7 +1505,10 @@ generate_summary() {
         echo "===================================="
         echo ""
         echo "Collection Time: $(date)"
-        echo "Script Version: $SCRIPT_VERSION"
+        echo "Collector Version: $SCRIPT_VERSION"
+        echo "Network Operator Version: ${NETWORK_OPERATOR_VERSION:-unknown}"
+        echo "Helm Release: ${HELM_RELEASE_NAME:-unknown}"
+        echo "Helm Chart: ${HELM_CHART:-unknown}"
         echo "Operator Namespace: $OPERATOR_NAMESPACE"
         echo ""
 
@@ -1493,13 +1681,14 @@ create_archive() {
 
 # Main function
 main() {
+    parse_args "$@"
+
     echo "========================================"
     echo "NVIDIA Network Operator SOS-Report Collection"
-    echo "Version: $SCRIPT_VERSION"
+    echo "Collector Version: $SCRIPT_VERSION"
     echo "========================================"
     echo ""
 
-    parse_args "$@"
     check_prerequisites
     detect_operator_namespace
     setup_output_dir
@@ -1510,6 +1699,7 @@ main() {
     collect_crd_instances
     collect_operator_resources
     collect_all_components
+    collect_operator_namespace_pods
     collect_diagnostic_commands
     collect_node_info
     collect_network_info

--- a/scripts/sosreport/test-sosreport.sh
+++ b/scripts/sosreport/test-sosreport.sh
@@ -28,6 +28,8 @@ SOSREPORT_SCRIPT="$SCRIPT_DIR/kubectl-netop_sosreport"
 REPORT_SCRIPT="$SCRIPT_DIR/generate-report.py"
 REPORT_TEMPLATE="$SCRIPT_DIR/report-template.html"
 LEGACY_SYMLINK="$SCRIPT_DIR/network-operator-sosreport.sh"
+CHART_FILE="$SCRIPT_DIR/../../deployment/network-operator/Chart.yaml"
+RELEASE_WORKFLOW="$SCRIPT_DIR/../../.github/workflows/release.yaml"
 
 echo "========================================"
 echo "NVIDIA Network Operator SOS-Report Test Suite"
@@ -84,9 +86,12 @@ required_functions=(
     "collect_operator_resources"
     "collect_container_logs"
     "collect_pods_and_logs"
+    "detect_network_operator_version"
     "detect_helm_release_selector"
+    "collect_helm_release_info"
     "resolve_pod_workload"
     "collect_helm_release_components"
+    "collect_operator_namespace_pods"
     "resolve_component_selector"
     "collect_component"
     "collect_all_components"
@@ -269,17 +274,57 @@ else
     exit 1
 fi
 
-# Test 8: Script version is defined
+# Test 8: Collector version matches the chart appVersion
 echo ""
-echo "[Test 8] Checking script version..."
+echo "[Test 8] Checking collector version..."
 if grep -q "SCRIPT_VERSION=" "$SOSREPORT_SCRIPT"; then
     version=$(grep "SCRIPT_VERSION=" "$SOSREPORT_SCRIPT" | head -1 | cut -d'"' -f2)
-    echo "  Script version: $version"
-    echo "PASS: Script version defined"
+    chart_app_version=$(awk '$1 == "appVersion:" { print $2; exit }' "$CHART_FILE")
+    if [ "$version" != "$chart_app_version" ]; then
+        echo "FAIL: Collector version $version does not match chart appVersion $chart_app_version"
+        exit 1
+    fi
+    version_output=$("$SOSREPORT_SCRIPT" --version)
+    if [ "$version_output" != "NVIDIA Network Operator SOS-Report Collector $chart_app_version" ]; then
+        echo "FAIL: --version reported an unexpected collector version: $version_output"
+        exit 1
+    fi
+    if ! grep -q 'SCRIPT_VERSION=.*APP_VERSION' "$RELEASE_WORKFLOW"; then
+        echo "FAIL: Automated release workflow does not update the collector version"
+        exit 1
+    fi
+    echo "  Collector version: $version"
+    echo "PASS: Collector version matches chart appVersion"
 else
-    echo "FAIL: Script version not defined"
+    echo "FAIL: Collector version not defined"
     exit 1
 fi
+
+# Test 8b: Non-Helm deployments report their image version
+echo ""
+echo "[Test 8b] Testing non-Helm Network Operator version detection..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    fake_non_helm_kubectl() {
+        case "$*" in
+            "get deployments -n olm-network-operator -l app.kubernetes.io/name=network-operator -o jsonpath="*)
+                echo "|nvcr.io/nvidia/cloud-native/network-operator:network-operator-v26.7.0"
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_non_helm_kubectl
+    OPERATOR_NAMESPACE=olm-network-operator
+    NETWORK_OPERATOR_VERSION=""
+
+    detect_network_operator_version
+    if [ "$NETWORK_OPERATOR_VERSION" != "network-operator-v26.7.0" ]; then
+        echo "FAIL: Non-Helm image version was not detected: $NETWORK_OPERATOR_VERSION"
+        exit 1
+    fi
+)
+echo "PASS: Non-Helm Network Operator version is detected"
 
 # Test 9: Check CRD collection coverage
 echo ""
@@ -657,6 +702,13 @@ RESOURCE_EOF
             "get deployments -n test-operator -l app.kubernetes.io/name=network-operator -o jsonpath="*)
                 echo "netop-release"
                 ;;
+            "get deployments -n test-operator -l app.kubernetes.io/instance=netop-release -o jsonpath="*)
+                echo "network-operator-26.7.0|v26.7.0|Helm"
+                ;;
+            "get secrets -n test-operator -l owner=helm,name=netop-release -o custom-columns="*)
+                echo "SECRET                                   STATUS     REVISION   CREATED"
+                echo "sh.helm.release.v1.netop-release.v3      deployed   3          2026-09-01T00:00:00Z"
+                ;;
             "get deployments -n test-operator -l app.kubernetes.io/instance=netop-release -o yaml"|\
             "get deployment -n test-operator chart-addon -o yaml"|\
             "get -n test-operator pod/chart-addon-abc -o yaml")
@@ -709,14 +761,50 @@ EMPTY_EOF
         esac
     }
 
+    fake_helm() {
+        case "$*" in
+            "list --namespace test-operator --all --filter ^netop-release$ --output yaml")
+                cat <<HELM_EOF
+- name: netop-release
+  namespace: test-operator
+  revision: "3"
+  status: deployed
+  chart: network-operator-26.7.0
+  app_version: v26.7.0
+HELM_EOF
+                ;;
+            "get metadata --help")
+                ;;
+            "get metadata netop-release --namespace test-operator --output yaml")
+                cat <<HELM_EOF
+name: netop-release
+chart: network-operator
+version: 26.7.0
+appVersion: v26.7.0
+revision: 3
+status: deployed
+HELM_EOF
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    }
+
     KUBECTL_BIN=fake_helm_kubectl
+    HELM_BIN=fake_helm
     OPERATOR_NAMESPACE=test-operator
     OUTPUT_DIR="$TEST_DIR/report"
     ERROR_LOG="$OUTPUT_DIR/collection-errors.log"
     NODE_SELECTOR=""
     LOG_LINES=100
     HELM_RELEASE_SELECTOR=""
+    HELM_RELEASE_NAME=""
+    HELM_CHART=""
+    HELM_APP_VERSION=""
+    HELM_MANAGED_BY=""
     HELM_RELEASE_DISCOVERED=false
+    HELM_RELEASE_INFO_COLLECTED=false
     declare -A COLLECTED_PODS=()
     declare -A DISCOVERED_COMPONENTS=()
     mkdir -p "$OUTPUT_DIR"
@@ -727,9 +815,13 @@ EMPTY_EOF
     collect_helm_release_components
     collect_helm_release_components
 
-    COMPONENT_DIR="$OUTPUT_DIR/operator/components/chart-addon"
+    COMPONENT_DIR="$OUTPUT_DIR/operator/components/deployment-chart-addon"
     for expected_file in \
         "$OUTPUT_DIR/operator/helm-release/workloads/deployments.yaml" \
+        "$OUTPUT_DIR/operator/helm-release/chart-info.txt" \
+        "$OUTPUT_DIR/operator/helm-release/revisions.txt" \
+        "$OUTPUT_DIR/operator/helm-release/helm-list.yaml" \
+        "$OUTPUT_DIR/operator/helm-release/helm-metadata.yaml" \
         "$COMPONENT_DIR/deployment.yaml" \
         "$COMPONENT_DIR/pods/chart-addon-abc.yaml" \
         "$COMPONENT_DIR/pods/chart-addon-abc-controller.log" \
@@ -744,12 +836,174 @@ EMPTY_EOF
         fi
     done
 
+    if ! grep -q "Chart: network-operator-26.7.0" \
+        "$OUTPUT_DIR/operator/helm-release/chart-info.txt" || \
+       ! grep -q "App Version: v26.7.0" \
+        "$OUTPUT_DIR/operator/helm-release/chart-info.txt" || \
+       ! grep -q "sh.helm.release.v1.netop-release.v3" \
+        "$OUTPUT_DIR/operator/helm-release/revisions.txt"; then
+        echo "FAIL: Helm release metadata is incomplete"
+        exit 1
+    fi
+
     if [ "${STATS[components_found]}" -ne 1 ] || [ "${STATS[component_pods]}" -ne 1 ]; then
         echo "FAIL: Helm component or pod was counted more than once"
         exit 1
     fi
 )
 echo "PASS: Helm-only workloads and all container types are collected once"
+
+# Test 10e: Unlabelled pods are collected and cross-kind names stay distinct
+echo ""
+echo "[Test 10e] Testing namespace-wide pod and collision-safe log collection..."
+(
+    source "$SOSREPORT_SCRIPT"
+
+    TEST_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEST_DIR"' EXIT
+
+    emit_namespace_resource_yaml() {
+        local kind="$1"
+        local name="$2"
+        cat <<RESOURCE_EOF
+apiVersion: v1
+kind: $kind
+metadata:
+  name: $name
+spec:
+  containers:
+    - name: collector-test
+status:
+  phase: Running
+RESOURCE_EOF
+    }
+
+    fake_namespace_kubectl() {
+        case "$*" in
+            "get pods -n test-operator -o yaml")
+                cat <<PODS_EOF
+apiVersion: v1
+kind: List
+items:
+  - metadata:
+      name: sriov-network-config-daemon-node-a
+  - metadata:
+      name: nic-configuration-daemon-node-a
+  - metadata:
+      name: shared-deployment-pod
+  - metadata:
+      name: shared-job-pod
+metadata: {}
+PODS_EOF
+                ;;
+            "get pods -n test-operator -o name")
+                echo "pod/sriov-network-config-daemon-node-a"
+                echo "pod/nic-configuration-daemon-node-a"
+                echo "pod/shared-deployment-pod"
+                echo "pod/shared-job-pod"
+                ;;
+            "get -n test-operator pod/sriov-network-config-daemon-node-a -o jsonpath={.metadata.ownerReferences[0].kind}"|\
+            "get -n test-operator pod/nic-configuration-daemon-node-a -o jsonpath={.metadata.ownerReferences[0].kind}")
+                echo "DaemonSet"
+                ;;
+            "get -n test-operator pod/shared-deployment-pod -o jsonpath={.metadata.ownerReferences[0].kind}")
+                echo "Deployment"
+                ;;
+            "get -n test-operator pod/shared-job-pod -o jsonpath={.metadata.ownerReferences[0].kind}")
+                echo "Job"
+                ;;
+            "get -n test-operator pod/sriov-network-config-daemon-node-a -o jsonpath={.metadata.ownerReferences[0].name}")
+                echo "sriov-network-config-daemon"
+                ;;
+            "get -n test-operator pod/nic-configuration-daemon-node-a -o jsonpath={.metadata.ownerReferences[0].name}")
+                echo "nic-configuration-daemon"
+                ;;
+            "get -n test-operator pod/shared-deployment-pod -o jsonpath={.metadata.ownerReferences[0].name}"|\
+            "get -n test-operator pod/shared-job-pod -o jsonpath={.metadata.ownerReferences[0].name}")
+                echo "shared-worker"
+                ;;
+            "get daemonset -n test-operator sriov-network-config-daemon -o yaml")
+                emit_namespace_resource_yaml "DaemonSet" "sriov-network-config-daemon"
+                ;;
+            "get daemonset -n test-operator nic-configuration-daemon -o yaml")
+                emit_namespace_resource_yaml "DaemonSet" "nic-configuration-daemon"
+                ;;
+            "get deployment -n test-operator shared-worker -o yaml")
+                emit_namespace_resource_yaml "Deployment" "shared-worker"
+                ;;
+            "get job -n test-operator shared-worker -o yaml")
+                emit_namespace_resource_yaml "Job" "shared-worker"
+                ;;
+            "get -n test-operator pod/sriov-network-config-daemon-node-a -o yaml")
+                emit_namespace_resource_yaml "Pod" "sriov-network-config-daemon-node-a"
+                ;;
+            "get -n test-operator pod/nic-configuration-daemon-node-a -o yaml")
+                emit_namespace_resource_yaml "Pod" "nic-configuration-daemon-node-a"
+                ;;
+            "get -n test-operator pod/shared-deployment-pod -o yaml")
+                emit_namespace_resource_yaml "Pod" "shared-deployment-pod"
+                ;;
+            "get -n test-operator pod/shared-job-pod -o yaml")
+                emit_namespace_resource_yaml "Pod" "shared-job-pod"
+                ;;
+            "get -n test-operator pod/sriov-network-config-daemon-node-a -o jsonpath={.spec.containers[*].name}")
+                echo "sriov-network-config-daemon"
+                ;;
+            "get -n test-operator pod/nic-configuration-daemon-node-a -o jsonpath={.spec.containers[*].name}")
+                echo "nic-configuration-daemon"
+                ;;
+            "get -n test-operator pod/shared-deployment-pod -o jsonpath={.spec.containers[*].name}"|\
+            "get -n test-operator pod/shared-job-pod -o jsonpath={.spec.containers[*].name}")
+                echo "worker"
+                ;;
+            "logs -n test-operator pod/"*" -c "*" --previous --tail="*)
+                echo "previous config daemon log"
+                ;;
+            "logs -n test-operator pod/"*" -c "*" --tail="*)
+                echo "current config daemon log"
+                ;;
+        esac
+    }
+
+    KUBECTL_BIN=fake_namespace_kubectl
+    OPERATOR_NAMESPACE=test-operator
+    OUTPUT_DIR="$TEST_DIR/report"
+    ERROR_LOG="$OUTPUT_DIR/collection-errors.log"
+    NODE_SELECTOR=""
+    LOG_LINES=100
+    declare -A COLLECTED_PODS=()
+    declare -A DISCOVERED_COMPONENTS=()
+    mkdir -p "$OUTPUT_DIR"
+    : > "$ERROR_LOG"
+    STATS[components_found]=0
+    STATS[component_pods]=0
+
+    collect_operator_namespace_pods
+
+    for expected_file in \
+        "$OUTPUT_DIR/operator/pods.yaml" \
+        "$OUTPUT_DIR/operator/components/daemonset-sriov-network-config-daemon/pods/sriov-network-config-daemon-node-a.yaml" \
+        "$OUTPUT_DIR/operator/components/daemonset-sriov-network-config-daemon/pods/sriov-network-config-daemon-node-a-sriov-network-config-daemon.log" \
+        "$OUTPUT_DIR/operator/components/daemonset-sriov-network-config-daemon/pods/sriov-network-config-daemon-node-a-sriov-network-config-daemon-previous.log" \
+        "$OUTPUT_DIR/operator/components/daemonset-nic-configuration-daemon/pods/nic-configuration-daemon-node-a.yaml" \
+        "$OUTPUT_DIR/operator/components/daemonset-nic-configuration-daemon/pods/nic-configuration-daemon-node-a-nic-configuration-daemon.log" \
+        "$OUTPUT_DIR/operator/components/daemonset-nic-configuration-daemon/pods/nic-configuration-daemon-node-a-nic-configuration-daemon-previous.log" \
+        "$OUTPUT_DIR/operator/components/deployment-shared-worker/deployment.yaml" \
+        "$OUTPUT_DIR/operator/components/deployment-shared-worker/pods/shared-deployment-pod-worker.log" \
+        "$OUTPUT_DIR/operator/components/job-shared-worker/job.yaml" \
+        "$OUTPUT_DIR/operator/components/job-shared-worker/pods/shared-job-pod-worker.log"; do
+        if [ ! -s "$expected_file" ]; then
+            echo "FAIL: Namespace pod artifact is missing: $expected_file"
+            exit 1
+        fi
+    done
+
+    if [ "${STATS[components_found]}" -ne 4 ] || [ "${STATS[component_pods]}" -ne 4 ]; then
+        echo "FAIL: Namespace-discovered components or pods were counted incorrectly"
+        exit 1
+    fi
+)
+echo "PASS: Every operator namespace pod is collected with collision-safe grouping"
 
 # Test 11: HTML report generator exists and is executable
 echo ""
@@ -854,7 +1108,10 @@ mkdir -p "$FIXTURE_DIR/network"
 
 cat > "$FIXTURE_DIR/metadata/collection-info.txt" <<FIXTURE_EOF
 Collection Time: 2026-02-18 14:30:00 UTC
-Script Version: v26.1.0
+Collector Version: v26.7.0-rc.1
+Network Operator Version: v26.7.0
+Helm Release: netop-release
+Helm Chart: network-operator-26.7.0
 Operator Namespace: nvidia-network-operator
 Platform: Kubernetes
 FIXTURE_EOF
@@ -966,7 +1223,7 @@ fi
 
 # Check for key HTML elements
 missing_elements=false
-for element in "<!DOCTYPE html>" "NicClusterPolicy" "Component Health" "OFED Diagnostics" "Node Overview" "Events" "RBAC" "sidebar" "sidecar container log" "Init Container Logs (setup)" "Helm Release Artifacts" "network-operator-upgrade-hook" "Diagnostic command status" "rdma dev show" "standalone sriov namespace log"; do
+for element in "<!DOCTYPE html>" "NicClusterPolicy" "Component Health" "OFED Diagnostics" "Node Overview" "Events" "RBAC" "sidebar" "Operator: v26.7.0" "Collector: v26.7.0-rc.1" "Chart: network-operator-26.7.0" "sidecar container log" "Init Container Logs (setup)" "Helm Release Artifacts" "network-operator-upgrade-hook" "Diagnostic command status" "rdma dev show" "standalone sriov namespace log"; do
     if grep -q "$element" "$REPORT_OUTPUT"; then
         echo "  Found element: $element"
     else


### PR DESCRIPTION
## Summary

- report the collector version aligned with the chart and show the deployed Network Operator app version separately
- archive pod YAML plus current/previous logs for every container in every pod in the Network Operator namespace
- collect non-secret Helm release, chart, app-version, and revision metadata, with optional Helm CLI metadata
- render the operator, collector, release, and chart versions in the HTML report

## Testing

- `docker run --rm --platform linux/amd64 -v "$PWD:/workspace" -w /workspace python:3.13-bookworm bash scripts/sosreport/test-sosreport.sh`
- `docker run --rm --platform linux/amd64 -v "$PWD:/workspace:ro" -w /workspace python:3.13-bookworm bash scripts/sosreport/generate-maps.sh --verify`
- `shellcheck scripts/sosreport/kubectl-netop_sosreport scripts/sosreport/generate-maps.sh scripts/sosreport/test-sosreport.sh`
- `helm lint deployment/network-operator`
- `git diff --check`