### PR TITLE
fix(chart): raise vendored maintenance-operator memory defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Check [Upgrade section in Helm Chart documentation](deployment/network-operator/
 
 ## Drain Controller
 In case users would like to use [NVIDIA maintenance operator](https://github.com/Mellanox/maintenance-operator) to manage node operations, e.g. SRIOV node draining, there is an option to disable [SRIOV operator's internal drain controller](https://github.com/Mellanox/sriov-network-operator/blob/master/README.md#key-configuration-fields) and enabling network operator drain controller, which utilizes maintenance operator.
+
+> **Resource sizing / naming:** maintenance-operator memory scales with node count (Node informer cache). Override via `maintenance-operator-chart.operator.resources` (defaults: 256Mi limit / 192Mi request). Top-level `operator.resources` configures the *network-operator* controller and does **not** size maintenance-operator.
 To do so, the following environment variables are required by network operator pod:
 ```text
 # enable drain controller requestor

--- a/deployment/network-operator/charts/maintenance-operator-chart/README.md
+++ b/deployment/network-operator/charts/maintenance-operator-chart/README.md
@@ -4,6 +4,12 @@
 
 Maintenance Operator Helm Chart
 
+## Resource sizing
+
+Operator memory usage is dominated by the Kubernetes **Node informer cache**, so it scales primarily with **cluster node count**. The chart default (`256Mi` limit / `192Mi` request) is a mid-size baseline; raise further for larger clusters.
+
+When deployed as a Network Operator subchart, set `maintenance-operator-chart.operator.resources`. Do **not** use the parent top-level `operator.resources` — that sizes the network-operator controller.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -22,7 +28,7 @@ Maintenance Operator Helm Chart
 | operator.image.tag | string | `nil` | image tag to use for the operator image |
 | operator.nodeSelector | object | `{}` | node selector for the operator |
 | operator.replicas | int | `1` | operator deployment number of repplicas |
-| operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | specify resource requests and limits for the operator |
+| operator.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"192Mi"}}` | Resource requests and limits for the operator. Memory scales with node count (Node informer cache); default 256Mi/192Mi is a mid-size baseline. Override via parent `maintenance-operator-chart.operator.resources`, not top-level `operator.resources`. |
 | operator.serviceAccount.annotations | object | `{}` | set annotations for the operator service account |
 | operator.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | toleration for the operator |
 | operatorConfig | object | `{"logLevel":"info","maxNodeMaintenanceTimeSeconds":null,"maxParallelOperations":null,"maxUnavailable":null}` | operator configuration values. fields here correspond to fields in MaintenanceOperatorConfig CR |

--- a/deployment/network-operator/charts/maintenance-operator-chart/values.yaml
+++ b/deployment/network-operator/charts/maintenance-operator-chart/values.yaml
@@ -32,14 +32,22 @@ operator:
             matchExpressions:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: Exists
-  # -- specify resource requests and limits for the operator
+  # -- Resource requests and limits for the operator. Memory usage is dominated by
+  # the Node informer cache and therefore scales with cluster node count, not
+  # requestor workload. The default limit of 256Mi is a reasonable baseline for
+  # mid-size clusters (about 130–156Mi idle working set was measured on ~141
+  # nodes); raise further for larger clusters (for example toward 1Gi when
+  # expecting substantial growth or GPU-dense nodes with large status payloads).
+  # When installed via NVIDIA Network Operator, override with
+  # `maintenance-operator-chart.operator.resources` — not the parent chart
+  # top-level `operator.resources`, which configures network-operator itself.
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 192Mi
   # -- operator deployment number of repplicas
   replicas: 1
   serviceAccount:

--- a/deployment/network-operator/values.yaml
+++ b/deployment/network-operator/values.yaml
@@ -198,6 +198,19 @@ maintenance-operator-chart:
       repository: nvcr.io/nvstaging/mellanox
       name: maintenance-operator
       tag: network-operator-v26.7.0-rc.1
+    # -- Resource requests and limits for the *maintenance-operator* controller.
+    # Memory scales with cluster node count (Node informer cache). Defaults match
+    # Mellanox/maintenance-operator#225 / PR #243 (256Mi limit / 192Mi request).
+    # Raise for larger clusters. Do NOT confuse with top-level `operator.resources`,
+    # which sizes the *network-operator* controller, not maintenance-operator.
+    # @notationType -- yaml
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 192Mi
     admissionController:
       # -- enable admission controller of the operator
       enable: false


### PR DESCRIPTION
## Summary

Follow-up to [Mellanox/maintenance-operator#225](https://github.com/Mellanox/maintenance-operator/issues/225) / [PR #243](https://github.com/Mellanox/maintenance-operator/pull/243): network-operator vendors the maintenance-operator chart locally and still ships `128Mi` / `64Mi`. Parent `deployment/network-operator/values.yaml` under `maintenance-operator-chart.operator` also did not pin `resources`, so installs via network-operator kept the old defaults.

### Changes

- Vendored `deployment/network-operator/charts/maintenance-operator-chart/values.yaml`: `limits.memory` `128Mi` → **`256Mi`**, `requests.memory` `64Mi` → **`192Mi`** (CPU unchanged); helm-docs-style comments on node-count / Node informer sizing
- Parent `deployment/network-operator/values.yaml`: explicitly set `maintenance-operator-chart.operator.resources` to the same defaults, with comments noting (a) scales with node count and (b) top-level `operator.resources` is the *network* operator and does **not** size maintenance-operator
- Short sizing/naming note in main `README.md` (Drain Controller) and vendored chart README values docs

No controller code changes.

Relates to Mellanox/maintenance-operator#225

## Test plan

- [x] `helm lint deployment/network-operator` (pass; icon INFO only)
- [x] `helm template ... --kube-version 1.32.0 --set maintenanceOperator.enabled=true -s charts/maintenance-operator-chart/templates/deployment.yaml` shows `memory: 256Mi` / `192Mi`
- [ ] CI on NVIDIA runners (may need `/ok-to-test` / copy-pr-bot approval)